### PR TITLE
feat(cli): add bindgen-only generation mode

### DIFF
--- a/docs/src/content/docs/packages/cli.mdx
+++ b/docs/src/content/docs/packages/cli.mdx
@@ -56,6 +56,7 @@ Options:
 
 - `-c, --canister <name>`: Generate only for a specific canister.
 - `--clean`: Clean output directory before generating.
+- `--bindgen-only`: Generate only `.did`, `.did.d.ts`, and `.js` declarations.
 
 For each canister, the CLI writes:
 
@@ -68,6 +69,10 @@ For each canister, the CLI writes:
 The CLI regenerates `index.generated.ts` on every run. It creates `index.ts`
 once, then preserves it unless the file is still the default wrapper or an
 older generated scaffold that can be migrated automatically.
+
+Use `--bindgen-only` when you only want the generated declaration files. In
+that mode, the CLI skips `index.generated.ts` and `index.ts` entirely and
+leaves any existing reactor files untouched.
 
 ## Configuration
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -67,6 +67,7 @@ pnpm exec ic-reactor generate [options]
 Options:
   -c, --canister <name>  Generate only one configured canister
   --clean                Clean the output directory before generation
+  --bindgen-only         Generate only .did, .did.d.ts, and .js declarations
 ```
 
 ## Generated Output
@@ -82,6 +83,10 @@ For each canister, the CLI generates:
 The CLI regenerates `index.generated.ts` on every run. It creates `index.ts`
 once, then preserves it unless the file is still the default wrapper or an
 older generated scaffold that can be migrated automatically.
+
+Use `--bindgen-only` when you only want the generated declaration files. In
+that mode, the CLI skips `index.generated.ts` and `index.ts` entirely and
+leaves any existing reactor files untouched.
 
 ## When To Use The CLI
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -12,7 +12,9 @@ import type { GenerateOptions } from "../types.js"
 
 export async function generateCommand(options: GenerateOptions) {
   console.log()
-  p.intro(pc.cyan("🔄 Generate Hooks"))
+  const generationLabel = options.bindgenOnly ? "Bindgen" : "Hooks"
+  const generationSummary = options.bindgenOnly ? "bindgen files" : "hooks"
+  p.intro(pc.cyan(`🔄 Generate ${generationLabel}`))
 
   // Load config
   const configPath = findConfigFile()
@@ -54,7 +56,7 @@ export async function generateCommand(options: GenerateOptions) {
 
   const spinner = p.spinner()
   spinner.start(
-    `Generating hooks for ${canistersToProcess.length} canisters...`
+    `Generating ${generationSummary} for ${canistersToProcess.length} canisters...`
   )
 
   let successCount = 0
@@ -72,6 +74,7 @@ export async function generateCommand(options: GenerateOptions) {
         canisterConfig,
         projectRoot,
         globalConfig: config,
+        generateReactor: !options.bindgenOnly,
       })
 
       if (result.success) {
@@ -88,7 +91,7 @@ export async function generateCommand(options: GenerateOptions) {
     }
   }
 
-  spinner.stop("Generation complete")
+  spinner.stop(`${generationLabel} generation complete`)
 
   if (errorMessages.length > 0) {
     console.log()
@@ -106,9 +109,9 @@ export async function generateCommand(options: GenerateOptions) {
   )
 
   if (errorCount > 0) {
-    p.outro(pc.red("✖ Generation failed with errors."))
+    p.outro(pc.red(`✖ ${generationLabel} generation failed with errors.`))
     process.exit(1)
   } else {
-    p.outro(pc.green("✓ All hooks generated successfully!"))
+    p.outro(pc.green(`✓ All ${generationSummary} generated successfully!`))
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,9 +28,13 @@ program
 program
   .command("generate")
   .alias("g")
-  .description("Generate hooks from .did files")
+  .description("Generate canister declarations and hooks from .did files")
   .option("-c, --canister <name>", "Generate for a specific canister only")
   .option("--clean", "Clean output directory before generating")
+  .option(
+    "--bindgen-only",
+    "Generate only .did, .did.d.ts, and .js declarations"
+  )
   .action(generateCommand)
 
 program.parse()

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -24,4 +24,5 @@ export interface InitOptions {
 export interface GenerateOptions {
   canister?: string
   clean?: boolean
+  bindgenOnly?: boolean
 }

--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -25,6 +25,7 @@ await runCanisterPipeline({
     outDir: "src/declarations",
     clientManagerPath: "../../clients",
   },
+  generateReactor: true,
 })
 ```
 
@@ -39,6 +40,9 @@ Set `canisterConfig.mode` to choose the generated reactor class:
 - `MetadataDisplayReactor`
 
 Codegen now writes two files per canister: a managed `index.generated.ts` implementation that is regenerated on every run, and an `index.ts` entry wrapper. The wrapper is created once, then preserved unless it still matches the default generated wrapper or an older generated scaffold that can be migrated automatically.
+
+Set `generateReactor: false` if you only want the bindgen/declaration output and
+need to skip `index.generated.ts` and `index.ts`.
 
 ## Generators
 

--- a/packages/codegen/src/pipeline.test.ts
+++ b/packages/codegen/src/pipeline.test.ts
@@ -95,6 +95,102 @@ describe("Codegen pipeline", () => {
     expect(generated).toContain('name: "workflow"')
   })
 
