### PR TITLE
Add IC Reactor hooks skill documentation

### DIFF
--- a/.codex/skills/ic-reactor-hooks/SKILL.md
+++ b/.codex/skills/ic-reactor-hooks/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: ic-reactor-hooks
+description: Create, refactor, and document Reactor hook integrations for this ic-reactor repository. Use when working with createActorHooks, query or mutation factories, useActorMethod, or generated hooks from the ic-reactor CLI or Vite plugin, especially when implementing or explaining usage inside React components versus imperative code outside React.
+---
+
+# IC Reactor Hooks
+
+Use this skill to implement or explain hook patterns in this repository with minimal rework and consistent cache behavior.
+
+Read `references/patterns.md` only when you need concrete examples, file pointers, or exact API surface reminders.
+
+## Follow This Workflow
+
+1. Identify the target integration style.
+2. Prefer generated hooks for canister-heavy app code.
+3. Reuse singleton `QueryClient`, `ClientManager`, and reactor instances.
+4. Choose the smallest abstraction that fits:
+   - `createActorHooks(...)` for generic hook access
+   - `createQuery` / `createMutation` factories for reusable operations
+   - `useActorMethod` for unified imperative component calls
+   - direct reactor methods for non-React code
+5. Attach cache invalidation to mutations using `query.getQueryKey()` or `query.invalidate()`.
+6. Keep custom logic outside generated files.
+
+## Choose The Right Pattern
+
+| Need                                           | Preferred API                                           | Use Location                     |
+| ---------------------------------------------- | ------------------------------------------------------- | -------------------------------- |
+| Fastest setup across many methods              | `createActorHooks(reactor)`                             | React components/custom hooks    |
+| Reusable query with loader support             | `createQuery` / `createSuspenseQuery`                   | Inside React and outside React   |
+| Reusable mutation with imperative execution    | `createMutation`                                        | Inside React and outside React   |
+| Paginated data                                 | `createInfiniteQuery` / suspense variant                | Inside React and prefetch paths  |
+| Dynamic args with cached factory instances     | `createQueryFactory` / `createSuspenseQueryFactory`     | Shared modules                   |
+| Unified hook that auto-detects query vs update | `useActorMethod`                                        | React components/custom hooks    |
+| Zero/low-maintenance canister hook generation  | `@ic-reactor/vite-plugin` or `@ic-reactor/cli`          | App scaffolding/codegen          |
+| Imperative call outside React                  | `query.fetch`, `mutation.execute`, `reactor.callMethod` | loaders/actions/services/scripts |
+
+## Apply Repo Conventions
+
+- Keep `queryClient`, `clientManager`, and reactors as module-level singletons.
+- Give each reactor an explicit `name`.
+- Use `DisplayReactor` for UI-friendly string transforms and forms.
+- Use `Reactor` for raw Candid types (`bigint`, `Principal`, etc.).
+- Define reusable query and mutation instances in shared modules (for example `factories.ts`) instead of inside components.
+- Call React hooks only inside React components or custom hooks.
+- Use factory imperative methods (`fetch`, `execute`, `invalidate`, `getCacheData`) outside React.
+- Prefer `query.getQueryKey()` when wiring invalidation to avoid key drift.
+- Do not hand-edit generated hook files; wrap or compose around them.
+
+## Implement Patterns Efficiently
+
+### 1. Generic Actor Hooks (component-first)
+
+Use `createActorHooks(reactor)` when you want a single typed entry point and can pass `{ functionName, args }` per call.
+
+Export the returned hooks from a shared module and reuse them across components.
+
+### 2. Factory Objects (shared component + non-component usage)
+
+Use `createQuery`, `createSuspenseQuery`, `createInfiniteQuery`, and `createMutation` when you need:
+
+- reusable method-specific objects
+- route loader prefetching with `.fetch()`
+- imperative execution with `.execute()`
+- localized cache invalidation with `getQueryKey()`
+
+This is the preferred pattern for code that must work both inside and outside React.
+
+### 3. Generated Hooks (best for scale)
+
+Prefer the Vite plugin in Vite apps for hot regeneration from `.did` changes.
+
+Prefer the CLI in non-Vite apps, CI generation flows, or explicit codegen pipelines.
+
+After generation, keep app-specific behavior in separate wrapper modules or factory files.
+
+### 4. `useActorMethod` (unified but specialized)
+
+Use `useActorMethod` when a component needs a single imperative API (`call`, `reset`, `refetch`) and you want the hook to auto-handle query vs update methods.
+
+Prefer query/mutation factories when the method-specific API is clearer or you need outside-React access.
+
+## Handle Outside-React Usage Correctly
+
+Never call `.useQuery()`, `.useSuspenseQuery()`, `.useInfiniteQuery()`, or `.useMutation()` outside React.
+
+Use these instead:
+
+- `query.fetch()` for cache-aware reads in loaders/actions
+- `query.getCacheData()` for synchronous cache reads
+- `query.invalidate()` for targeted invalidation
+- `mutation.execute(args)` for imperative updates
+- `reactor.fetchQuery(...)` / `reactor.getQueryData(...)` / `reactor.invalidateQueries(...)` / `reactor.callMethod(...)` for advanced control
+
+## Inspect These Files First
+
+- `packages/react/src/createActorHooks.ts`
+- `packages/react/src/createQuery.ts`
+- `packages/react/src/createSuspenseQuery.ts`
+- `packages/react/src/createInfiniteQuery.ts`
+- `packages/react/src/createMutation.ts`
+- `packages/react/src/hooks/useActorMethod.ts`
+- `examples/all-in-one-demo/src/lib/factories.ts`
+- `examples/tanstack-router/src/canisters/ledger/hooks/`
+- `packages/react/README.md`
+- `packages/vite-plugin/README.md`
+- `packages/cli/README.md`
+
+## Verify Changes
+
+- Check the generated/imported hook style matches the surrounding code.
+- Confirm mutation invalidation targets the correct query keys.
+- Confirm non-React usage uses imperative methods only.
+- Run the most relevant React package tests or example app checks when available.

