### PR TITLE
chore: Update default client port from 4943 to 8000.

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -73,7 +73,7 @@ export class ClientManager {
    * @param parameters - Configuration options for the agent and network environment.
    */
   constructor({
-    port = 4943,
+    port = 8000,
     withLocalEnv,
     withProcessEnv,
     withCanisterEnv,


### PR DESCRIPTION
This pull request makes a minor update to the default configuration in the `ClientManager` class. The default value for the `port` parameter has been changed from 4943 to 8000. 

- Changed the default `port` in the `ClientManager` constructor from 4943 to 8000 to align with updated environment or deployment requirements.