### PR TITLE
docs: refresh package and example docs

### DIFF
--- a/docs/src/content/docs/examples/nextjs.mdx
+++ b/docs/src/content/docs/examples/nextjs.mdx
@@ -1,27 +1,30 @@
 ---
 title: "Next.js Integration"
-description: Full-stack template with Rust backend and Next.js frontend
+description: Pages Router example with a Rust canister and manual dfx declarations
 editUrl: false
 ---
 
 import { Aside, LinkCard, CardGrid } from "@astrojs/starlight/components"
 
-A complete template for building Internet Computer applications with **Next.js** and a **Rust** backend. This example demonstrates how to configure the IC SDK to work seamlessly with Next.js's server and client components.
+This example shows how to use IC Reactor in an existing Next.js app that still
+uses `dfx` for local deployment and declaration generation.
 
 ## Features Demonstrated
 
-- **Next.js App Router**: Modern React architecture.
-- **Rust Backend**: Integrates with a Rust-based canister.
-- **Local Development**: Scripts to run the full stack locally.
-- **Environment config**: Handling `dfx` generated declarations in Next.js.
+- **Next.js Pages Router**: The app lives under `src/pages`, not the App Router.
+- **Rust Backend**: A local canister under `backend/`.
+- **Manual declaration flow**: `dfx generate` output is committed under
+  `src/declarations/todo/`.
+- **IC Reactor hooks**: `createActorHooks` wraps a `Reactor` built from those
+  generated declarations.
 
 ## Links
 
 <CardGrid>
   <LinkCard
     title="Open in StackBlitz"
-    description="Edit and run in your browser"
-    href="https://stackblitz.com/github/b3pay/ic-reactor/tree/main/examples/nextjs?embed=1&theme=dark&file=src/app/page.tsx"
+    description="Edit and inspect the example"
+    href="https://stackblitz.com/github/b3pay/ic-reactor/tree/main/examples/nextjs?embed=1&theme=dark&file=src/pages/index.tsx"
   />
   <LinkCard
     title="View on GitHub"
@@ -32,43 +35,43 @@ A complete template for building Internet Computer applications with **Next.js**
 
 ## Setup Guide
 
-### 1. Install Dependencies
-
 ```bash
-pnpm install
+cd examples/nextjs
+npm run install:all
+npm run dfx:start
+npm run deploy
+npm run generate
+npm run dev
 ```
 
-### 2. Start Local Replica & Deploy
+## Key Integration
 
-```bash
-# Starts replica, deploys backend, and generates declarations
-pnpm run dfx:start
-pnpm run deploy
+```ts
+// src/service/client.ts
+export const clientManager = new ClientManager({
+  queryClient,
+  withProcessEnv: true,
+  agentOptions: {
+    verifyQuerySignatures: false,
+  },
+})
 ```
 
-### 3. Start Next.js
+```ts
+// src/service/todo.ts
+export const todoReactor = new Reactor<_SERVICE>({
+  name: "todo",
+  clientManager,
+  canisterId,
+  idlFactory,
+})
 
-```bash
-pnpm run dev
+export const { useActorQuery: useQueryTodo, useActorMutation: useMutateTodo } =
+  createActorHooks(todoReactor)
 ```
 
-## Configuration
-
-The key to getting Next.js to work with IC Reactor is properly configuring the webpack setup in `next.config.js` to handle WebAssembly and the DFINITY proxy, or simply using the client-side hooks provided by `@ic-reactor/react`.
-
-This example uses a client-side only approach for simplicity:
-
-```tsx
-"use client"
-
-import { useActorQuery } from "./reactor"
-
-export default function Home() {
-  const { data, isLoading } = useActorQuery({
-    functionName: "greet",
-    args: ["World"],
-  })
-
-  return <main>{isLoading ? "Loading..." : data}</main>
-}
-```
+<Aside type="note">
+  This example is intentionally a manual `dfx` workflow reference. If you want
+  automatic regeneration on `.did` changes, use the Vite plugin examples
+  instead.
+</Aside>

--- a/docs/src/content/docs/examples/query-demo.mdx
+++ b/docs/src/content/docs/examples/query-demo.mdx
@@ -1,21 +1,18 @@
 ---
 title: "Query Demo"
-description: Queries, suspense, and real-time data fetching from mainnet ICP ledgers
+description: Reusable suspense queries and mutations against mainnet ICP ledgers
 editUrl: false
 ---
 
 import { Aside, LinkCard, CardGrid } from "@astrojs/starlight/components"
 
-A comprehensive example showing queries, suspense, and real-time data fetching from mainnet ICP ledgers.
+This example demonstrates the current factory APIs in `@ic-reactor/react`
+against live ledger canisters:
 
-## Features Demonstrated
-
-- `createActorSuspenseQuery` for static queries
-- `createActorSuspenseQueryFactory` for dynamic queries with args
-- `DisplayReactor` for automatic type transformations
-- Multi-token support (ICP, ckBTC, ckETH)
-- Internet Identity authentication
-- Balance formatting and display
+- `createSuspenseQuery` for static method wrappers
+- `createSuspenseQueryFactory` for runtime arguments
+- `createMutation` for updates and invalidation
+- `DisplayReactor` for UI-friendly string values
 
 ## Links
 
@@ -44,27 +41,23 @@ A comprehensive example showing queries, suspense, and real-time data fetching f
 
 ## Key Code
 
-```typescript
-// Setup with DisplayReactor for human-readable display values
-export const icpReactor = new DisplayReactor<Ledger>({
-  clientManager,
-  canisterId: "ryjl3-tyaaa-aaaaa-aaaba-cai", // ICP Ledger mainnet
-  idlFactory: ledgerIdlFactory,
-})
-
-// Static query - no args needed
-export const icpNameQuery = createActorSuspenseQuery(icpReactor, {
+```ts
+export const icpNameQuery = createSuspenseQuery(icpReactor, {
   functionName: "icrc1_name",
 })
 
