### PR TITLE
docs: default root to v3 and keep v2 under /v2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,6 +63,19 @@ jobs:
             rm -rf final-docs/.git
           fi
 
+          # If v2 isn't already namespaced, move existing root docs into /v2
+          if [ ! -d "final-docs/v2" ]; then
+            mkdir -p final-docs/v2
+            shopt -s dotglob
+            for item in final-docs/*; do
+              case "$(basename "$item")" in
+                v2|v3|llms.txt) continue;;
+              esac
+              mv "$item" final-docs/v2/
+            done
+            shopt -u dotglob
+          fi
+
           # Remove old v3 directory if exists and copy new v3 docs
           rm -rf final-docs/v3
           mkdir -p final-docs/v3
@@ -74,13 +87,33 @@ jobs:
             echo "Copied llms.txt to site root"
           fi
 
+          # Redirect root docs to v3 by default
+          cat > final-docs/index.html << 'EOF'
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8" />
+              <meta http-equiv="refresh" content="0; url=/ic-reactor/v3/" />
+              <meta name="robots" content="noindex" />
+              <title>IC Reactor Docs</title>
+              <link rel="canonical" href="https://b3pay.github.io/ic-reactor/v3/" />
+              <script>
+                window.location.replace("/ic-reactor/v3/");
+              </script>
+            </head>
+            <body>
+              <p>Redirecting to v3 docs…</p>
+            </body>
+          </html>
+          EOF
+
       - name: Inject v3 banner into v2 docs
         run: |
           # Banner HTML to inject after <body> tag in all v2 HTML files
           BANNER='<div id="v3-banner" style="position:fixed;top:0;left:0;right:0;z-index:9999;background:linear-gradient(90deg,#6366f1,#8b5cf6);color:white;padding:12px 20px;text-align:center;font-family:system-ui,-apple-system,sans-serif;font-size:14px;box-shadow:0 2px 8px rgba(0,0,0,0.15);"><span style="margin-right:8px;">🚀</span><strong>IC Reactor v3 is here!</strong> Featuring TanStack Query integration, improved type safety, and more. <a href="/ic-reactor/v3/" style="color:white;text-decoration:underline;font-weight:600;margin-left:8px;">View v3 Documentation →</a><button onclick="document.getElementById('\''v3-banner'\'').remove();localStorage.setItem('\''v3-banner-dismissed'\'','\''1'\'')" style="position:absolute;right:12px;top:50%;transform:translateY(-50%);background:none;border:none;color:white;cursor:pointer;font-size:18px;padding:4px 8px;">×</button></div><script>if(localStorage.getItem('\''v3-banner-dismissed'\''))document.getElementById('\''v3-banner'\'').remove();</script>'
 
           # Find all HTML files in v2 docs (not in v3 folder) and inject banner
-          find final-docs -maxdepth 2 -name "*.html" -not -path "final-docs/v3/*" | while read file; do
+          find final-docs/v2 -name "*.html" | while read file; do
             if grep -q "<body" "$file" && ! grep -q "v3-banner" "$file"; then
               # Inject banner after <body> tag (handles <body> with or without attributes)
               sed -i 's|<body[^>]*>|&'"$BANNER"'|' "$file"


### PR DESCRIPTION
## Summary\n- move existing root docs into /v2 if not already namespaced\n- publish v3 docs to /v3 and set site root to redirect to /v3\n- inject the v3 banner only into /v2 HTML\n\n## Notes\n- keeps /v2 intact for legacy docs\n- root now defaults to v3\n\n## Testing\n- not run (workflow-only change)