### PR TITLE
add candid type to the metadata

### DIFF
--- a/packages/candid/src/visitor/arguments/index.ts
+++ b/packages/candid/src/visitor/arguments/index.ts
@@ -258,6 +258,7 @@ export class FieldVisitor<A = BaseActor> extends IDL.Visitor<
           )
 
     return {
+      candidType: t.name,
       functionType,
       functionName,
       args,

--- a/packages/candid/src/visitor/arguments/types.ts
+++ b/packages/candid/src/visitor/arguments/types.ts
@@ -332,6 +332,8 @@ export interface ArgumentsMeta<
   A = BaseActor,
   Name extends FunctionName<A> = FunctionName<A>,
 > {
+  /** The original Candid type signature for the method */
+  candidType: string
   /** Whether this is a "query" or "update" call */
   functionType: FunctionType
   /** The method name as defined in the Candid interface */


### PR DESCRIPTION
This pull request enhances the metadata provided for method arguments in the Candid visitor utilities. The main improvement is the addition of the original Candid type signature to the `ArgumentsMeta` interface and its corresponding implementation in the visitor.

**Enhancements to method argument metadata:**

* Added a new `candidType` property to the `ArgumentsMeta` interface in `types.ts`, which stores the original Candid type signature for each method.
* Updated the `FieldVisitor` implementation in `index.ts` to include the `candidType` property when returning argument metadata.