--- a/.codex/skills/ic-reactor-hooks/agents/openai.yaml
+++ b/.codex/skills/ic-reactor-hooks/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "IC Reactor Hooks"
+  short_description: "Create and use ic-reactor hooks efficiently"
+  default_prompt: "Use $ic-reactor-hooks to create or refactor Reactor hooks and show how to use them inside React components and outside React."

--- a/.codex/skills/ic-reactor-hooks/references/patterns.md
+++ b/.codex/skills/ic-reactor-hooks/references/patterns.md
@@ -1,0 +1,251 @@
+# IC Reactor Hook Patterns (Repo Reference)
+
+Load this file when you need concrete examples, exact return methods, or repo file pointers.
+
+## Pattern Matrix
+
+| API                         | Inside React          | Outside React                                  | Notes                                                       |
+| --------------------------- | --------------------- | ---------------------------------------------- | ----------------------------------------------------------- |
+| `createActorHooks(reactor)` | Yes                   | No                                             | Returns generic hooks that accept `functionName` and `args` |
+| `createQuery(...)`          | `.useQuery()`         | `.fetch()`, `.invalidate()`, `.getCacheData()` | Best shared read pattern                                    |
+| `createSuspenseQuery(...)`  | `.useSuspenseQuery()` | `.fetch()`, `.invalidate()`, `.getCacheData()` | Suspense-only component usage                               |
+| `createInfiniteQuery(...)`  | `.useInfiniteQuery()` | `.fetch()`, `.invalidate()`, `.getCacheData()` | Uses `getArgs(pageParam)`                                   |
+| `createMutation(...)`       | `.useMutation()`      | `.execute(args)`                               | Supports `onCanisterError` and invalidation                 |
+| `useActorMethod(...)`       | Yes                   | No                                             | Unified query/update hook                                   |
+| `reactor.callMethod(...)`   | Indirectly            | Yes                                            | Lowest-level imperative call                                |
+
+## Returned Methods (Important)
+
+### `createActorHooks(reactor)`
+
+Returns:
+
+- `useActorQuery`
+- `useActorSuspenseQuery`
+- `useActorInfiniteQuery`
+- `useActorSuspenseInfiniteQuery`
+- `useActorMutation`
+- `useActorMethod`
+
+Source: `packages/react/src/createActorHooks.ts`
+
+### `createQuery(...)`
+
+Returns an object with:
+
+- `.useQuery(options?)`
+- `.fetch()`
+- `.invalidate()`
+- `.getQueryKey()`
+- `.getCacheData(select?)`
+
+Source: `packages/react/src/createQuery.ts`
+
+### `createSuspenseQuery(...)`
+
+Returns an object with:
+
+- `.useSuspenseQuery(options?)`
+- `.fetch()`
+- `.invalidate()`
+- `.getQueryKey()`
+- `.getCacheData(select?)`
+
+Source: `packages/react/src/createSuspenseQuery.ts`
+
+### `createInfiniteQuery(...)`
+
+Returns an object with:
+
+- `.useInfiniteQuery(options?)`
+- `.fetch()`
+- `.invalidate()`
+- `.getQueryKey()`
+- `.getCacheData(select?)`
+
+Source: `packages/react/src/createInfiniteQuery.ts`
+
+### `createMutation(...)`
+
+Returns an object with:
+
+- `.useMutation(options?)`
+- `.execute(args)`
+
+Source: `packages/react/src/createMutation.ts`
+
+## Inside React: Recommended Patterns
+
+### A. Generic hooks from `createActorHooks`
+
+Use for component-focused code when method names vary:
+
+```tsx
+const { useActorQuery, useActorMutation } = createActorHooks(backendReactor)
+
+function Profile({ userId }: { userId: string }) {
+  const user = useActorQuery({
+    functionName: "get_user",
+    args: [userId],
+  })
+
+  const save = useActorMutation({
+    functionName: "update_user",
+  })
+
+  if (user.isPending) return <div>Loading...</div>
+
+  return (
+    <button onClick={() => save.mutate([{ id: userId, name: "Alice" }])}>
+      Save
+    </button>
+  )
+}
+```
+
+### B. Factory objects reused across components
+
+Define once at module scope (repo example: `examples/all-in-one-demo/src/lib/factories.ts`):
+
+```ts
+export const getLikes = createQuery(backendReactor, {
+  functionName: "get_likes",
+  refetchInterval: 3000,
+})
+
+export const likeHeart = createMutation(backendReactor, {
+  functionName: "like",
+})
+```
+
+Use in components/custom hooks:
+
+```tsx
+const { data: likes = [] } = getLikes.useQuery()
+const { mutateAsync } = likeHeart.useMutation({
+  onSettled: () => getLikes.invalidate(),
+})
+```
+
+### C. `useActorMethod` for unified imperative behavior
+
+Use when one component needs a `call()` API and should not care if the method is query or update:
+
+```tsx
+const method = useActorMethod({
+  reactor: backendReactor,
+  functionName: "get_user",
+  args: ["user-1"],
+})
+
+await method.call()
+```
+
+Source: `packages/react/src/hooks/useActorMethod.ts`
+
+## Outside React: Correct Patterns
+
+### A. Prefetch/read in loaders or actions
+
+Use query factory objects:
+
+```ts
+const userQuery = createQuery(backendReactor, {
+  functionName: "get_user",
+  args: ["user-1"],
+})
+
+await userQuery.fetch()
+const cached = userQuery.getCacheData()
+```
+
+This pattern is used by generated hook files in `examples/tanstack-router/src/canisters/ledger/hooks/`.
+
+### B. Imperative mutation execution
+
+Use `.execute(args)`:
+
+```ts
+const transfer = createMutation(ledgerReactor, {
+  functionName: "icrc1_transfer",
+})
+
+const result = await transfer.execute([transferArg])
+```
+
+Generated example file:
+
+- `examples/tanstack-router/src/canisters/ledger/hooks/icrc1TransferMutation.ts`
+
+### C. Advanced reactor-level control
+
+Use direct reactor methods when factory wrappers are too narrow:
+
+```ts
+await backendReactor.fetchQuery({
+  functionName: "get_user",
+  args: ["user-1"],
+})
+
+const cached = backendReactor.getQueryData({
+  functionName: "get_user",
+  args: ["user-1"],
+})
+
+await backendReactor.invalidateQueries({
+  functionName: "get_user",
+})
+
+await backendReactor.callMethod({
+  functionName: "update_user",
+  args: [{ name: "Alice" }],
+})
+```
+
+Reference: `packages/react/README.md`
+
+## Efficient Hook Creation Strategy
+
+### Prefer generated hooks when:
+
+- the project has multiple canisters or many methods
+- `.did` files change often
+- you want consistent typed exports and less hand-written boilerplate
+
+Use:
+
+- `@ic-reactor/vite-plugin` for Vite dev workflows (watch + regenerate)
+- `@ic-reactor/cli` for explicit generation and non-Vite projects
+
+References:
+
+- `packages/vite-plugin/README.md`
+- `packages/cli/README.md`
+- `packages/codegen/src/generators/reactor.ts`
+
+### Prefer manual factories when:
+
+- you need app-specific naming and composition
+- you want one object usable both in components and outside React
+- you want custom invalidation/select logic per operation
+
+## Common Mistakes To Prevent
+
+- Calling React hooks outside React. Use `.fetch()` or `.execute()` instead.
+- Recreating factory instances inside components. Define them at module scope.
+- Hardcoding invalidation keys manually. Prefer `query.getQueryKey()`.
+- Editing generated hook files directly. Regeneration will overwrite them.
+- Mixing `DisplayReactor` and `Reactor` expectations. Confirm transformed return and arg types first.
+
+## Useful Repo Files
+
+- `packages/react/src/createActorHooks.ts`
+- `packages/react/src/createQuery.ts`
+- `packages/react/src/createSuspenseQuery.ts`
+- `packages/react/src/createInfiniteQuery.ts`
+- `packages/react/src/createMutation.ts`
+- `packages/react/src/hooks/useActorMethod.ts`
+- `examples/all-in-one-demo/src/lib/factories.ts`
+- `examples/all-in-one-demo/src/lib/useHeart.ts`
+- `examples/tanstack-router/src/canisters/ledger/hooks/icrc1NameQuery.ts`
+- `examples/tanstack-router/src/canisters/ledger/hooks/icrc1TransferMutation.ts`


### PR DESCRIPTION
Summary
- add the new `ic-reactor-hooks` skill with workflow guidance for choosing query/mutation APIs and handling React vs imperative contexts
- include patterns reference docs and agents metadata that surface the skill when creating Reactor hooks

Testing
- Not run (not requested)