### PR TITLE
fix: upgrade node-version to 22 in CI and docs to support Astro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - name: Install dependencies
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - name: Install dependencies
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: MDX lint

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - name: Install Rust

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - name: Install dependencies

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "type": "module",
   "version": "0.0.1",
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "scripts": {
     "dev": "astro dev",
     "build": "typedoc --options ./typedoc.json && node scripts/split-index.js && astro build",


### PR DESCRIPTION
This pull request updates the Node.js version used across all CI workflows and documents the minimum required Node.js version for the documentation site. These changes ensure consistency and compatibility with the latest Node.js features and security updates.

**CI/CD Workflow Updates:**

* Updated Node.js version from 20 to 22 in all GitHub Actions workflow files, including `.github/workflows/ci.yml`, `.github/workflows/docs.yml`, `.github/workflows/docs-check.yml`, `.github/workflows/e2e.yml`, and `.github/workflows/size-check.yml`. This ensures all automated checks and builds run on Node.js 22. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL29-R29) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL59-R59) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL86-R86) [[4]](diffhunk://#diff-e46c1ec033b20788f5b3e9f3943ebfe3ab884ef46c3538f9f7c27414b7ad366bL23-R23) [[5]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL37-R37) [[6]](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eL30-R30) [[7]](diffhunk://#diff-0b8b0d77e678a9396abc70162c1a73e59c4766d13fb75d679c0f3f15b9c3a40cL26-R26)

**Documentation Site Configuration:**

* Added an `engines` field to `docs/package.json` specifying a minimum required Node.js version of `>=22.12.0` for local development and deployment of the documentation site.