### PR TITLE
[codex] fix fixed-width display number encoding

### DIFF
--- a/packages/candid/tests/unit/metadata-display-reactor.test.ts
+++ b/packages/candid/tests/unit/metadata-display-reactor.test.ts
@@ -999,6 +999,33 @@ describe("MetadataDisplayReactor", () => {
   })
 })
 
+describe("MetadataDisplayReactor display argument encoding", () => {
+  it("should encode form-style opt nat32 strings before IDL encoding", async () => {
+    const reactor = new MetadataDisplayReactor({
+      name: "metadata-display-nat32-test",
+      canisterId: "aaaaa-aa",
+      clientManager: createMockClientManager(),
+      candid: `
+        service : {
+          set_confirmations : (record { min_confirmations : opt nat32 }) -> ();
+        }
+      `,
+    })
+
+    await reactor.initialize()
+
+    const methodName = "set_confirmations"
+    const transformedArgs = (reactor as any).transformArgs(methodName, [
+      { min_confirmations: "1" },
+    ])
+
+    expect(transformedArgs).toEqual([{ min_confirmations: [1] }])
+
+    const func = (reactor as any).getFuncClass(methodName) as IDL.FuncClass
+    expect(() => IDL.encode(func.argTypes, transformedArgs)).not.toThrow()
+  })
+})
+
 describe("MetadataDisplayReactor E2E", () => {
   let reactor: MetadataDisplayReactor<TestActor>
   let clientManager: ClientManager

--- a/packages/core/src/display/visitor.ts
+++ b/packages/core/src/display/visitor.ts
@@ -9,6 +9,46 @@ import {
   isNullish,
 } from "../utils"
 
+function createFixedNumberCodec(bits: number, signed: boolean): z.ZodTypeAny {
+  const min = signed ? -(2 ** (bits - 1)) : 0
+  const max = signed ? 2 ** (bits - 1) - 1 : 2 ** bits - 1
+  const integerPattern = signed ? /^-?\d+$/ : /^\d+$/
+  const typeName = `${signed ? "int" : "nat"}${bits}`
+
+  const parseDisplayNumber = (val: string | number): number => {
+    const num = typeof val === "string" ? Number(val) : val
+
+    if (typeof val === "string" && !integerPattern.test(val)) {
+      throw new TypeError(
+        `[ic-reactor] Invalid ${typeName} display value: expected an integer string, got "${val}"`
+      )
+    }
+
+    if (!Number.isInteger(num)) {
+      throw new TypeError(
+        `[ic-reactor] Invalid ${typeName} display value: expected an integer, got ${String(val)}`
+      )
+    }
+
+    if (num < min || num > max) {
+      throw new RangeError(
+        `[ic-reactor] Invalid ${typeName} display value: expected ${min}..${max}, got ${String(val)}`
+      )
+    }
+
+    return num
+  }
+
+  return z.codec(
+    z.number().int().min(min).max(max), // Candid format
+    z.union([z.number(), z.string()]), // Display format
+    {
+      decode: (val) => val,
+      encode: parseDisplayNumber,
+    }
+  )
+}
+
 export class DisplayCodecVisitor extends IDL.Visitor<unknown, z.ZodTypeAny> {
   private _recCache = new Map<IDL.RecClass, z.ZodTypeAny>()
 
@@ -74,8 +114,9 @@ export class DisplayCodecVisitor extends IDL.Visitor<unknown, z.ZodTypeAny> {
     const bits = t._bits
 
     if (bits <= 32) {
-      // 32-bit integers stay as numbers
-      return z.number()
+      // 32-bit integers stay as numbers for display, but form inputs may
+      // submit numeric strings that must be converted before IDL.encode.
+      return createFixedNumberCodec(bits, true)
     } else {
       // 64-bit integers: bigint ↔ string
       return z.codec(
@@ -93,7 +134,7 @@ export class DisplayCodecVisitor extends IDL.Visitor<unknown, z.ZodTypeAny> {
     const bits = t._bits
 
     if (bits <= 32) {
-      return z.number()
+      return createFixedNumberCodec(bits, false)
     } else {
       return z.codec(
         z.bigint(), // Candid format

--- a/packages/core/tests/codec/display-codec.test.ts
+++ b/packages/core/tests/codec/display-codec.test.ts
@@ -69,6 +69,49 @@ describe("Zod Codec - didToDisplayCodec", () => {
       expect(codec.asCandid(42)).toBe(42)
     })
 
+    it("should convert IDL.Nat32 display strings to numbers", () => {
+      const codec = didToDisplayCodec(IDL.Nat32)
+
+      expect(codec.asDisplay(1)).toBe(1)
+      expect(codec.asCandid("1" as any)).toBe(1)
+    })
+
+    it("should convert optional IDL.Nat32 display strings to optional numbers", () => {
+      const codec = didToDisplayCodec(IDL.Opt(IDL.Nat32))
+
+      expect(codec.asCandid("1" as any)).toEqual([1])
+    })
+
+    it("should convert record opt IDL.Nat32 display strings to optional numbers", () => {
+      const codec = didToDisplayCodec(
+        IDL.Record({
+          min_confirmations: IDL.Opt(IDL.Nat32),
+        })
+      )
+
+      expect(codec.asCandid({ min_confirmations: "1" } as any)).toEqual({
+        min_confirmations: [1],
+      })
+    })
+
+    it("should reject invalid IDL.Nat32 display strings", () => {
+      const codec = didToDisplayCodec(IDL.Nat32)
+
+      expect(() => codec.asCandid("-1" as any)).toThrow()
+      expect(() => codec.asCandid("1.5" as any)).toThrow()
+      expect(() => codec.asCandid("abc" as any)).toThrow()
+      expect(() => codec.asCandid("4294967296" as any)).toThrow()
+    })
+
+    it("should accept valid IDL.Int32 display strings and reject invalid values", () => {
+      const codec = didToDisplayCodec(IDL.Int32)
+
+      expect(codec.asCandid("-1" as any)).toBe(-1)
+      expect(() => codec.asCandid("1.5" as any)).toThrow()
+      expect(() => codec.asCandid("2147483648" as any)).toThrow()
+      expect(() => codec.asCandid("-2147483649" as any)).toThrow()
+    })
+
     it("should handle IDL.Float64", () => {
       const codec = didToDisplayCodec(IDL.Float64)
 


### PR DESCRIPTION
## Summary

Fixes display argument encoding for fixed-width numeric Candid types in `@ic-reactor/core` and the `@ic-reactor/candid` metadata display flow.

HTML form inputs provide numeric values as strings. The display codec already converted unbounded `nat`/`int` and 64-bit fixed integers correctly, but `nat8`/`nat16`/`nat32` and `int8`/`int16`/`int32` returned a plain `z.number()` codec. That meant a form value like `{ min_confirmations: "1" }` for `opt nat32` stayed as `["1"]` after display transformation and failed later in `IDL.encode`.

This changes fixed-width integer codecs for <=32-bit types to:

- keep decoded display values as numbers for existing API behavior
- accept number or numeric string display inputs during encode
- convert valid numeric strings to numbers before Candid encoding
- reject invalid integer strings, decimals, negative nat values, and out-of-range values
- preserve existing `nat`/`int` and 64-bit fixed integer string-to-`BigInt` behavior

## Tests

- `pnpm --filter @ic-reactor/core test -- tests/codec/display-codec.test.ts`
- `pnpm --filter @ic-reactor/candid test -- tests/unit/metadata-display-reactor.test.ts`