### PR TITLE
fix: bump Axios override to 1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
       "@dfinity/candid": "npm:@icp-sdk/core/candid@^5.2.0",
       "@dfinity/principal": "npm:@icp-sdk/core/principal@^5.2.0",
       "@dfinity/identity": "npm:@icp-sdk/core/identity@^5.2.0",
-      "axios": "1.15.0",
+      "axios": "1.16.0",
       "devalue": "5.6.4",
       "h3": "1.15.9",
       "picomatch": "4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@dfinity/candid': npm:@icp-sdk/core/candid@^5.2.0
   '@dfinity/principal': npm:@icp-sdk/core/principal@^5.2.0
   '@dfinity/identity': npm:@icp-sdk/core/identity@^5.2.0
-  axios: 1.15.0
+  axios: 1.16.0
   devalue: 5.6.4
   h3: 1.15.9
   picomatch: 4.0.4
@@ -2800,8 +2800,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3619,10 +3619,6 @@ packages:
 
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.3:
@@ -8612,7 +8608,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -8720,7 +8716,7 @@ snapshots:
 
   binary-install@1.1.2:
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       rimraf: 3.0.2
       tar: 7.5.13
     transitivePeerDependencies:
@@ -9127,7 +9123,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -9388,7 +9384,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       mime-types: 2.1.35
 
   formdata-polyfill@4.0.10:
@@ -9498,10 +9494,6 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
-
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
 
   hasown@2.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

- Bump the root pnpm override for `axios` from `1.15.0` to `1.16.0`
- Regenerate `pnpm-lock.yaml` so `binary-install` / `wasm-pack` resolve to `axios@1.16.0`

## Verification

- `corepack pnpm audit --prod --audit-level moderate`
- `corepack pnpm why axios --recursive`
- `corepack pnpm list axios --recursive --depth 20`
- `corepack pnpm format:check`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm --filter @ic-reactor/core test`

audit result: no known vulnerabilities found; dependency tree shows only `axios@1.16.0`.