-// Factory for dynamic queries with args
-export const getIcpBalance = createActorSuspenseQueryFactory(icpReactor, {
+export const getIcpBalance = createSuspenseQueryFactory(icpReactor, {
   functionName: "icrc1_balance_of",
   select: (balance) => formatBalance(balance, "ICP"),
+})
+
+export const icpTransferMutation = createMutation(icpReactor, {
+  functionName: "icrc1_transfer",
 })
 ```
 
 <Aside type="tip">
-  This example connects to mainnet canisters (ICP, ckBTC, ckETH ledgers), so it
-  works without a local replica. Perfect for testing in StackBlitz!
+  The example points at mainnet ICP ecosystem ledgers, so it is a good reference
+  for reusable query and mutation composition without depending on a local
+  replica.
 </Aside>

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -139,23 +139,26 @@ IC Reactor is written in TypeScript and provides first-class type support. Ensur
   Reactor's type safety.
 </Aside>
 
-## Generate Candid Declarations
+## Generate Declarations
 
-If you have a DFX project, generate TypeScript declarations from your Candid files:
+IC Reactor needs generated canister declarations for end-to-end type safety. You
+can supply them in three ways:
 
-```bash
-dfx generate
-```
+1. **Recommended for Vite**: use [`@ic-reactor/vite-plugin`](/v3/packages/vite-plugin)
+2. **Recommended for non-Vite or CI**: use [`@ic-reactor/cli`](/v3/packages/cli)
+3. **Manual or existing workflow**: keep using your existing generator such as
+   `dfx generate` or `@icp-sdk/bindgen`
 
-This creates TypeScript declarations in `src/declarations/<canister_name>/` that IC Reactor uses for type safety. The generated files include:
+The generated files typically include:
 
-- `index.js` — IDL factory and canister ID
-- `<canister>.did.d.ts` — TypeScript types for your canister interface
+- `index.js` or `<canister>.js` with the `idlFactory`
+- `<canister>.did.d.ts` service types
+- an optional generated `index.ts` reactor entrypoint when you use IC Reactor
+  tooling
 
 <Aside type="note">
-  If you use **@ic-reactor/vite-plugin** or **@ic-reactor/cli**, you don't need
-  `dfx generate`! These tools automatically generate the necessary declarations
-  for you.
+  If you use **@ic-reactor/vite-plugin** or **@ic-reactor/cli**, you do not need
+  a separate `dfx generate` step for the IC Reactor output.
 </Aside>
 
 ## Verify Installation

--- a/docs/src/content/docs/getting-started/local-development.mdx
+++ b/docs/src/content/docs/getting-started/local-development.mdx
@@ -132,8 +132,9 @@ This error usually means the agent hasn't fetched the local root key.
 
 Check if your local replica is running and on which port.
 
-1. Run `dfx info webserver-port` to verify the port.
-2. If it's not `4943`, update your `ClientManager` config:
+1. If you use `icp-cli`, run `icp network status -e local --json` and check the returned port.
+2. If you use a manual `dfx` workflow, run `dfx info webserver-port`.
+3. If the replica is not on `4943`, update your `ClientManager` config:
 
    ```typescript
    export const clientManager = new ClientManager({
@@ -142,9 +143,10 @@ Check if your local replica is running and on which port.
    })
    ```
 
-### Internet Identity on Localhost
+### Internet Identity on Localhost (manual `dfx` workflow)
 
-To use Internet Identity locally, you need to deploy a local instance of the II canister.
+If you are using a manual `dfx` project, deploy a local instance of the
+Internet Identity canister.
 
 1. Pull the dependency in `dfx.json`:
 
@@ -170,7 +172,8 @@ To use Internet Identity locally, you need to deploy a local instance of the II 
    dfx deploy internet_identity --specified-id rdmx6-jaaaa-aaaaa-aaadq-cai
    ```
 
-3. Login using the local provider URL. `useAuth` handles this automatically if `withProcessEnv` is set correctly!
+3. Login using the local provider URL. `useAuth` handles this automatically if
+   `withProcessEnv` is set correctly.
 
    ```typescript
    // Auto-detects based on network

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -142,7 +142,7 @@ This tutorial walks you through creating your first IC Reactor integration with 
 Using the Vite plugin provides several advantages out-of-the-box:
 
 - **Zero-config Proxy**: `/api` requests are automatically proxied to your local replica.
-- **Auto-Canister IDs**: Canister IDs are automatically detected from your local network (via `icp` or `dfx`).
+- **Auto-Canister IDs**: Canister IDs are automatically detected from your local network through `icp-cli` when environment injection is enabled.
 - **Identity Support**: Works seamlessly with local Internet Identity setups.
 
 ## Environment Variables

--- a/docs/src/content/docs/guides/type-safety.mdx
+++ b/docs/src/content/docs/guides/type-safety.mdx
@@ -11,17 +11,19 @@ IC Reactor provides **end-to-end type safety** from your Candid definitions all 
 ## How It Works
 
 ```
-Candid IDL → dfx generate → TypeScript Types → IC Reactor → React Hooks
+Candid IDL → generated declarations → IC Reactor → React Hooks
 ```
 
 1. **Candid IDL** — Your canister's interface definition (`.did` file)
-2. **dfx generate** — Creates TypeScript declarations from Candid
+2. **Declaration generator** — `@ic-reactor/vite-plugin`, `@ic-reactor/cli`,
+   `@icp-sdk/bindgen`, or `dfx generate`
 3. **IC Reactor** — Infers types for all hooks and methods
 4. **React Components** — Full autocomplete and type checking
 
 ## Generated Types
 
-When you run `dfx generate`, it creates TypeScript files in `src/declarations/<canister_name>/`:
+When your toolchain generates declarations, it creates TypeScript files similar
+to `src/declarations/<canister_name>/`:
 
 ```typescript
 // src/declarations/backend/backend.did.d.ts
@@ -326,7 +328,7 @@ const { mutate } = useCreateUser() // mutate expects CreateUserInput
 1. **Always use the generated `_SERVICE` type** — Pass it to `Reactor<_SERVICE>`
 2. **Enable strict TypeScript** — Use `strict: true` in tsconfig.json
 3. **Trust the types** — If it compiles, the call is structurally valid
-4. **Run dfx generate after Candid changes** — Keep types in sync
+4. **Regenerate declarations after Candid changes** — Keep types in sync
 5. **Use type narrowing** — Check for `isPending` and `isError` before accessing `data`
 
 ## TypeScript Configuration

--- a/docs/src/content/docs/packages/parser/index.mdx
+++ b/docs/src/content/docs/packages/parser/index.mdx
@@ -1,94 +1,78 @@
 ---
 title: "@ic-reactor/parser"
-description: WASM-based Candid parser and transformer for the Internet Computer
+description: WASM-based Candid parser used by IC Reactor tooling and dynamic adapters
 editUrl: false
 ---
 
 import { Aside, Card, CardGrid } from "@astrojs/starlight/components"
 
-The `@ic-reactor/parser` package is a high-performance **WASM-based parser** for the DFINITY Candid language. It compiles Candid interface definitions (`.did` files) into JavaScript and TypeScript bindings directly in the browser or Node.js environment.
+`@ic-reactor/parser` is the low-level WASM parser behind local Candid
+compilation in IC Reactor. It converts raw `.did` source into JavaScript IDL
+factories or TypeScript declaration strings.
 
 ## Why This Package?
 
-While `@ic-reactor/candid` handles the fetching and interaction logic, this package provides the raw parsing power.
-
-- **Fast & Local** — No need to call a remote `didjs` canister to compile Candid.
-- **Offline Capable** — Parse Candid strings entirely on the client side.
-- **Type Generation** — Generate TypeScript interfaces on the fly.
+- **Fast and local**: Compile Candid without a remote `didjs` canister.
+- **Tooling friendly**: Used by `@ic-reactor/codegen` to turn `.did` files into
+  generated declarations.
+- **Runtime friendly**: Can be loaded by `@ic-reactor/candid` for local
+  `CandidAdapter` compilation.
 
 <CardGrid>
   <Card title="Candid to JS" icon="seti:javascript">
-    Compiles Candid strings to `idlFactory` and `init` exports for `HttpAgent`.
+    Returns JS source that exports `idlFactory` and `init`.
   </Card>
   <Card title="Candid to TS" icon="seti:typescript">
-    Generates full TypeScript type definitions from Candid.
+    Returns TypeScript declaration source for the same interface.
   </Card>
-  <Card title="WASM Power" icon="rocket">
-    Built with Rust and compiled to WebAssembly for performance.
+  <Card title="WASM Runtime" icon="rocket">
+    Implemented in Rust and compiled to WebAssembly.
   </Card>
 </CardGrid>
 
 ## Installation
 
 ```bash
-npm install @ic-reactor/parser
+pnpm add @ic-reactor/parser
 ```
 
 ## Usage
 
-### Basic Usage
-
-Import the parser and use the synchronous methods `didToJs` or `didToTs`.
-
-<Aside type="caution">
-  This package uses WebAssembly. In some environments (like standard Create
-  React App or older bundlers), you may need specific configuration to load WASM
-  files.
-</Aside>
-
-```typescript
+```ts
 import { didToJs, didToTs } from "@ic-reactor/parser"
 
-const candid = "service:{icrc1_name:()->(text) query;}"
+const candid = `service : {
+  greet : (text) -> (text) query;
+}`
 
-// Convert to JavaScript (idlFactory)
-const js = didToJs(candid)
-console.log(js)
-// Output:
-// export const idlFactory = ({ IDL }) => {
-//   return IDL.Service({ 'icrc1_name' : IDL.Func([], [IDL.Text], ['query']) });
-// };
-// export const init = ({ IDL }) => { return []; };
-
-// Convert to TypeScript definitions
-const ts = didToTs(candid)
-console.log(ts)
-// Output:
-// import type { Principal } from '@icp-sdk/core/principal';
-// ...
-// export interface _SERVICE { 'icrc1_name' : ActorMethod<[], string> }
-// ...
+const jsSource = didToJs(candid)
+const tsSource = didToTs(candid)
 ```
 
-### Integration with Candid Package
+<Aside type="caution">
+  This package returns source strings. If you need a higher-level runtime API,
+  prefer `@ic-reactor/candid` or the codegen packages instead of using the
+  parser directly.
+</Aside>
 
-This package is designed to work seamlessly with `@ic-reactor/candid`. When you initialize a `CandidAdapter` or `CandidReactor`, it can automatically use this parser.
+## Integration with `@ic-reactor/candid`
 
-```typescript
+```ts
 import { CandidAdapter } from "@ic-reactor/candid"
 import { ClientManager } from "@ic-reactor/core"
 
-const clientManager = new ClientManager()
-const adapter = new CandidAdapter({ clientManager })
+const adapter = new CandidAdapter({
+  clientManager: new ClientManager(),
+})
 
-// Load the WASM parser
 await adapter.loadParser()
-
-// Now the adapter uses @ic-reactor/parser for local compilation
-const { idlFactory } = await adapter.getCandidDefinition("canister-id")
+const jsSource = adapter.compileLocal(
+  "service : { greet : () -> (text) query }"
+)
 ```
 
 ## See Also
 
-- [API Reference](/v3/packages/parser/reference) — Detailed function documentation
-- [@ic-reactor/candid](/v3/packages/candid/) — Dynamic fetching and interaction
+- [API Reference](/v3/packages/parser/reference) — Detailed function reference
+- [@ic-reactor/candid](/v3/packages/candid) — Dynamic runtime Candid support
+- [@ic-reactor/codegen](/v3/packages/codegen) — Uses the parser for declaration generation

--- a/docs/src/content/docs/packages/vite-plugin.mdx
+++ b/docs/src/content/docs/packages/vite-plugin.mdx
@@ -1,38 +1,27 @@
 ---
 title: "@ic-reactor/vite-plugin"
-description: Zero-config Vite plugin for IC Reactor
+description: Zero-config Vite plugin for IC Reactor code generation
 editUrl: false
 ---
 
-import { Aside, Tabs, TabItem } from "@astrojs/starlight/components"
+import { Aside } from "@astrojs/starlight/components"
 
-The `@ic-reactor/vite-plugin` automates the generation of TypeScript declarations and Reactor hooks from your Candid files. It integrates seamlessly with Vite's development server, providing hot-module replacement (HMR) for your canister interfaces.
-
-It is powered by the shared [`@ic-reactor/codegen`](/v3/packages/codegen)
-package, so the generated output matches the CLI pipeline.
+`@ic-reactor/vite-plugin` runs the shared
+[`@ic-reactor/codegen`](/v3/packages/codegen) pipeline inside Vite. It
+generates declarations and typed reactor entrypoints from `.did` files, watches
+for changes, and can inject the `ic_env` cookie used by
+[`ClientManager`](/v3/reference/clientmanager).
 
 ## Installation
 
-<Tabs syncKey="pm">
-  <TabItem label="pnpm" icon="pnpm">
-    ```bash pnpm add -D @ic-reactor/vite-plugin ```
-  </TabItem>
-  <TabItem label="npm" icon="npm">
-    ```bash npm install -D @ic-reactor/vite-plugin ```
-  </TabItem>
-  <TabItem label="yarn" icon="seti:yarn">
-    ```bash yarn add -D @ic-reactor/vite-plugin ```
-  </TabItem>
-  <TabItem label="bun" icon="bun">
-    ```bash bun add -D @ic-reactor/vite-plugin ```
-  </TabItem>
-</Tabs>
+```bash
+pnpm add -D @ic-reactor/vite-plugin
+pnpm add @ic-reactor/react @tanstack/react-query @icp-sdk/core
+```
 
 ## Usage
 
-Add the plugin to your `vite.config.ts`:
-
-```typescript
+```ts
 import { defineConfig } from "vite"
 import react from "@vitejs/plugin-react"
 import { icReactor } from "@ic-reactor/vite-plugin"
@@ -41,82 +30,75 @@ export default defineConfig({
   plugins: [
     react(),
     icReactor({
-      canisters: [
-        {
-          name: "backend",
-          didFile: "src/backend/backend.did", // Path to your .did file
-        },
-      ],
+      canisters: [{ name: "backend", didFile: "./backend/backend.did" }],
     }),
   ],
 })
 ```
 
-### Reactor Mode (per canister)
+By default, generated files go to `src/declarations/<canister>/`, and the
+plugin imports `clientManager` from `../../clients`.
 
-By default, generated hooks use `DisplayReactor` (backward compatible). Set `mode` on a canister to choose the generated reactor class (`Reactor`, `DisplayReactor`, `CandidReactor`, `CandidDisplayReactor`, or `MetadataDisplayReactor`).
+## Reactor Mode
 
-```typescript
+Set `mode` per canister to choose the generated reactor class:
+
+```ts
 icReactor({
   canisters: [
     { name: "backend", didFile: "./backend/backend.did" },
     {
       name: "workflow_engine",
-      mode: "Reactor",
       didFile: "./workflow/workflow_engine.did",
+      mode: "Reactor",
     },
   ],
 })
 ```
 
-## Features
+Supported modes:
 
-### Zero-Config Proxy
+- `Reactor`
+- `DisplayReactor`
+- `CandidReactor`
+- `CandidDisplayReactor`
+- `MetadataDisplayReactor`
 
-The plugin automatically configures a proxy for `/api` requests to your local replica (defaulting to `http://127.0.0.1:4943`). This ensures your frontend can communicate with backend canisters during development without CORS issues.
+## Local Development
 
-### Automatic `ic_env` Injection
+When `injectEnvironment` is enabled during `vite dev`, the plugin tries to read
+local network details from `icp-cli`, then:
 
-The plugin automatically detects your network environment and canister IDs using the `icp` or `dfx` CLI. It injects this information into the `ic_env` cookie. This allows `ClientManager` to automatically resolve the correct canister IDs and network root key without manual configuration.
+1. resolves configured canister IDs
+2. sets the `ic_env` cookie
+3. proxies `/api` to the local replica
 
-### Hot Module Replacement
+If `icp-cli` environment detection is unavailable, the plugin still falls back
+to proxying `/api` to `http://127.0.0.1:4943`, but it skips cookie injection.
 
-The plugin watches your `.did` files. When you modify a Candid file, it automatically:
+## `.did` File Changes
 
-1. Regenerates the TypeScript declarations (`.d.ts`, `.js` factory).
-2. Regenerates `index.ts` with fully typed hooks when the file is still managed by codegen.
-3. Preserves your `index.ts` if you overwrite/customize it manually.
-4. Restarts the Vite server to pick up the changes.
+When a watched `.did` file changes, the plugin:
 
-## Configuration Options
+1. regenerates declarations
+2. regenerates the managed `index.ts` entrypoint when it still contains the
+   codegen marker
+3. preserves manually replaced `index.ts` files
+4. triggers a full browser reload
 
-| Option              | Type               | Description                                          | Default              |
-| :------------------ | :----------------- | :--------------------------------------------------- | :------------------- |
-| `canisters`         | `CanisterConfig[]` | List of canisters to generate hooks for (required).  | -                    |
-| `outDir`            | `string`           | Base output directory for generated files.           | `"src/declarations"` |
-| `injectEnvironment` | `boolean`          | Whether to inject canister IDs into `ic_env` cookie. | `true`               |
-| `clientManagerPath` | `string`           | Path to a custom `ClientManager` instance.           | `"../../clients"`    |
-
-### Canister Config
-
-| Option              | Type                                                                                                     | Description                                     | Required |
-| :------------------ | :------------------------------------------------------------------------------------------------------- | :---------------------------------------------- | :------- |
-| `name`              | `string`                                                                                                 | Name of the canister (used in generated code).  | Yes      |
-| `didFile`           | `string`                                                                                                 | Path to the `.did` file.                        | Yes      |
-| `outDir`            | `string`                                                                                                 | Override output directory for this canister.    | No       |
-| `clientManagerPath` | `string`                                                                                                 | Override client manager path for this canister. | No       |
-| `mode`              | `"Reactor" \| "DisplayReactor" \| "CandidReactor" \| "CandidDisplayReactor" \| "MetadataDisplayReactor"` | Reactor class for generated hooks.              | No       |
-| `canisterId`        | `string`                                                                                                 | Optional fixed canister ID.                     | No       |
+<Aside type="tip">
+  Use the Vite plugin when you want the fastest `.did` edit loop. Use the
+  [CLI](/v3/packages/cli) when you want explicit generation in non-Vite or CI
+  workflows.
+</Aside>
 
 ## Examples
 
-Check out these examples to see the Vite plugin in action:
-
-- **[Vite Plugin Demo](/v3/examples/vite-plugin)**: Basic usage of the Vite plugin for automatic hook generation.
-- **[Vite Environment Variables](/v3/examples/vite-env)**: Using the plugin to automatically inject canister IDs and root keys.
-- **[Codegen in Action](/v3/examples/codegen-in-action)**: Comparison between Vite plugin and CLI output.
+- [Vite Plugin Demo](/v3/examples/vite-plugin)
+- [Vite Environment Variables](/v3/examples/vite-env)
+- [Codegen in Action](/v3/examples/codegen-in-action)
 
 ## See Also
 
-- [@ic-reactor/codegen](/v3/packages/codegen) — Shared generator pipeline
-- [@ic-reactor/cli](/v3/packages/cli) — Manual code generation outside Vite
+- [@ic-reactor/codegen](/v3/packages/codegen)
+- [@ic-reactor/cli](/v3/packages/cli)

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -1,63 +1,54 @@
-# InternetComputer - Rust + Next.js Template
+# Next.js Example
 
-This is a template for creating a Next.js app with a Rust backend that can be deployed to the Internet Computer.
+This example is a Next.js Pages Router app backed by a Rust canister and a
+manual `dfx` declaration workflow. It shows how to wire `@ic-reactor/react`
+into a traditional Next.js project without the Vite plugin.
 
-![Alt text](public/demo.png)
+## What It Uses
 
-## Getting Started
+- Next.js Pages Router under `src/pages`
+- a Rust backend canister under `backend/`
+- `dfx` for local replica, deployment, and declaration generation
+- `ClientManager` with `withProcessEnv: true`
+- `createActorHooks` over a `Reactor` built from generated declarations
 
-1. Install the [DFINITY Canister SDK](https://sdk.dfinity.org/docs/quickstart/local-quickstart.html)
-2. Install [Node.js](https://nodejs.org/en/download/)
-3. Install [Rust](https://www.rust-lang.org/tools/install)
+## Prerequisites
 
-## Running Locally
+- Node.js
+- Rust
+- `dfx`
+- `cargo install candid-extractor ic-wasm` if you have not installed those
+  helpers yet
 
-Installing dependencies:
+## Run It
 
-1. Run `yarn install:all` or `npm run install:all`
-   it will run the following commands:
+```bash
+cd examples/nextjs
+npm run install:all
+npm run dfx:start
+npm run deploy
+npm run generate
+npm run dev
+```
 
-   Install Node.js dependencies:
+Open http://localhost:3000 when the app is ready.
 
-- Run `yarn install` or `npm install`
+## Key Files
 
-  For extract candid definition from canister WASM:
+- `src/service/client.ts` creates the shared `ClientManager` and auth hooks
+- `src/service/todo.ts` creates the `Reactor` and bound hooks from generated
+  declarations
+- `src/pages/index.tsx` renders the app
+- `src/declarations/todo/` contains the `dfx generate` output used by the app
 
-- Run `yarn candid:install` or `npm run candid:install`
+## Why This Example Exists
 
-  For transforming Wasm canisters running on the Internet Computer:
+Most current IC Reactor examples use Vite plus generated hooks. This one is the
+reference for teams that still have:
 
-- Run `yarn wasm:install` or `npm run wasm:install`
+- an existing Next.js project
+- `dfx`-generated declarations
+- manual build or deployment scripts
 
-Running Local Internet Computer:
-
-2. Run `yarn dfx:start` or `npm run dfx:start`
-
-Deploying to the Local Internet Computer:
-
-3.1 Run `yarn deploy` or `npm run deploy`
-3.2 Run `yarn identity:deploy` or `npm run identity:deploy`
-
-Running Next.js app:
-
-4. Run `yarn dev` or `npm run dev`
-5. Open http://localhost:3000 in your browser
-
-## Deploying to the Internet Computer
-
-1. Run `yarn deploy --network=ic` to deploy the canisters to the Internet Computer
-
-## Notes
-
-- The Rust code is located in the `backend` directory
-- The Next.js code is located in the `src` directory
-- The canister configuration is located in the `dfx.json` file
-
-## Resources
-
-- [DFINITY Canister SDK](https://sdk.dfinity.org/docs/quickstart/local-quickstart.html)
-- [Rust](https://www.rust-lang.org/)
-- [Next.js](https://nextjs.org/)
-- [ic-wasm](https://github.com/dfinity/ic-wasm)
-- [candid-extractor](https://github.com/dfinity/cdk-rs/tree/main/src/candid-extractor)
-- [Reactor](https://github.com/B3Pay/re-actor)
+If you want zero-command regeneration during development, use the Vite examples
+instead.

--- a/examples/query-demo/README.md
+++ b/examples/query-demo/README.md
@@ -1,221 +1,74 @@
-# IC Reactor Demo - Queries & Mutations
+# Query Demo
 
-This example demonstrates how to use `createActorSuspenseQuery`, `createActorSuspenseQueryFactory`, and `createActorMutation` from `@ic-reactor/react` to create reusable, type-safe query and mutation wrappers for Internet Computer canister calls.
+This example demonstrates the current factory APIs from `@ic-reactor/react`:
 
-## Quick Start
+- `createSuspenseQuery` for static method wrappers
+- `createSuspenseQueryFactory` for runtime args
+- `createMutation` for updates and targeted invalidation
+- `createAuthHooks` for Internet Identity login state
+
+It talks to the live ICP, ckBTC, and ckETH ledgers through `DisplayReactor`
+instances, so the example focuses on reusable query and mutation composition
+instead of local canister setup.
+
+## Run It
 
 ```bash
-# From the monorepo root
-pnpm install
-pnpm build
 cd examples/query-demo
+pnpm install
 pnpm dev
 ```
 
-## Key Concepts
+## Key Files
 
-### 1. `createActorSuspenseQuery` - Static Queries
+- `src/reactor.ts` creates the shared `ClientManager`, `DisplayReactor`
+  instances, query factories, and mutation factories
+- `src/App.tsx` shows how to consume those factories inside React components
 
-Use when arguments are known at definition time:
+## Patterns Shown
 
-```typescript
-import { createActorSuspenseQuery, DisplayReactor } from "@ic-reactor/react"
+### Static suspense query
 
-// Define query once (no arguments)
-const icpNameQuery = createActorSuspenseQuery(icpReactor, {
+```ts
+import { createSuspenseQuery } from "@ic-reactor/react"
+
+export const icpNameQuery = createSuspenseQuery(icpReactor, {
   functionName: "icrc1_name",
 })
-
-// Usage in component (uses useSuspenseQuery internally)
-function TokenName() {
-  const { data } = icpNameQuery.useQuery()
-  return <span>{data}</span>
-}
-
-// Usage in loader/router
-async function loader() {
-  const name = await icpNameQuery.fetch()
-  return { name }
-}
 ```
 
-### 2. `createActorSuspenseQueryFactory` - Dynamic Queries
+### Dynamic suspense query factory
 
-Use when arguments are provided at runtime:
+```ts
+import { createSuspenseQueryFactory } from "@ic-reactor/react"
 
-```typescript
-import { createActorSuspenseQueryFactory } from "@ic-reactor/react"
-
-// Define factory (args provided later)
-const getBalance = createActorSuspenseQueryFactory(icpReactor, {
-  functionName: "icrc1_balance_of",
-})
-
-// Create query with specific args
-const balanceQuery = getBalance({ owner: principal, subaccount: null })
-
-// Usage in component
-function Balance({ account }) {
-  const { data } = getBalance(account).useQuery()
-  return <span>{data}</span>
-}
-```
-
-### 3. `createActorMutation` - Mutations with Auto-Refetch 🔥
-
-Use for state-changing operations like transfers. **The killer feature**: just pass `invalidateQueries` and the library handles everything!
-
-```typescript
-import { createActorMutation, createActorSuspenseQueryFactory } from "@ic-reactor/react"
-
-// Define mutation
-const icpTransferMutation = createActorMutation(icpReactor, {
-  functionName: "icrc1_transfer",
-})
-
-// Define balance query factory
-const getIcpBalance = createActorSuspenseQueryFactory(icpReactor, {
+export const getIcpBalance = createSuspenseQueryFactory(icpReactor, {
   functionName: "icrc1_balance_of",
   select: (balance) => formatBalance(balance, "ICP"),
 })
-
-// Usage in component - balance auto-updates after transfer!
-function TransferForm({ userAccount }) {
-  // Get the balance query for this user
-  const balanceQuery = getIcpBalance(userAccount)
-
-  // 🔥 Pass invalidateQueries with .getQueryKey() - that's it!
-  const { mutate, isPending } = icpTransferMutation.useMutation({
-    invalidateQueries: [balanceQuery.getQueryKey()], // Auto-refetch! ✨
-  })
-
-  const handleTransfer = () => {
-    // DisplayReactor accepts string amounts - no bigint needed!
-    mutate([{
-      to: { owner: recipientPrincipal, subaccount: null },
-      amount: "100000000", // 1 ICP
-      fee: null,
-      memo: null,
-      from_subaccount: null,
-      created_at_time: null,
-    }])
-  }
-
-  return (
-    <>
-      <span>Balance: {balanceQuery.useQuery().data}</span>
-      <button onClick={handleTransfer} disabled={isPending}>
-        {isPending ? "Transferring..." : "Transfer"}
-      </button>
-    </>
-  )
-}
 ```
 
-### 4. Authentication with `createAuthHooks`
+### Mutation with invalidation
 
-```typescript
-import { createAuthHooks } from "@ic-reactor/react"
+```ts
+import { createMutation } from "@ic-reactor/react"
 
-export const { useAuth, useAuthState, useUserPrincipal } = createAuthHooks(clientManager)
-
-// Usage in component
-function AuthButton() {
-  const { login, logout } = useAuth()
-  const { isAuthenticated, isAuthenticating } = useAuthState()
-  const principal = useUserPrincipal()
-
-  if (isAuthenticated) {
-    return (
-      <div>
-        <span>Logged in as: {principal?.toText()}</span>
-        <button onClick={() => logout()}>Logout</button>
-      </div>
-    )
-  }
-
-  return (
-    <button onClick={() => login()} disabled={isAuthenticating}>
-      {isAuthenticating ? "Connecting..." : "Login with Internet Identity"}
-    </button>
-  )
-}
-```
-
-### 5. Select Transformations
-
-Transform data at query time:
-
-```typescript
-// Transform at definition
-const formattedBalance = createActorSuspenseQueryFactory(icpReactor, {
-  functionName: "icrc1_balance_of",
-  select: (balance) => `${balance} ICP`,
-})
-
-// Chain another select in hook
-const { data } = formattedBalance(account).useQuery({
-  select: (formatted) => formatted.toUpperCase(),
+export const icpTransferMutation = createMutation(icpReactor, {
+  functionName: "icrc1_transfer",
 })
 ```
 
-## API Reference
+```tsx
+const balanceQuery = getIcpBalance([account])
+const transfer = icpTransferMutation.useMutation({
+  invalidateQueries: [balanceQuery.getQueryKey()],
+})
+```
 
-### `createActorSuspenseQuery(reactor, config)`
+## Why This Example Matters
 
-Creates a query wrapper for methods without dynamic arguments.
-
-**Config:**
-
-- `functionName` - The canister method to call
-- `args?` - Static arguments (optional)
-- `staleTime?` - Cache duration (default: 5 minutes)
-- `select?` - Transform function for the result
-
-**Returns:**
-
-- `fetch()` - Fetch data (uses `ensureQueryData`)
-- `useQuery(options?)` - React hook (uses `useSuspenseQuery`)
-- `refetch()` - Invalidate and refetch
-- `getQueryKey()` - Get the query key
-- `getCacheData()` - Get data from cache without fetching
-
-### `createActorSuspenseQueryFactory(reactor, config)`
-
-Creates a factory that returns query wrappers when called with arguments.
-
-**Config:** Same as `createActorSuspenseQuery`, but without `args`
-
-**Returns:** A function that accepts args and returns a `ActorSuspenseQueryResult`
-
-### `createActorMutation(reactor, config)`
-
-Creates a mutation wrapper for state-changing operations.
-
-**Config:**
-
-- `functionName` - The canister method to call
-- `onSuccess?` - Callback on successful mutation
-- `invalidateQueries?` - Query keys to refetch after mutation
-
-**Returns:**
-
-- `useMutation(options?)` - React hook with `mutate`, `isPending`, `error`, `isSuccess`
-- `execute(args)` - Direct execution function for loaders/actions
-
-## Benefits
-
-1. **Type-Safe** - Full TypeScript inference for methods, args, and returns
-2. **Cacheable** - Uses React Query's caching automatically
-3. **Reusable** - Define once, use in loaders and components
-4. **Composable** - Chain select transformations
-5. **Suspense-Ready** - Works with React Suspense out of the box
-6. **Mutation Support** - Full mutation handling with loading/error states
-
-## Important Notes
-
-- `useQuery()` uses `useSuspenseQuery` internally, so wrap components in `<Suspense>`
-- The `enabled` option is NOT supported for suspense queries (use `createActorQuery` instead)
-- Data is always defined when the component renders
-- Use `DisplayReactor` for automatic bigint → string transformations
-- Mutations work with Internet Identity authentication out of the box
+- shows the recommended factory naming used in the current package exports
+- keeps reusable query objects outside components
+- demonstrates `DisplayReactor` for UI-friendly string values
+- works well as a reference for loader or service patterns because the same
+  factories also expose `.fetch()` and `.execute()`

--- a/examples/suspense-infinite-query-demo/README.md
+++ b/examples/suspense-infinite-query-demo/README.md
@@ -1,45 +1,46 @@
 # Suspense Infinite Query Demo
 
-This example demonstrates how to use the `createSuspenseInfiniteQuery` function from `@ic-reactor/react` to create a production-ready, Suspense-enabled infinite scrolling list.
+This example demonstrates `createSuspenseInfiniteQueryFactory` with a local
+Rust canister and a traditional `dfx` workflow.
 
-## Features Demonstrated
+## What It Shows
 
-1.  **Mock Actor Manager**: How to simulate a canister call using `ActorManager` interface without a local replica.
-2.  **Suspense Integration**: Using React Suspense to handle the initial loading state natively.
-3.  **Infinite Loading**: Handling pagination (cursors) and "Load More" functionality seamlessly.
-4.  **Type Safety**: Full TypeScript integration for actor methods and query results.
+- `ClientManager` and `Reactor` setup for a local replica
+- `createSuspenseInfiniteQueryFactory` for cursor-based pagination
+- React Suspense for the first load
+- typed `getNextPageParam` handling from real canister results
 
-## How to Run
+## Run It
 
-1.  **Install Dependencies**:
+```bash
+cd examples/suspense-infinite-query-demo
+pnpm install
+dfx start --background --clean
+dfx deploy
+pnpm dev
+```
 
-    ```bash
-    pnpm install
-    ```
+`dfx deploy` generates the declarations consumed by `src/store.ts`.
 
-2.  **Start Local Replica**:
-    Make sure you have `dfx` installed.
+## Key Files
 
-    ```bash
-    cd examples/suspense-infinite-query-demo
-    dfx start --background --clean
-    ```
+- `src/store.ts` sets up the shared `ClientManager`, `Reactor`, auth hooks, and
+  `createSuspenseInfiniteQueryFactory`
+- `src/App.tsx` renders the paginated list inside a Suspense boundary
+- `backend/src/lib.rs` implements the demo canister and pagination response
 
-3.  **Deploy Canister**:
+## Core Factory
 
-    ```bash
-    dfx deploy
-    ```
+```ts
+export const getPostsQuery = createSuspenseInfiniteQueryFactory(reactor, {
+  functionName: "get_posts",
+  initialPageParam: 0n,
+  getNextPageParam: (lastPage) => {
+    if (lastPage.next_cursor.length === 0) return undefined
+    return lastPage.next_cursor[0]
+  },
+})
+```
 
-    This will generate the definitions in `src/declarations`.
-
-4.  **Run Development Server**:
-    ```bash
-    pnpm dev
-    ```
-
-## Code Structure
-
-- `backend/`: Rust canister source code.
-- `src/store.ts`: Defines the `ActorManager` (now pointing to local canister) and creates the query.
-- `src/App.tsx`: Consumes the query using Suspense.
+Use this example when you want a minimal reference for suspense-enabled
+infinite queries against a locally deployed canister.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,65 +1,49 @@
 # @ic-reactor/cli
 
-> 🔧 Command-line tool for generating type-safe React hooks for ICP canisters.
+Command-line code generation for IC Reactor. It uses the shared
+`@ic-reactor/codegen` pipeline to generate declarations and typed reactor entry
+files from your `.did` files.
 
-The `@ic-reactor/cli` helps you generate TypeScript declarations and React hooks from your Candid files. It uses the shared `@ic-reactor/codegen` pipeline to ensure consistency with the Vite plugin.
-
-## Installation
+## Install
 
 ```bash
 pnpm add -D @ic-reactor/cli
 ```
 
+After installation, the local executable is `ic-reactor`.
+
 ## Quick Start
 
-### 1. Initialize your project
-
 ```bash
-npx @ic-reactor/cli init
+pnpm exec ic-reactor init
+pnpm exec ic-reactor generate
 ```
 
-This creates an `ic-reactor.json` configuration file in your project root and optionally sets up a default `ClientManager` at `src/clients.ts`.
+If you prefer one-off usage without installing first:
 
-### 2. Configure your canisters
+```bash
+pnpm dlx @ic-reactor/cli init
+pnpm dlx @ic-reactor/cli generate
+```
 
-Update `ic-reactor.json` with the paths to your Candid files:
+## What `init` Creates
+
+- an `ic-reactor.json` config file
+- an optional `src/clients.ts` helper with a shared `ClientManager`
+
+## Example Config
 
 ```json
 {
+  "$schema": "./node_modules/@ic-reactor/cli/schema.json",
   "outDir": "src/declarations",
   "clientManagerPath": "../../clients",
   "canisters": {
     "backend": {
-      "didFile": "src/backend/backend.did"
+      "name": "backend",
+      "didFile": "./backend/backend.did"
     }
   }
-}
-```
-
-### 3. Generate hooks
-
-```bash
-npx ic-reactor generate
-```
-
-This command will:
-
-1. Generate TypeScript declarations (`.d.ts`, `.js`, `.did`) for each canister.
-2. Create an `index.ts` reactor file for each canister with fully typed hooks.
-
-### 4. Use the generated hooks
-
-Import the hooks directly from the generated output folder:
-
-```tsx
-import { useBackendQuery } from "./declarations/backend"
-
-function MyComponent() {
-  const { data, isPending } = useBackendQuery({
-    functionName: "get_message",
-  })
-
-  return <p>{isPending ? "Loading..." : data}</p>
 }
 ```
 
@@ -67,62 +51,55 @@ function MyComponent() {
 
 ### `init`
 
-Initialize the configuration file (`ic-reactor.json`).
-
 ```bash
-npx @ic-reactor/cli init [options]
+pnpm exec ic-reactor init [options]
 
 Options:
   -y, --yes              Skip prompts and use defaults
-  -o, --out-dir <path>   Output directory for generated hooks
+  -o, --out-dir <path>   Output directory for generated files
 ```
 
-### `generate` (alias: `g`)
-
-Generate hooks and declarations based on your configuration and DID files.
+### `generate` / `g`
 
 ```bash
-npx ic-reactor generate [options]
+pnpm exec ic-reactor generate [options]
 
 Options:
-  -c, --canister <name>   Generate only for a specific canister
-  --clean                 Clean output directory before generating
+  -c, --canister <name>  Generate only one configured canister
+  --clean                Clean the output directory before generation
 ```
 
-## Configuration
+## Generated Output
 
-The `ic-reactor.json` file schema:
+For each canister, the CLI generates:
 
-```typescript
-interface CodegenConfig {
-  /** Default output directory (relative to project root) */
-  outDir: string
-  /** Default import path for the client manager */
-  clientManagerPath?: string
-  /** Canister configurations */
-  canisters: Record<string, CanisterConfig>
-}
+- `<canister>.did` copy
+- `<canister>.did.d.ts` TypeScript service types
+- `<canister>.js` IDL factory module
+- `index.ts` reactor and typed hook entrypoint
 
-interface CanisterConfig {
-  /** Canister name (required) */
-  name: string
-  /** Path to the .did file (required) */
-  didFile: string
-  /** Override output directory for this canister */
-  outDir?: string
-  /** Override client manager import path */
-  clientManagerPath?: string
-  /** Optional fixed canister ID */
-  canisterId?: string
-}
-```
+The generated `index.ts` is only overwritten while it still contains the
+generator marker. If you replace it with a custom module, later runs leave it
+alone.
+
+## When To Use The CLI
+
+- non-Vite apps
+- CI or explicit build pipelines
+- projects that want manual control over when generation runs
+
+Use `@ic-reactor/vite-plugin` instead when you want watch-mode regeneration
+inside a Vite app.
 
 ## Requirements
 
 - Node.js 18+
-- @ic-reactor/react 3.x
-- TypeScript 5.0+
+- TypeScript 5+
+- `@ic-reactor/react` in the consuming app if you plan to use generated React
+  hooks
 
-## License
+## See Also
 
-MIT
+- Docs: https://ic-reactor.b3pay.net/v3/packages/cli
+- `@ic-reactor/codegen`: ../codegen/README.md
+- `@ic-reactor/vite-plugin`: ../vite-plugin/README.md

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -1,80 +1,58 @@
 # @ic-reactor/parser
 
-A high-performance **WASM-based parser** for the DFINITY Candid language, built for the `ic-reactor` ecosystem.
+WASM-based Candid parser used by IC Reactor tooling and dynamic Candid
+workflows. It turns raw Candid source into JavaScript IDL factories or
+TypeScript declaration strings.
 
-This package compiles Candid interface definitions (`.did` files) into JavaScript and TypeScript bindings directly in the browser or Node.js environment, without needing to interact with a remote canister.
-
-## Features
-
-- **Blazing Fast**: Built with Rust and compiled to WebAssembly.
-- **Offline Capable**: Parse Candid strings entirely on the client side.
-- **Zero Dependencies**: Does not rely on the `didjs` canister.
-- **Universal**: Works in the browser and Node.js.
-
-## Installation
+## Install
 
 ```bash
-npm install @ic-reactor/parser
+pnpm add @ic-reactor/parser
 ```
 
-## Usage
+## API
 
-### Converting Candid to JavaScript
+### `didToJs(candid: string): string`
 
-```typescript
-import { didToJs } from "@ic-reactor/parser"
+Returns JavaScript source that exports `idlFactory` and `init`.
+
+### `didToTs(candid: string): string`
+
+Returns TypeScript declaration source for the same Candid interface.
+
+## Example
+
+```ts
+import { didToJs, didToTs } from "@ic-reactor/parser"
 
 const candid = `service : {
   greet : (text) -> (text) query;
 }`
 
-const jsCode = didToJs(candid)
-console.log(jsCode)
+const jsSource = didToJs(candid)
+const tsSource = didToTs(candid)
+
+console.log(jsSource)
+console.log(tsSource)
 ```
 
-**Output:**
+## Where It Is Used
 
-```javascript
-export const idlFactory = ({ IDL }) => {
-  return IDL.Service({ greet: IDL.Func([IDL.Text], [IDL.Text], ["query"]) })
-}
-export const init = ({ IDL }) => {
-  return []
-}
-```
+- `@ic-reactor/candid` can load it for local `CandidAdapter` compilation
+- `@ic-reactor/codegen` uses it to generate declaration files from `.did`
+  sources
 
-### Converting Candid to TypeScript
+If you only need runtime dynamic interaction, install `@ic-reactor/candid` and
+let that package load the parser when needed.
 
-```typescript
-import { didToTs } from "@ic-reactor/parser"
+## Notes
 
-const tsCode = didToTs(candid)
-console.log(tsCode)
-```
+- The package is compiled from Rust to WebAssembly.
+- It returns source strings rather than ready-made JS objects.
+- Browser environments need standard WASM support from the bundler/runtime.
 
-**Output:**
+## See Also
 
-```typescript
-import type { Principal } from "@icp-sdk/core/principal"
-import type { ActorMethod } from "@icp-sdk/core/agent"
-import type { IDL } from "@icp-sdk/core/candid"
-
-export interface _SERVICE {
-  greet: ActorMethod<[string], string>
-}
-export declare const idlFactory: IDL.InterfaceFactory
-export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[]
-```
-
-## Integration with IC-Reactor
-
-This package is used internally by `@ic-reactor/candid` and `@ic-reactor/core` to enable local parsing strategies.
-
-```typescript
-import { createCandidAdapter } from "@ic-reactor/core"
-// The parser is dynamically imported if available
-```
-
-## License
-
-MIT
+- Docs: https://ic-reactor.b3pay.net/v3/packages/parser
+- `@ic-reactor/candid`: ../candid/README.md
+- `@ic-reactor/codegen`: ../codegen/README.md

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,386 +1,144 @@
 # @ic-reactor/react
 
-<div align="center">
-  <strong>The Ultimate React Hooks for the Internet Computer.</strong>
-  <br><br>
-  
-  [![npm version](https://img.shields.io/npm/v/@ic-reactor/react.svg)](https://www.npmjs.com/package/@ic-reactor/react)
-  [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-  [![TypeScript](https://img.shields.io/badge/TypeScript-5.0+-blue.svg)](https://www.typescriptlang.org/)
-</div>
+React bindings for IC Reactor. This package re-exports everything from
+`@ic-reactor/core` and adds hook factories, auth hooks, direct reactor hooks,
+and reusable query or mutation factories built around TanStack Query.
 
----
-
-Connect your React application to the Internet Computer Blockchain with full [TanStack Query](https://tanstack.com/query) integration for caching, suspense, and infinite queries.
-
-## Features
-
-- ⚛️ **TanStack Query Integration** — Full power of React Query (caching, refetching, suspense, infinite queries)
-- � **End-to-End Type Safety** — Automatic type inference from your Candid files
-- � **Auto Transformations** — `DisplayReactor` converts BigInt to string, Principal to text, and more
-- 📦 **Result Unwrapping** — Automatic `Ok`/`Err` handling from Candid Result types
-- 🔐 **Authentication** — Easy-to-use hooks with Internet Identity integration
-- 🏗️ **Multi-Actor Support** — Manage multiple canisters with shared authentication
-
-## Installation
+## Install
 
 ```bash
-# With npm
-npm install @ic-reactor/react @tanstack/react-query @icp-sdk/core
+pnpm add @ic-reactor/react @icp-sdk/core @tanstack/react-query
 
-# With pnpm
-pnpm add @ic-reactor/react @tanstack/react-query @icp-sdk/core
-
-# Optional: For Internet Identity authentication
-npm install @icp-sdk/auth
+# Optional: Internet Identity login helpers
+pnpm add @icp-sdk/auth
 ```
 
 ## Quick Start
 
-### 1. Setup ClientManager and Reactor
-
-```typescript
+```tsx
 // src/reactor.ts
-import { ClientManager, Reactor } from "@ic-reactor/react"
+import { ClientManager, Reactor, createActorHooks } from "@ic-reactor/react"
 import { QueryClient } from "@tanstack/react-query"
-import { idlFactory, type _SERVICE } from "./declarations/my_canister"
+import { idlFactory, type _SERVICE } from "./declarations/backend"
 
-// Create query client for caching
 export const queryClient = new QueryClient()
 
-// Create client manager (handles identity and agent)
-// Create client manager (handles identity and agent)
 export const clientManager = new ClientManager({
   queryClient,
-  withCanisterEnv: true, // Reads canister IDs from environment/cookies
+  withCanisterEnv: true,
 })
 
-// Create reactor for your canister
 export const backend = new Reactor<_SERVICE>({
   clientManager,
   idlFactory,
-  name: "backend", // Required: explicit name for the reactor
+  name: "backend",
 })
+
+export const {
+  useActorQuery,
+  useActorMutation,
+  useActorSuspenseQuery,
+  useActorMethod,
+} = createActorHooks(backend)
 ```
-
-### 2. Create Hooks
-
-```typescript
-// src/hooks.ts
-import { createActorHooks, createAuthHooks } from "@ic-reactor/react"
-import { backend, clientManager } from "./reactor"
-
-// Create actor hooks for queries and mutations
-export const { useActorQuery, useActorMutation, useActorSuspenseQuery } =
-  createActorHooks(backend)
-
-// Create auth hooks for login/logout
-export const { useAuth, useUserPrincipal } = createAuthHooks(clientManager)
-```
-
-### 3. Setup Provider (not required) and Use in Components
 
 ```tsx
 // src/App.tsx
 import { QueryClientProvider } from "@tanstack/react-query"
-import { queryClient } from "./reactor"
-import { useAuth, useActorQuery, useActorMutation } from "./hooks"
-
-function App() {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <AuthButton />
-      <Greeting />
-    </QueryClientProvider>
-  )
-}
-
-function AuthButton() {
-  const { login, logout, isAuthenticated, principal } = useAuth()
-
-  return isAuthenticated ? (
-    <button onClick={() => logout()}>
-      Logout {principal?.toText().slice(0, 8)}...
-    </button>
-  ) : (
-    <button onClick={() => login()}>Login with Internet Identity</button>
-  )
-}
+import { queryClient, useActorMethod, useActorQuery } from "./reactor"
 
 function Greeting() {
-  // Query: Fetch data (auto-cached!)
-  const { data, isPending, error } = useActorQuery({
+  const { data, isPending } = useActorQuery({
     functionName: "greet",
     args: ["World"],
   })
 
-  if (isPending) return <div>Loading...</div>
-  if (error) return <div>Error: {error.message}</div>
+  if (isPending) return <p>Loading...</p>
+  return <p>{data}</p>
+}
 
-  return <h1>{data}</h1>
+function Increment() {
+  const { call, isPending } = useActorMethod({ functionName: "increment" })
+
+  return (
+    <button disabled={isPending} onClick={() => call([])}>
+      {isPending ? "Updating..." : "Increment"}
+    </button>
+  )
+}
+
+export function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Greeting />
+      <Increment />
+    </QueryClientProvider>
+  )
 }
 ```
 
-## Core Concepts
+## Main APIs
 
-### Reactor vs DisplayReactor
+- `createActorHooks(reactor)` for per-canister hooks like `useActorQuery` and
+  `useActorMutation`
+- `createAuthHooks(clientManager)` for `useAuth`, `useAuthState`,
+  `useAgentState`, and `useUserPrincipal`
+- direct reactor hooks like `useReactorQuery` when you want to pass the reactor
+  instance at call time
+- factory helpers like `createQuery`, `createSuspenseQuery`,
+  `createInfiniteQuery`, `createSuspenseInfiniteQuery`, and `createMutation`
+  when the same operation must work both inside and outside React
 
-| Feature       | `Reactor`        | `DisplayReactor`             |
-| ------------- | ---------------- | ---------------------------- |
-| Types         | Raw Candid types | Display-friendly types       |
-| BigInt        | `bigint`         | `string`                     |
-| Principal     | `Principal`      | `string`                     |
-| Vec nat8      | `Uint8Array`     | <= 512 bytes: `string` (hex) |
-| Result        | Unwrapped        | Unwrapped                    |
-| Form-friendly | No               | Yes                          |
+## Choosing the Right Pattern
 
-```typescript
-import { DisplayReactor } from "@ic-reactor/react"
+- Use `createActorHooks` for the simplest component-first integration.
+- Use query and mutation factories when you also need loader, action, service,
+  or test usage through `.fetch()`, `.execute()`, `.invalidate()`, or
+  `.getCacheData()`.
+- Use `DisplayReactor` when you want UI-friendly values such as strings instead
+  of `bigint` or `Principal`.
+- Use generated hooks from `@ic-reactor/vite-plugin` or `@ic-reactor/cli` when
+  you have larger canisters or frequent `.did` changes.
 
-// DisplayReactor for form-friendly UI work
-const backend = new DisplayReactor<_SERVICE>({
-  clientManager,
-  idlFactory,
-  canisterId: "rrkah-fqaaa-aaaaa-aaaaq-cai",
+## Factory Example
+
+```ts
+import { createSuspenseQueryFactory, createMutation } from "@ic-reactor/react"
+import { backend } from "./reactor"
+
+export const getProfile = createSuspenseQueryFactory(backend, {
+  functionName: "get_profile",
 })
 
-// Now hooks return strings instead of bigint/Principal
-const { data } = useActorQuery({
-  functionName: "icrc1_balance_of",
-  args: [{ owner: "aaaaa-aa", subaccount: [] }], // strings!
-})
-// data is "100000000" instead of 100000000n
-```
-
-## Hooks Reference
-
-### Actor Hooks (from `createActorHooks`)
-
-| Hook                            | Description                                    |
-| ------------------------------- | ---------------------------------------------- |
-| `useActorQuery`                 | Standard queries with loading states           |
-| `useActorSuspenseQuery`         | Suspense-enabled queries (data always defined) |
-| `useActorInfiniteQuery`         | Paginated/infinite scroll queries              |
-| `useActorSuspenseInfiniteQuery` | Suspense infinite queries                      |
-| `useActorMutation`              | State-changing operations                      |
-
-### Auth Hooks (from `createAuthHooks`)
-
-| Hook               | Description                         |
-| ------------------ | ----------------------------------- |
-| `useAuth`          | Login, logout, authentication state |
-| `useAgentState`    | Agent initialization state          |
-| `useUserPrincipal` | Current user's Principal            |
-
-## Query Examples
-
-### Standard Query
-
-```tsx
-const { data, isPending, error } = useActorQuery({
-  functionName: "get_user",
-  args: ["user-123"],
-  staleTime: 5 * 60 * 1000, // 5 minutes
-})
-```
-
-### Suspense Query
-
-```tsx
-// Parent must have <Suspense> boundary
-function UserProfile() {
-  // data is never undefined with suspense!
-  const { data } = useActorSuspenseQuery({
-    functionName: "get_user",
-    args: ["user-123"],
-  })
-
-  return <div>{data.name}</div>
-}
-```
-
-### Infinite Query
-
-```tsx
-const { data, fetchNextPage, hasNextPage } = useActorInfiniteQuery({
-  functionName: "get_posts",
-  initialPageParam: 0,
-  getNextPageParam: (lastPage, pages) => pages.length * 10,
-  args: (pageParam) => [{ offset: pageParam, limit: 10 }],
-})
-```
-
-`createInfiniteQuery(...)` and `createInfiniteQueryFactory(...)` support standard
-TanStack Query infinite-query options at the create level, including
-`refetchInterval`, `refetchOnMount`, `refetchOnWindowFocus`, `retry`, and `gcTime`.
-
-## Mutation Examples
-
-### Basic Mutation
-
-```tsx
-const { mutate, isPending, error } = useActorMutation({
+export const updateProfile = createMutation(backend, {
   functionName: "update_profile",
-  onSuccess: (result) => {
-    console.log("Profile updated!", result)
-  },
 })
-
-// Call the mutation
-mutate([{ name: "Alice", bio: "Hello IC!" }])
 ```
-
-## Query Factories
-
-Create reusable query configurations with factory functions:
-
-```typescript
-import {
-  createQuery,
-  createSuspenseQuery,
-  createMutation,
-} from "@ic-reactor/react"
-
-// Static query (no args at call time)
-export const tokenNameQuery = createSuspenseQuery(backend, {
-  functionName: "icrc1_name",
-})
-
-// In component:
-const { data } = tokenNameQuery.useSuspenseQuery()
-```
-
-### Factory with Dynamic Args
-
-```typescript
-import { createSuspenseQueryFactory } from "@ic-reactor/react"
-
-// Factory for balance queries
-export const getBalance = createSuspenseQueryFactory(backend, {
-  functionName: "icrc1_balance_of",
-  select: (balance) => `${balance} tokens`,
-})
-
-// In component - create the query instance with args at call time
-const balanceQuery = getBalance([{ owner: userPrincipal, subaccount: [] }])
-const { data } = balanceQuery.useSuspenseQuery()
-```
-
-### Infinite Query Factory (Route/Search Params Safe)
-
-Use `getKeyArgs` in the factory config to derive a stable logical identity from
-the first-page args, and keep pagination cursors inside `getArgs(pageParam)`.
-This prevents cache collisions when loaders rerun with different search params.
 
 ```tsx
-import { createInfiniteQueryFactory } from "@ic-reactor/react"
+const profileQuery = getProfile(["alice"])
+const { data } = profileQuery.useSuspenseQuery()
 
-type TodoSearch = {
-  filter: "all" | "active" | "completed"
-  q: string
-  sort: "newest" | "oldest"
-}
-
-export const makeTodoListQuery = createInfiniteQueryFactory(todoReactor, {
-  functionName: "list_todos",
-  initialPageParam: 0,
-  getKeyArgs: (args) => {
-    const [request] = args
-    return [
-      {
-        filter: request.filter,
-        q: request.q,
-        sort: request.sort,
-      },
-    ]
-  },
-  getNextPageParam: (lastPage) => lastPage.nextCursor,
-})
-
-// TanStack Router loader/search-param flow
-export async function loader({ context, deps }: any) {
-  const search = deps.search as TodoSearch
-
-  const todosQuery = makeTodoListQuery((cursor) => [
-    {
-      cursor,
-      limit: 20,
-      filter: search.filter,
-      q: search.q,
-      sort: search.sort,
-    },
-  ])
-
-  await todosQuery.fetch()
-  return { queryKey: todosQuery.getQueryKey() }
-}
-
-function TodosPage({ search }: { search: TodoSearch }) {
-  const todosQuery = makeTodoListQuery((cursor) => [
-    {
-      cursor,
-      limit: 20,
-      filter: search.filter,
-      q: search.q,
-      sort: search.sort,
-    },
-  ])
-
-  const { data, fetchNextPage, hasNextPage } = todosQuery.useInfiniteQuery()
-  return null
-}
-```
-
-## Advanced: Direct Reactor Usage
-
-Access reactor methods directly for manual cache management:
-
-```typescript
-// Fetch and cache
-await backend.fetchQuery({
-  functionName: "get_user",
-  args: ["user-123"],
-})
-
-// Get cached data (no fetch)
-const cached = backend.getQueryData({
-  functionName: "get_user",
-  args: ["user-123"],
-})
-
-// Invalidate cache to trigger refetch
-backend.invalidateQueries({
-  functionName: "get_user",
-})
-
-// Direct call without caching
-const result = await backend.callMethod({
-  functionName: "update_user",
-  args: [{ name: "Alice" }],
+const mutation = updateProfile.useMutation({
+  invalidateQueries: [profileQuery.getQueryKey()],
 })
 ```
 
 ## Re-exports
 
-`@ic-reactor/react` re-exports everything from `@ic-reactor/core`, so you typically only need one import:
+`@ic-reactor/react` re-exports the core runtime, so you can import these from a
+single package:
 
-```typescript
-// Everything from one package
-import {
-  ClientManager,
-  Reactor,
-  DisplayReactor,
-  createActorHooks,
-  createAuthHooks,
-  createQuery,
-  CanisterError,
-} from "@ic-reactor/react"
-```
+- `ClientManager`
+- `Reactor`
+- `DisplayReactor`
+- `CallError`
+- `CanisterError`
+- `ValidationError`
 
-## Documentation
+## See Also
 
-For comprehensive guides and API reference, visit the [documentation site](https://ic-reactor.b3pay.net/v3).
-
-## License
-
-MIT © [Behrad Deylami](https://github.com/b3hr4d)
+- Docs: https://ic-reactor.b3pay.net/v3/packages/react
+- `@ic-reactor/core`: ../core/README.md
+- `@ic-reactor/vite-plugin`: ../vite-plugin/README.md
+- `@ic-reactor/cli`: ../cli/README.md

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -1,40 +1,19 @@
 # @ic-reactor/vite-plugin
 
-<div align="center">
-  <strong>Zero-config Vite plugin for auto-generating IC reactor hooks from Candid files.</strong>
-  <br><br>
-  
-  [![npm version](https://img.shields.io/npm/v/@ic-reactor/vite-plugin.svg)](https://www.npmjs.com/package/@ic-reactor/vite-plugin)
-  [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-  [![TypeScript](https://img.shields.io/badge/TypeScript-5.0+-blue.svg)](https://www.typescriptlang.org/)
-</div>
+Vite plugin for IC Reactor code generation. It runs the shared
+`@ic-reactor/codegen` pipeline, watches `.did` files, and can inject the
+`ic_env` cookie used by `ClientManager` during local development.
 
----
-
-Automatically generate type-safe React hooks for your Internet Computer canisters. This plugin watches your `.did` files and generates ready-to-use hooks with full TypeScript support using the shared `@ic-reactor/codegen` pipeline.
-
-## Features
-
-- ⚡ **Zero Config** — Point to your `.did` file and get hooks instantly
-- 🔄 **Hot Reload** — Automatically regenerates hooks and types when `.did` files change
-- 📦 **TypeScript Declarations** — Full built-in type safety
-- 🌍 **Auto Environment** — Automatically detects local replica and injects `ic_env` cookie
-
-## Installation
+## Install
 
 ```bash
-# With pnpm
 pnpm add -D @ic-reactor/vite-plugin
-
-# Required peer dependencies
 pnpm add @ic-reactor/react @tanstack/react-query @icp-sdk/core
 ```
 
 ## Quick Start
 
-### 1. Configure the Plugin
-
-```typescript
+```ts
 // vite.config.ts
 import { defineConfig } from "vite"
 import react from "@vitejs/plugin-react"
@@ -44,22 +23,13 @@ export default defineConfig({
   plugins: [
     react(),
     icReactor({
-      canisters: [
-        {
-          name: "backend",
-          didFile: "./backend/backend.did",
-        },
-      ],
+      canisters: [{ name: "backend", didFile: "./backend/backend.did" }],
     }),
   ],
 })
 ```
 
-### 2. Create Your ClientManager
-
-The plugin looks for a client manager to import. By default, it expects it at `../../clients` relative to the generated files.
-
-```typescript
+```ts
 // src/clients.ts
 import { ClientManager } from "@ic-reactor/react"
 import { QueryClient } from "@tanstack/react-query"
@@ -67,75 +37,72 @@ import { QueryClient } from "@tanstack/react-query"
 export const queryClient = new QueryClient()
 export const clientManager = new ClientManager({
   queryClient,
-  withCanisterEnv: true, // Important for cookie injection support
+  withCanisterEnv: true,
 })
 ```
 
-### 3. Use Generated Hooks
+The plugin generates files under `src/declarations/<canister>/` by default.
 
-The plugin generates headers in `src/declarations/<name>/index.ts` by default.
-
-```tsx
-import { useBackendQuery } from "./declarations/backend"
-
-function MyComponent() {
-  const { data, isPending } = useBackendQuery({
-    functionName: "get_message",
-  })
-
-  return <p>{isPending ? "Loading..." : data}</p>
-}
-```
-
-### Reactor Mode (per canister)
-
-By default, generated hooks use `DisplayReactor` (backward compatible). Set `mode` on a canister to choose the generated reactor class (`Reactor`, `DisplayReactor`, `CandidReactor`, `CandidDisplayReactor`, or `MetadataDisplayReactor`).
+## Options
 
 ```ts
 icReactor({
   canisters: [
-    { name: "backend", didFile: "./backend/backend.did" },
     {
-      name: "workflow_engine",
-      mode: "Reactor",
-      didFile: "./workflow/workflow_engine.did",
+      name: "backend",
+      didFile: "./backend/backend.did",
+      mode: "DisplayReactor",
     },
   ],
+  outDir: "src/declarations",
+  clientManagerPath: "../../clients",
+  injectEnvironment: true,
 })
 ```
 
-## Configuration
+### Per-canister options
 
-### Plugin Options
+- `name`
+- `didFile`
+- `outDir`
+- `clientManagerPath`
+- `mode`
+- `canisterId`
 
-| Option              | Type               | Description                                         | Default              |
-| :------------------ | :----------------- | :-------------------------------------------------- | :------------------- |
-| `canisters`         | `CanisterConfig[]` | List of canisters to generate hooks for (required). | -                    |
-| `outDir`            | `string`           | Base output directory for generated files.          | `"src/declarations"` |
-| `clientManagerPath` | `string`           | Path to client manager import.                      | `"../../clients"`    |
-| `injectEnvironment` | `boolean`          | Inject `ic_env` cookie for local development.       | `true`               |
+Supported `mode` values:
 
-### Canister Config
+- `Reactor`
+- `DisplayReactor`
+- `CandidReactor`
+- `CandidDisplayReactor`
+- `MetadataDisplayReactor`
 
-| Option              | Type                                                                                                     | Description                                     | Required |
-| :------------------ | :------------------------------------------------------------------------------------------------------- | :---------------------------------------------- | :------- |
-| `name`              | `string`                                                                                                 | Name of the canister (used for variable names). | Yes      |
-| `didFile`           | `string`                                                                                                 | Path to the `.did` file.                        | Yes      |
-| `outDir`            | `string`                                                                                                 | Override output directory for this canister.    | No       |
-| `clientManagerPath` | `string`                                                                                                 | Override client manager path.                   | No       |
-| `mode`              | `"Reactor" \| "DisplayReactor" \| "CandidReactor" \| "CandidDisplayReactor" \| "MetadataDisplayReactor"` | Reactor class for generated hooks.              | No       |
-| `canisterId`        | `string`                                                                                                 | Optional fixed canister ID.                     | No       |
+## Local Development Behavior
 
-## Local Development (Environment Injection)
+When `injectEnvironment` is enabled during `vite dev`, the plugin:
 
-When running `vite dev`, the plugin automatically handles local canister environment connection:
+1. asks `icp-cli` for the local network status
+2. resolves configured canister IDs
+3. sets the `ic_env` cookie
+4. proxies `/api` to the local replica
 
-1. Detects your local environment (using `icp` or `dfx` CLI).
-2. Sets an `ic_env` cookie containing the root key and canister IDs.
-3. Sets up a proxy for `/api` to your local replica.
+If environment detection fails, the plugin still falls back to proxying `/api`
+to `http://127.0.0.1:4943`, but it will not inject canister metadata.
 
-This means you **don't** need complex `vite.config.ts` proxy rules or manual `.env` file management for local addresses — it just works.
+## File Regeneration
 
-## License
+On startup and on `.did` file changes, the plugin regenerates declarations and
+the per-canister `index.ts` entrypoint. When a watched `.did` file changes, the
+plugin sends a full browser reload so the new declarations are picked up.
 
-MIT © [Behrad Deylami](https://github.com/b3hr4d)
+## When To Use It
+
+- Vite apps with active `.did` iteration
+- teams that want zero extra codegen commands during development
+- projects that want the same output format as the CLI without manual steps
+
+## See Also
+
+- Docs: https://ic-reactor.b3pay.net/v3/packages/vite-plugin
+- `@ic-reactor/codegen`: ../codegen/README.md
+- `@ic-reactor/cli`: ../cli/README.md


### PR DESCRIPTION
## Summary
- refresh package and example READMEs so they match the current exported APIs, codegen behavior, and run commands
- update docs pages for the query demo, Next.js example, parser package, and Vite plugin to remove stale guidance and improve accuracy
- clarify getting-started guidance around declaration generation and local development so recommended `icp-cli` flows are distinct from manual `dfx` workflows

## Testing
- pnpm --dir docs run lint:mdx
- pnpm docs:build

## Notes
- the docs build still emits the existing TypeDoc tsconfig warning for `packages/react/src/index.ts`
- the docs build still emits the existing generated `libs/*` duplicate-id warnings during API docs generation