### PR TITLE
fix: refine `DisplayOf` array type inference

### DIFF
--- a/packages/core/src/display/types.ts
+++ b/packages/core/src/display/types.ts
@@ -69,8 +69,8 @@ export type DisplayOf<T> =
         ? VariantUnionOf<T>
         : T extends Array<[string, infer B]>
           ? Record<string, DisplayOf<B>>
-          : T extends (infer U)[]
-            ? DisplayOf<U>[]
+          : T extends any[]
+            ? { [K in keyof T]: DisplayOf<T[K]> }
             : T extends null
               ? null
               : T extends Principal

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,4 +1,5 @@
+import { version } from "../package.json"
 /**
  * Library version - automatically synced from package.json.
  */
-export const VERSION = "3.0.0"
+export const VERSION = version


### PR DESCRIPTION
This pull request makes two key improvements: it updates the way the library version is sourced to ensure consistency with `package.json`, and it refines the `DisplayOf` type utility to provide more accurate type mappings for arrays.

Version management improvement:

* [`packages/core/src/version.ts`](diffhunk://#diff-b1bec3cf7968f25bbc331e757ffc285dcacf536da71a5e86e2edc3c1bb3cce72R1-R5): The `VERSION` constant is now automatically imported from `package.json` instead of being hardcoded, ensuring the library version stays in sync with the package metadata.

Type utility enhancement:

* [`packages/core/src/display/types.ts`](diffhunk://#diff-aeb1e2130fd1a15842e7b6cfde8ce6ea97583fb18da6e3a2d488bc22e0aa872dL72-R73): The `DisplayOf` type was updated so that for tuple types and fixed-length arrays, it now produces a mapped type over the array's keys, rather than always inferring a uniform array type. This results in more precise type inference for tuples and heterogeneous arrays.