### PR TITLE
fix(tsconfig): remove deprecated baseUrl from example tsconfigs

### DIFF
--- a/examples/all-in-one-demo/tsconfig.json
+++ b/examples/all-in-one-demo/tsconfig.json
@@ -20,7 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/examples/nextjs/tsconfig.json
+++ b/examples/nextjs/tsconfig.json
@@ -13,7 +13,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
       "@dfinity/*": [
         "./node_modules/@icp-sdk/core/lib/esm/*/dist/index.d.ts",

--- a/examples/tanstack-router/tsconfig.json
+++ b/examples/tanstack-router/tsconfig.json
@@ -20,7 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@ic-reactor/core": ["../../packages/core/src/index.ts"],


### PR DESCRIPTION
## Summary
- remove deprecated `baseUrl` from example TypeScript configs
- keep existing `paths` mappings unchanged
- resolve TS deprecation diagnostics related to `baseUrl`

## Files changed
- `examples/all-in-one-demo/tsconfig.json`
- `examples/tanstack-router/tsconfig.json`
- `examples/nextjs/tsconfig.json`

## Validation
- verified each updated `tsconfig.json` has no diagnostics after the change
- confirmed no remaining `baseUrl` entries in `tsconfig*.json` files