### PR TITLE
docs: fix v2 switcher and redirect legacy root paths

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -107,6 +107,37 @@ jobs:
           </html>
           EOF
 
+          # Root 404: redirect missing legacy paths to v3, preserve path
+          cat > final-docs/404.html << 'EOF'
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8" />
+              <meta name="robots" content="noindex" />
+              <title>Not Found | IC Reactor Docs</title>
+              <script>
+                (function () {
+                  var path = window.location.pathname || "/";
+                  // Normalize to project base
+                  var base = "/ic-reactor";
+                  if (!path.startsWith(base)) {
+                    window.location.replace(base + "/v3/");
+                    return;
+                  }
+                  var rel = path.slice(base.length);
+                  if (rel.startsWith("/v2") || rel.startsWith("/v3")) return;
+                  var target = base + "/v3" + rel;
+                  if (!target.endsWith("/") && path.endsWith("/")) target += "/";
+                  window.location.replace(target);
+                })();
+              </script>
+            </head>
+            <body>
+              <p>Redirecting…</p>
+            </body>
+          </html>
+          EOF
+
       - name: Inject v3 banner into v2 docs
         run: |
           # Banner HTML to inject after <body> tag in all v2 HTML files

--- a/docs/src/components/SiteTitle.astro
+++ b/docs/src/components/SiteTitle.astro
@@ -19,7 +19,7 @@ import Default from '@astrojs/starlight/components/SiteTitle.astro';
   function handleVersionChange(event) {
     const version = event.target.value;
     if (version === 'v2') {
-      window.location.href = 'https://b3pay.github.io/ic-reactor/';
+      window.location.href = '/ic-reactor/v2/';
     } else if (version === 'v3') {
       window.location.href = '/ic-reactor/v3/';
     }


### PR DESCRIPTION
## Summary\n- change v2 switcher link to /v2\n- add root 404 redirect to send legacy paths to /v3 (preserves path)\n\n## Examples\n- /ic-reactor/framework/react-setup/ -> /ic-reactor/v3/framework/react-setup/\n- v2 selector -> /ic-reactor/v2/\n\n## Testing\n- not run (workflow/site config changes)