+  it("can generate declarations without creating reactor files", async () => {
+    const projectRoot = createTempProject()
+    writeDid(projectRoot, "backend.did")
+
+    const result = await runCanisterPipeline({
+      canisterConfig: {
+        name: "backend",
+        didFile: "backend.did",
+      },
+      projectRoot,
+      globalConfig: {
+        outDir: "src/declarations",
+        clientManagerPath: "../../clients",
+      },
+      generateReactor: false,
+    })
+
+    expect(result.success).toBe(true)
+    expect(
+      fs.existsSync(
+        path.join(
+          projectRoot,
+          "src/declarations/backend/declarations/backend.js"
+        )
+      )
+    ).toBe(true)
+    expect(
+      fs.existsSync(
+        path.join(
+          projectRoot,
+          "src/declarations/backend/declarations/backend.d.ts"
+        )
+      )
+    ).toBe(true)
+    expect(
+      fs.existsSync(
+        path.join(
+          projectRoot,
+          "src/declarations/backend/declarations/backend.did"
+        )
+      )
+    ).toBe(true)
+    expect(
+      fs.existsSync(
+        path.join(projectRoot, "src/declarations/backend/index.generated.ts")
+      )
+    ).toBe(false)
+    expect(
+      fs.existsSync(path.join(projectRoot, "src/declarations/backend/index.ts"))
+    ).toBe(false)
+    expect(
+      result.files.some((file) => file.filePath.endsWith("index.generated.ts"))
+    ).toBe(false)
+    expect(
+      result.files.some((file) => file.filePath.endsWith("index.ts"))
+    ).toBe(false)
+  })
+
+  it("leaves existing reactor files untouched when reactor generation is disabled", async () => {
+    const projectRoot = createTempProject()
+    writeDid(projectRoot, "backend.did")
+
+    const canisterOutDir = path.join(projectRoot, "src/declarations/backend")
+    fs.mkdirSync(canisterOutDir, { recursive: true })
+
+    const existingGenerated = "// existing generated reactor"
+    const existingEntry = "// existing entry wrapper"
+
+    fs.writeFileSync(
+      path.join(canisterOutDir, "index.generated.ts"),
+      existingGenerated
+    )
+    fs.writeFileSync(path.join(canisterOutDir, "index.ts"), existingEntry)
+
+    const result = await runCanisterPipeline({
+      canisterConfig: {
+        name: "backend",
+        didFile: "backend.did",
+      },
+      projectRoot,
+      globalConfig: {
+        outDir: "src/declarations",
+        clientManagerPath: "../../clients",
+      },
+      generateReactor: false,
+    })
+
+    expect(result.success).toBe(true)
+    expect(
+      fs.readFileSync(path.join(canisterOutDir, "index.generated.ts"), "utf-8")
+    ).toBe(existingGenerated)
+    expect(
+      fs.readFileSync(path.join(canisterOutDir, "index.ts"), "utf-8")
+    ).toBe(existingEntry)
+  })
+
   it("does not overwrite user-modified index.ts on regenerate", async () => {
     const projectRoot = createTempProject()
     writeDid(projectRoot, "backend.did")

--- a/packages/codegen/src/pipeline.ts
+++ b/packages/codegen/src/pipeline.ts
@@ -7,8 +7,8 @@
  * Pipeline steps (in order):
  *  1. Resolve paths (didFile, outDir)
  *  2. Generate declarations (JS + .d.ts + .did copy)
- *  3. Generate reactor implementation (`index.generated.ts`)
- *  4. Create or migrate the user entry (`index.ts`)
+ *  3. Optionally generate reactor implementation (`index.generated.ts`)
+ *  4. Optionally create or migrate the user entry (`index.ts`)
  */
 
 import fs from "node:fs"
@@ -37,6 +37,11 @@ export interface PipelineOptions {
    * Global codegen config (for fallback outDir and clientManagerPath).
    */
   globalConfig: Pick<CodegenConfig, "outDir" | "clientManagerPath">
+  /**
+   * Whether the managed reactor files should be generated.
+   * Defaults to true.
+   */
+  generateReactor?: boolean
 }
 
 function resolveReactorClass(canisterConfig: CanisterConfig): ReactorClassName {
@@ -79,7 +84,12 @@ export interface PipelineResult {
 export async function runCanisterPipeline(
   options: PipelineOptions
 ): Promise<PipelineResult> {
-  const { canisterConfig, projectRoot, globalConfig } = options
+  const {
+    canisterConfig,
+    projectRoot,
+    globalConfig,
+    generateReactor = true,
+  } = options
   const { name, didFile, clientManagerPath } = canisterConfig
 
   const files: GeneratorResult[] = []
@@ -136,6 +146,14 @@ export async function runCanisterPipeline(
       success: false,
       files,
       error: `Declarations step failed: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+
+  if (!generateReactor) {
+    return {
+      canisterName: name,
+      success: true,
+      files,
     }
   }
 


### PR DESCRIPTION
## Summary
- add a CLI-only --bindgen-only mode that generates declarations without writing reactor entry files
- add pipeline coverage to verify declarations-only runs skip reactor generation and leave existing reactor files untouched
- update the CLI and codegen docs for the new mode

## Verification
- pnpm --filter @ic-reactor/codegen test
- pnpm --filter @ic-reactor/codegen build
- pnpm --filter @ic-reactor/cli build
- pnpm --dir docs lint:mdx
- pnpm --dir docs build