### PR TITLE
ci: cache pnpm store with corepack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,18 @@ jobs:
           corepack prepare pnpm@10.30.3 --activate
           pnpm --version
 
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -59,6 +71,18 @@ jobs:
           corepack prepare pnpm@10.30.3 --activate
           pnpm --version
 
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -85,6 +109,18 @@ jobs:
           corepack enable
           corepack prepare pnpm@10.30.3 --activate
           pnpm --version
+
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -22,6 +22,16 @@ jobs:
           corepack enable
           corepack prepare pnpm@10.30.3 --activate
           pnpm --version
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: MDX lint

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,18 @@ jobs:
           corepack prepare pnpm@10.30.3 --activate
           pnpm --version
 
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,18 @@ jobs:
           corepack prepare pnpm@10.30.3 --activate
           pnpm --version
 
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release-tools.yml
+++ b/.github/workflows/release-tools.yml
@@ -41,6 +41,18 @@ jobs:
           corepack prepare pnpm@10.30.3 --activate
           pnpm --version
 
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Upgrade npm to v11 (required for OIDC)
         run: npm i -g npm@^11.5.1 && npm --version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,18 @@ jobs:
           corepack prepare pnpm@10.30.3 --activate
           pnpm --version
 
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Upgrade npm to v11 (required for OIDC)
         run: npm i -g npm@^11.5.1 && npm --version
 

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -26,6 +26,18 @@ jobs:
           corepack prepare pnpm@10.30.3 --activate
           pnpm --version
 
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- add explicit pnpm store caching back to GitHub Actions
- keep the Corepack-based pnpm setup that fixed the earlier CI failures
- avoid reintroducing `actions/setup-node` pnpm cache integration

## Details
- activate pnpm with Corepack first
- resolve the pnpm store path dynamically via `pnpm store path`
- cache the pnpm store with `actions/cache@v5`
- key the cache by runner OS and `pnpm-lock.yaml`

## Why
The previous `setup-node` pnpm cache integration conflicted with the new Corepack-based setup. This restores install performance without coupling cache restore to `setup-node`.
