### PR TITLE
fix(react): repair Internet Identity flows and support @icp-sdk/auth v8

### DIFF
--- a/examples/identity-attributes-demo/src/App.tsx
+++ b/examples/identity-attributes-demo/src/App.tsx
@@ -48,7 +48,7 @@ const productionSteps = [
   },
   {
     title: "2. Frontend requests attributes",
-    body: "Pass that backend-issued nonce to useIdentityAttributes(). Never create the production nonce in browser state.",
+    body: "Pass that backend-issued nonce to useIdentityAttributes() as a callback, so the Internet Identity window opens inside the click before the nonce resolves. Never create the production nonce in browser state.",
   },
   {
     title: "3. Backend verifies payload",
@@ -61,12 +61,17 @@ const productionSteps = [
 ]
 
 const productionSnippet = `async function registerWithAttributes() {
-  const { nonce } = await api.registerBegin({
-    expectedKeys: ["email", "name"],
-  })
-
+  // Pass the nonce as a callback, not an awaited value: awaiting the backend
+  // first would end the click's user gesture and the browser would block the
+  // Internet Identity window. The callback lets the window open immediately
+  // while the nonce is still being fetched.
   const result = await requestOpenIdAttributes({
-    nonce,
+    nonce: async () => {
+      const { nonce } = await api.registerBegin({
+        expectedKeys: ["email", "name"],
+      })
+      return nonce
+    },
     openIdProvider: "google",
     keys: ["email", "name"],
   })

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -161,8 +161,14 @@ export const { useActorQuery, useAuth, useIdentityAttributes, authentication } =
 Auth options are forwarded to the underlying `@icp-sdk/auth` client:
 `identityProvider`, `derivationOrigin`, `windowOpenerFeatures`,
 `openIdProvider`, `storage`, `keyType`, `idleOptions`, `identity`, and
-`transport`. Pass `authentication` from one reactor into another to share a
-single session across canisters.
+`transport`. Only the `"google" | "apple" | "microsoft"` aliases are accepted
+for `openIdProvider`; any other value is dropped, since raw issuer URLs are
+only meaningful on `requestOpenIdAttributes`, where they scope the keys.
+
+Pass `authentication` from one reactor into another to share a single session
+across canisters. That reactor adopts the manager's `ClientManager` so sign-in
+updates the agent it calls through, so pass either `authentication` or `auth` —
+not both.
 
 Set up manually when you need more control:
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -136,12 +136,35 @@ const mutation = updateProfile.useMutation({
 })
 ```
 
-## Identity Attributes / OpenID email and profile values
+## Internet Identity
 
-Identity attributes use a dedicated `IdentityAttributesManager`, with React
-bindings created by `createIdentityAttributeHooks`. The configured auth client
-must support the `@icp-sdk/auth` v7 constructor, sign-in, sign-out, and
-attribute-request APIs.
+`defineReactor` wires up Internet Identity for you — `useAuth`,
+`useUserPrincipal`, `useAgentState` and `useIdentityAttributes` come back
+alongside the actor hooks:
+
+```tsx
+// src/reactor.ts
+export const { useActorQuery, useAuth, useIdentityAttributes, authentication } =
+  defineReactor<_SERVICE>({
+    name: "backend",
+    idlFactory,
+    auth: {
+      // Required when the app is served from more than one origin, so every
+      // origin resolves to the same principal.
+      derivationOrigin: "https://app.example.com",
+      // The default signs the user out and reloads after 10 minutes idle.
+      idleOptions: { disableIdle: true },
+    },
+  })
+```
+
+Auth options are forwarded to the underlying `@icp-sdk/auth` client:
+`identityProvider`, `derivationOrigin`, `windowOpenerFeatures`,
+`openIdProvider`, `storage`, `keyType`, `idleOptions`, `identity`, and
+`transport`. Pass `authentication` from one reactor into another to share a
+single session across canisters.
+
+Set up manually when you need more control:
 
 ```tsx
 // src/auth.ts
@@ -162,6 +185,35 @@ export const { useIdentityAttributes } =
   createIdentityAttributeHooks(identityAttributes)
 ```
 
+`useAuth()` calls `authentication.prepareClient()` on mount. Outside React, do
+it yourself during startup — it preloads the auth module so `login()` can open
+the identity provider window synchronously inside a click handler, which is
+what browser popup blockers require.
+
+## Identity Attributes / OpenID email and profile values
+
+Identity attributes use a dedicated `IdentityAttributesManager`, with React
+bindings created by `createIdentityAttributeHooks`. Works with `@icp-sdk/auth`
+v7 and v8; the two versions disagree on the nonce contract and IC Reactor
+normalizes whichever form you pass.
+
+**Pass the nonce as a callback.** Awaiting your backend before calling
+`requestOpenIdAttributes` ends the user gesture, and the browser then blocks
+the Internet Identity window:
+
+```tsx
+// ✅ window opens immediately, nonce resolves while the user is in II
+await requestOpenIdAttributes({
+  nonce: () => backend.registerBegin(),
+  openIdProvider: "google",
+  keys: ["email", "name"],
+})
+
+// ❌ gesture is gone by the time the window would open
+const nonce = await backend.registerBegin()
+await requestOpenIdAttributes({ nonce, openIdProvider: "google", keys })
+```
+
 ```tsx
 // src/RegisterWithOpenIdProvider.tsx
 import { useIdentityAttributes } from "./auth"
@@ -176,10 +228,8 @@ function RegisterWithOpenIdProvider() {
   } = useIdentityAttributes()
 
   async function handleProviderLogin() {
-    const nonce = await backend.registerBegin()
-
     const result = await requestOpenIdAttributes({
-      nonce,
+      nonce: () => backend.registerBegin(),
       openIdProvider: "microsoft",
       keys: ["email", "name"],
       windowOpenerFeatures: popupCenter(),

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,14 +55,14 @@
     "@ic-reactor/core": "workspace:^"
   },
   "peerDependencies": {
-    "@icp-sdk/auth": "^7.1.0",
+    "@icp-sdk/auth": "^7.1.0 || ^8.0.0",
     "@icp-sdk/core": "^6.0.0",
     "@tanstack/react-query": "^5.0.0",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   },
   "devDependencies": {
-    "@icp-sdk/auth": "^7.1.0",
+    "@icp-sdk/auth": "^8.0.0",
     "@icp-sdk/core": "^6.0.0",
     "@size-limit/preset-small-lib": "^12.1.0",
     "@tanstack/react-query": "^5.101.2",

--- a/packages/react/src/auth/authentication-manager.ts
+++ b/packages/react/src/auth/authentication-manager.ts
@@ -15,10 +15,14 @@ import {
   localInternetIdentityProvider,
 } from "./constants"
 
-export interface AuthenticationManagerParameters {
+export interface AuthenticationManagerParameters extends AuthenticationClientOptions {
   clientManager: ClientManager
+  /**
+   * Bring your own client instance. When provided, IC Reactor never constructs
+   * one and never applies the options below to it.
+   */
   authClient?: AuthClientLike
-  identityProvider?: string | URL
+  /** Canister ID of a locally deployed Internet Identity. */
   internetIdentityId?: string
 }
 
@@ -49,6 +53,7 @@ export class AuthenticationManager {
     AuthClientConstructor | undefined
   >
   private authModuleMissing = false
+  private authClientOptions?: AuthenticationClientOptions
   private authStateValue: AuthState = {
     identity: null,
     isAuthenticating: false,
@@ -57,6 +62,7 @@ export class AuthenticationManager {
   }
   private readonly identityProvider?: string | URL
   private readonly internetIdentityId?: string
+  private readonly defaultClientOptions: AuthenticationClientOptions
   public readonly clientManager: ClientManager
 
   /** The current authentication state. */
@@ -69,6 +75,7 @@ export class AuthenticationManager {
     authClient,
     identityProvider,
     internetIdentityId,
+    ...clientOptions
   }: AuthenticationManagerParameters) {
     this.clientManager = clientManager
     const canisterEnv =
@@ -82,6 +89,7 @@ export class AuthenticationManager {
       canisterEnv?.["internet_identity"] ||
       canisterEnv?.["PUBLIC_CANISTER_ID:internet_identity"] ||
       canisterEnv?.["CANISTER_ID_INTERNET_IDENTITY"]
+    this.defaultClientOptions = clientOptions
 
     if (authClient) {
       this.authClientWasProvided = true
@@ -111,23 +119,35 @@ export class AuthenticationManager {
   }
 
   /**
-   * Preloads and creates an AuthClient before a user gesture is needed.
+   * Preloads the auth module and creates an AuthClient ahead of time.
+   *
+   * Call (and await) this before wiring up a login button: it makes
+   * {@link login} and {@link IdentityAttributesManager.request} able to open
+   * the identity provider synchronously inside the click handler, which is
+   * what browser popup blockers and the ICRC-29 transport require.
    */
   public async prepareClient(options?: AuthenticationClientOptions) {
-    const clientOptions = getAuthClientOptions({
-      ...options,
-      identityProvider:
-        options?.identityProvider ?? this.getDefaultIdentityProvider(),
-    })
+    const clientOptions = this.resolveClientOptions(options)
 
-    if (
-      this.authClient &&
-      (!this.shouldRecreateClient(clientOptions) || this.authClientWasProvided)
-    ) {
+    if (this.authClient && !this.shouldRecreateClient(clientOptions)) {
       return this.authClient
     }
 
     return this.initializeClient(clientOptions)
+  }
+
+  /**
+   * Returns an AuthClient without awaiting, or `undefined` when the auth
+   * module has not been loaded yet.
+   *
+   * Callers that must stay inside a user gesture use this instead of
+   * {@link ensureClient}; awaiting anything before opening the identity
+   * provider window loses the gesture.
+   */
+  public getPreparedClient(
+    options?: AuthenticationClientOptions
+  ): AuthClientLike | undefined {
+    return this.ensurePreparedClient(this.resolveClientOptions(options))
   }
 
   public authenticate = async (): Promise<Identity | undefined> => {
@@ -157,9 +177,7 @@ export class AuthenticationManager {
       try {
         if (!this.authClient) {
           const authClient = await this.initializeClient(
-            getAuthClientOptions({
-              identityProvider: this.getDefaultIdentityProvider(),
-            })
+            this.resolveClientOptions()
           )
           if (!authClient) {
             this.updateState({ isAuthenticating: false })
@@ -168,7 +186,12 @@ export class AuthenticationManager {
         }
         const identity = await this.authClient!.getIdentity()
         const isAuthenticated = await this.authClient!.isAuthenticated()
-        this.clientManager.updateAgent(identity)
+        // Restoring an anonymous session is the common first-load case; pushing
+        // it through updateAgent would invalidate the whole query cache on
+        // every mount for nothing.
+        if (isAuthenticated || !identity.getPrincipal().isAnonymous()) {
+          this.clientManager.updateAgent(identity)
+        }
         this.updateState({
           identity,
           isAuthenticated,
@@ -191,13 +214,10 @@ export class AuthenticationManager {
     let didCompleteSignIn = false
 
     try {
-      const identityProvider =
-        loginOptions?.identityProvider || this.getDefaultIdentityProvider()
-      const authClientOptions = getAuthClientOptions({
-        ...loginOptions,
-        identityProvider,
-      })
+      const authClientOptions = this.resolveClientOptions(loginOptions)
 
+      // Stays synchronous when `prepareClient()` has already loaded the auth
+      // module, so `signIn()` still runs inside the caller's click handler.
       if (!this.ensurePreparedClient(authClientOptions)) {
         await this.initializeClient(authClientOptions)
       }
@@ -275,6 +295,7 @@ export class AuthenticationManager {
     }
 
     this.authClient = new AuthClient(options)
+    this.authClientOptions = options
     return this.authClient
   }
 
@@ -309,10 +330,7 @@ export class AuthenticationManager {
   private ensurePreparedClient(
     options?: AuthenticationClientOptions
   ): AuthClientLike | undefined {
-    if (
-      this.authClient &&
-      (!this.shouldRecreateClient(options) || this.authClientWasProvided)
-    ) {
+    if (this.authClient && !this.shouldRecreateClient(options)) {
       return this.authClient
     }
 
@@ -322,11 +340,41 @@ export class AuthenticationManager {
     }
 
     this.authClient = new AuthClient(options)
+    this.authClientOptions = options
     return this.authClient
   }
 
+  /**
+   * Only rebuild the client when the effective options actually changed.
+   *
+   * Recreating on every call would discard the client warmed up by
+   * `prepareClient()` and register a duplicate sign-out callback on the
+   * shared IdleManager singleton each time.
+   */
   private shouldRecreateClient(options?: AuthenticationClientOptions): boolean {
-    return !this.authClientWasProvided && hasAuthClientOptions(options)
+    if (this.authClientWasProvided) {
+      return false
+    }
+    return !isSameAuthClientOptions(this.authClientOptions, options)
+  }
+
+  /**
+   * Merges constructor-level defaults with per-call overrides and fills in the
+   * network-appropriate identity provider.
+   */
+  private resolveClientOptions(
+    options?: AuthenticationClientOptions
+  ): AuthenticationClientOptions {
+    const merged = getAuthClientOptions({
+      ...this.defaultClientOptions,
+      ...options,
+    })
+
+    return {
+      ...merged,
+      identityProvider:
+        merged?.identityProvider ?? this.getDefaultIdentityProvider(),
+    }
   }
 
   private async syncStateFromClient(revision = this.authStateRevision) {
@@ -350,11 +398,7 @@ export class AuthenticationManager {
 
   /** @internal Used by IdentityAttributesManager. */
   public async ensureClient(options?: AuthenticationClientOptions) {
-    const clientOptions = getAuthClientOptions({
-      ...options,
-      identityProvider:
-        options?.identityProvider ?? this.getDefaultIdentityProvider(),
-    })
+    const clientOptions = this.resolveClientOptions(options)
     if (!this.ensurePreparedClient(clientOptions)) {
       await this.initializeClient(clientOptions)
     }
@@ -452,6 +496,12 @@ function getAuthClientOptions(
     identityProvider: options.identityProvider,
     windowOpenerFeatures: options.windowOpenerFeatures,
     openIdProvider: getAuthClientOpenIdProvider(options.openIdProvider),
+    derivationOrigin: options.derivationOrigin,
+    storage: options.storage,
+    keyType: options.keyType,
+    idleOptions: options.idleOptions,
+    identity: options.identity,
+    transport: options.transport,
   }
 }
 
@@ -465,11 +515,34 @@ function getAuthClientOpenIdProvider(
     : undefined
 }
 
-function hasAuthClientOptions(options?: AuthenticationClientOptions): boolean {
-  return Boolean(
-    options?.identityProvider ||
-    options?.windowOpenerFeatures ||
-    options?.openIdProvider
+/**
+ * Compares the options two AuthClients would be built from. Object-valued
+ * options (`storage`, `identity`, `idleOptions`) are compared by reference,
+ * which is what module-scoped configuration produces.
+ */
+function isSameAuthClientOptions(
+  current?: AuthenticationClientOptions,
+  next?: AuthenticationClientOptions
+): boolean {
+  if (current === next) {
+    return true
+  }
+  if (!current || !next) {
+    return false
+  }
+
+  return (
+    String(current.identityProvider ?? "") ===
+      String(next.identityProvider ?? "") &&
+    current.windowOpenerFeatures === next.windowOpenerFeatures &&
+    current.openIdProvider === next.openIdProvider &&
+    String(current.derivationOrigin ?? "") ===
+      String(next.derivationOrigin ?? "") &&
+    current.storage === next.storage &&
+    current.keyType === next.keyType &&
+    current.idleOptions === next.idleOptions &&
+    current.identity === next.identity &&
+    current.transport === next.transport
   )
 }
 

--- a/packages/react/src/auth/identity-attributes-manager.ts
+++ b/packages/react/src/auth/identity-attributes-manager.ts
@@ -1,5 +1,6 @@
 import type {
-  AuthenticationClientOptions,
+  AuthClientLike,
+  IdentityAttributeNonce,
   IdentityAttributeResult,
   RequestIdentityAttributesParameters,
   RequestOpenIdIdentityAttributesParameters,
@@ -16,10 +17,17 @@ import {
  * Requests and decodes signed identity attributes for an authenticated
  * Internet Identity session.
  *
+ * Await `authentication.prepareClient()` once during startup (the `useAuth`
+ * hook already does) so that {@link request} can open the identity provider
+ * window synchronously from a click handler.
+ *
  * @example
  * ```ts
  * const attributes = new IdentityAttributesManager(authentication)
- * const result = await attributes.request({ keys: ["name"] })
+ * const result = await attributes.request({
+ *   keys: ["name"],
+ *   nonce: () => fetchNonceFromCanister(),
+ * })
  * ```
  */
 export class IdentityAttributesManager {
@@ -28,37 +36,40 @@ export class IdentityAttributesManager {
   public request = async ({
     keys,
     nonce,
-    identityProvider,
-    openIdProvider,
-    windowOpenerFeatures,
     signIn = true,
     maxTimeToLive,
     targets,
+    ...clientOptions
   }: RequestIdentityAttributesParameters): Promise<IdentityAttributeResult> => {
-    const authClient = await this.authentication.ensureClient(
-      getAuthClientOptions({
-        identityProvider,
-        windowOpenerFeatures,
-        openIdProvider,
-      })
-    )
+    // Nothing may be awaited before `requestAttributes` / `signIn` are invoked:
+    // the ICRC-29 transport only opens the identity provider window while the
+    // browser still considers us inside the user gesture. `getPreparedClient`
+    // is synchronous whenever `prepareClient()` has run.
+    const preparedClient = this.authentication.getPreparedClient(clientOptions)
+    const authClient =
+      preparedClient ?? (await this.authentication.ensureClient(clientOptions))
 
     if (!authClient) {
       throw new Error(
-        "Authentication module is missing or failed to initialize. To request identity attributes, please install @icp-sdk/auth v7 or provide a compatible authClient."
+        "Authentication module is missing or failed to initialize. To request identity attributes, please install @icp-sdk/auth v7 or later, or provide a compatible authClient."
       )
     }
 
     this.authentication.setAuthenticating()
 
     try {
+      // `signIn` first: it opens the transport channel synchronously, and the
+      // attribute request then reuses that same channel and window.
       const identityPromise = signIn
         ? this.authentication.signInOrRecoverIdentity({
             maxTimeToLive,
             targets,
           })
         : Promise.resolve(authClient.getIdentity())
-      const requestPromise = authClient.requestAttributes({ keys, nonce })
+      const requestPromise = authClient.requestAttributes({
+        keys,
+        nonce: toAuthClientNonce(authClient, nonce),
+      })
 
       const [signedAttributes, identity] = await Promise.all([
         requestPromise,
@@ -88,40 +99,38 @@ export class IdentityAttributesManager {
     }
   }
 
-  public requestOpenId = async ({
-    nonce,
-    openIdProvider,
+  public requestOpenId = ({
     keys,
-    identityProvider,
-    windowOpenerFeatures,
-    signIn,
-    maxTimeToLive,
-    targets,
+    openIdProvider,
+    ...rest
   }: RequestOpenIdIdentityAttributesParameters): Promise<IdentityAttributeResult> => {
+    // Called (not awaited) synchronously so the user gesture is preserved.
     return this.request({
-      keys: identityAttributeKeys({ openIdProvider, keys }),
-      nonce,
-      identityProvider,
+      ...rest,
       openIdProvider,
-      windowOpenerFeatures,
-      signIn,
-      maxTimeToLive,
-      targets,
+      keys: identityAttributeKeys({ openIdProvider, keys }),
     })
   }
 }
 
-function getAuthClientOptions(
-  options: AuthenticationClientOptions
-): AuthenticationClientOptions {
-  return {
-    identityProvider: options.identityProvider,
-    windowOpenerFeatures: options.windowOpenerFeatures,
-    openIdProvider:
-      options.openIdProvider === "google" ||
-      options.openIdProvider === "apple" ||
-      options.openIdProvider === "microsoft"
-        ? options.openIdProvider
-        : undefined,
+/**
+ * Bridges the two `@icp-sdk/auth` nonce contracts.
+ *
+ * v8 takes `() => Promise<Uint8Array>` (it journals the value so a redirect
+ * flow replays the same bytes); v7 takes `Uint8Array | Promise<Uint8Array>`.
+ * Both open the transport channel synchronously for the deferred forms, so we
+ * always hand over the deferred shape the installed client understands.
+ * `memoize` only exists from v8 onwards, which makes it a reliable marker.
+ */
+function toAuthClientNonce(
+  authClient: AuthClientLike,
+  nonce: IdentityAttributeNonce
+): Uint8Array | Promise<Uint8Array> | (() => Promise<Uint8Array>) {
+  const supportsNonceThunk = typeof authClient.memoize === "function"
+
+  if (supportsNonceThunk) {
+    return () => Promise.resolve(typeof nonce === "function" ? nonce() : nonce)
   }
+
+  return Promise.resolve(typeof nonce === "function" ? nonce() : nonce)
 }

--- a/packages/react/src/auth/types.ts
+++ b/packages/react/src/auth/types.ts
@@ -40,8 +40,8 @@ export interface IdentityAttributeResult {
 }
 
 /**
- * The providers Internet Identity supports for one-click sign-in. Only these
- * three reach the underlying auth client.
+ * The providers that Internet Identity supports for one-click sign-in. Only
+ * these three reach the underlying auth client.
  */
 type IdentityAttributeOpenIdProviderAlias = "google" | "apple" | "microsoft"
 

--- a/packages/react/src/auth/types.ts
+++ b/packages/react/src/auth/types.ts
@@ -39,8 +39,27 @@ export interface IdentityAttributeResult {
   completedAt: string
 }
 
+/**
+ * The providers Internet Identity supports for one-click sign-in. Only these
+ * three reach the underlying auth client.
+ */
 type IdentityAttributeOpenIdProviderAlias = "google" | "apple" | "microsoft"
 
+/**
+ * An OpenID provider, either as a well-known alias or as a raw issuer URL.
+ *
+ * The two forms are **not** interchangeable, and what each one does depends on
+ * where it is passed:
+ *
+ * - An alias (`"google" | "apple" | "microsoft"`) is forwarded to the auth
+ *   client, which adds an `openid` search param to the identity provider URL so
+ *   the user signs in through that provider directly.
+ * - Any other string is treated as a raw issuer URL and is **never** forwarded
+ *   to the auth client, so it never affects how the user signs in. It is only
+ *   meaningful when passed to {@link IdentityAttributesManager.requestOpenId}
+ *   (or `identityAttributeKeys`), which scopes the requested keys to
+ *   `openid:<issuer>:<key>`. Passed anywhere else it has no effect at all.
+ */
 export type IdentityAttributeOpenIdProvider =
   IdentityAttributeOpenIdProviderAlias | (string & {})
 
@@ -78,7 +97,14 @@ export interface AuthenticationClientOptions {
   identityProvider?: string | URL
   /** `window.open` features string for the identity provider popup. */
   windowOpenerFeatures?: string
-  /** OpenID provider for one-click sign-in. */
+  /**
+   * Provider for one-click sign-in.
+   *
+   * Only the `"google" | "apple" | "microsoft"` aliases reach the auth client.
+   * Any other value is dropped here and has **no effect** — raw issuer URLs are
+   * only meaningful on `requestOpenId`, where they scope the requested keys.
+   * @see {@link IdentityAttributeOpenIdProvider}
+   */
   openIdProvider?: IdentityAttributeOpenIdProvider
   /**
    * Derivation origin for the identity provider.
@@ -138,6 +164,15 @@ export interface RequestOpenIdIdentityAttributesParameters extends Omit<
   RequestIdentityAttributesParameters,
   "openIdProvider"
 > {
+  /**
+   * Provider the requested `keys` are scoped to, producing
+   * `openid:<issuer>:<key>`.
+   *
+   * Passing one of the `"google" | "apple" | "microsoft"` aliases additionally
+   * routes sign-in through that provider, so the user grants attribute access
+   * in the same step. A raw issuer URL only scopes the keys.
+   * @see {@link IdentityAttributeOpenIdProvider}
+   */
   openIdProvider: IdentityAttributeOpenIdProvider
 }
 

--- a/packages/react/src/auth/types.ts
+++ b/packages/react/src/auth/types.ts
@@ -1,4 +1,5 @@
-import type { Identity } from "@icp-sdk/core/agent"
+import type { Identity, SignIdentity } from "@icp-sdk/core/agent"
+import type { PartialIdentity } from "@icp-sdk/core/identity"
 import type { Principal } from "@icp-sdk/core/principal"
 
 export interface SignedIdentityAttributes {
@@ -6,9 +7,21 @@ export interface SignedIdentityAttributes {
   signature: Uint8Array
 }
 
+/**
+ * The 32-byte nonce issued by the relying-party canister.
+ *
+ * A function (or promise) lets the Internet Identity window open while the
+ * nonce is still being fetched, so the popup is opened inside the user gesture
+ * instead of after it. `@icp-sdk/auth` v8 requires the function form; v7
+ * accepts the promise form. IC Reactor normalizes whichever you pass to the
+ * shape the installed client expects.
+ */
+export type IdentityAttributeNonce =
+  Uint8Array | Promise<Uint8Array> | (() => Uint8Array | Promise<Uint8Array>)
+
 export interface IdentityAttributeRequest {
   keys: string[]
-  nonce: Uint8Array
+  nonce: IdentityAttributeNonce
 }
 
 export interface IdentityAttributeValues {
@@ -31,10 +44,71 @@ type IdentityAttributeOpenIdProviderAlias = "google" | "apple" | "microsoft"
 export type IdentityAttributeOpenIdProvider =
   IdentityAttributeOpenIdProviderAlias | (string & {})
 
+/** Session key algorithm used for each sign-in. */
+export type AuthClientKeyType = "ECDSA" | "Ed25519"
+
+/** Structural shape of an `@icp-sdk/auth` `AuthClientStorage`. */
+export interface AuthClientStorageLike {
+  get(key: string): Promise<string | CryptoKeyPair | null>
+  set(key: string, value: string | CryptoKeyPair): Promise<void>
+  remove(key: string): Promise<void>
+}
+
+/** Idle-session configuration forwarded to the underlying AuthClient. */
+export interface AuthClientIdleOptions {
+  /** Called once the user has been idle for `idleTimeout` ms. */
+  onIdle?: () => unknown
+  /** Idle timeout in ms. @default 600_000 (10 minutes) */
+  idleTimeout?: number
+  /** Treat scroll events as activity. @default false */
+  captureScroll?: boolean
+  /** Scroll debounce in ms. @default 100 */
+  scrollDebounce?: number
+  /** Disable idle detection entirely. @default false */
+  disableIdle?: boolean
+  /**
+   * Disable the built-in idle callback, which signs the user out and reloads
+   * the page. @default false
+   */
+  disableDefaultIdleCallback?: boolean
+}
+
 export interface AuthenticationClientOptions {
+  /** Identity provider URL. @default "https://id.ai/authorize" */
   identityProvider?: string | URL
+  /** `window.open` features string for the identity provider popup. */
   windowOpenerFeatures?: string
+  /** OpenID provider for one-click sign-in. */
   openIdProvider?: IdentityAttributeOpenIdProvider
+  /**
+   * Derivation origin for the identity provider.
+   *
+   * Required when the app is served from more than one origin (e.g. a custom
+   * domain plus `<canisterId>.icp0.io`) and every origin must resolve to the
+   * same principal.
+   * @see https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc
+   */
+  derivationOrigin?: string | URL
+  /** Persistent storage backend. @default IndexedDB */
+  storage?: AuthClientStorageLike
+  /**
+   * Session key algorithm. Use `"Ed25519"` when the storage backend cannot
+   * hold a `CryptoKey`. @default "ECDSA"
+   */
+  keyType?: AuthClientKeyType
+  /**
+   * Idle timeout configuration. Pass `{ disableIdle: true }` to opt out of the
+   * default behaviour, which signs the user out and reloads after 10 minutes.
+   */
+  idleOptions?: AuthClientIdleOptions
+  /** An existing identity to authenticate via delegation. */
+  identity?: SignIdentity | PartialIdentity
+  /**
+   * How the client talks to the identity provider. `"redirect"` requires
+   * `@icp-sdk/auth` v8 or later and is ignored by older versions.
+   * @default "window"
+   */
+  transport?: "window" | "redirect"
 }
 
 export interface AuthClientSignInOptions {
@@ -48,36 +122,43 @@ export interface AuthenticationSignInOptions
   onError?: (error?: string) => void | Promise<void>
 }
 
-export interface RequestIdentityAttributesParameters {
+export interface RequestIdentityAttributesParameters extends AuthenticationClientOptions {
   keys: string[]
-  nonce: Uint8Array
-  identityProvider?: string | URL
-  openIdProvider?: IdentityAttributeOpenIdProvider
-  windowOpenerFeatures?: string
+  nonce: IdentityAttributeNonce
+  /**
+   * Sign in as part of the same identity-provider interaction.
+   * @default true
+   */
   signIn?: boolean
   maxTimeToLive?: bigint
   targets?: Principal[]
 }
 
-export interface RequestOpenIdIdentityAttributesParameters {
-  nonce: Uint8Array
+export interface RequestOpenIdIdentityAttributesParameters extends Omit<
+  RequestIdentityAttributesParameters,
+  "openIdProvider"
+> {
   openIdProvider: IdentityAttributeOpenIdProvider
-  keys: string[]
-  identityProvider?: string | URL
-  windowOpenerFeatures?: string
-  signIn?: boolean
-  maxTimeToLive?: bigint
-  targets?: Principal[]
 }
 
+/**
+ * Structural subset of `@icp-sdk/auth`'s `AuthClient` that IC Reactor relies
+ * on. Declared locally so `@icp-sdk/auth` stays an optional peer dependency.
+ */
 export interface AuthClientLike {
   getIdentity(): Promise<Identity> | Identity
   isAuthenticated(): Promise<boolean> | boolean
   signIn(options?: AuthClientSignInOptions): Promise<Identity>
   signOut(options?: { returnTo?: string }): Promise<void>
-  requestAttributes(
-    params: IdentityAttributeRequest
-  ): Promise<SignedIdentityAttributes>
+  requestAttributes(params: {
+    keys: string[]
+    // Widened across `@icp-sdk/auth` v7 (value or promise) and v8 (thunk).
+    // Method-shorthand parameters are bivariant, so both real signatures are
+    // assignable to this one.
+    nonce: Uint8Array | Promise<Uint8Array> | (() => Promise<Uint8Array>)
+  }): Promise<SignedIdentityAttributes>
+  /** Present from `@icp-sdk/auth` v8; used to detect the nonce contract. */
+  memoize?<T>(produce: () => T | Promise<T>): Promise<T>
 }
 
 export interface AuthState {

--- a/packages/react/src/defineReactor.test.ts
+++ b/packages/react/src/defineReactor.test.ts
@@ -122,4 +122,70 @@ describe("defineReactor", () => {
 
     expect(index.authentication).toBe(ledger.authentication)
   })
+
+  it("adopts the ClientManager of a shared authentication manager", () => {
+    const ledger = defineReactor<TestActor>({ ...baseConfig, name: "ledger" })
+
+    // `authentication` without `clientManager`: the reactor must not get an
+    // agent the auth manager never updates, or sign-in would leave this
+    // reactor's calls anonymous.
+    const index = defineReactor<TestActor>({
+      ...baseConfig,
+      name: "index",
+      authentication: ledger.authentication,
+    })
+
+    expect(index.clientManager).toBe(ledger.clientManager)
+    expect(index.queryClient).toBe(ledger.queryClient)
+    expect(index.reactor.clientManager).toBe(
+      ledger.authentication.clientManager
+    )
+  })
+
+  it("reports the QueryClient the ClientManager actually uses", () => {
+    const managerQueryClient = new QueryClient()
+    const clientManager = new ClientManager({ queryClient: managerQueryClient })
+
+    // Queries run against clientManager.queryClient, so returning the stray
+    // one passed alongside it would hand back a cache nothing writes to.
+    const result = defineReactor<TestActor>({
+      ...baseConfig,
+      clientManager,
+      queryClient: new QueryClient(),
+    })
+
+    expect(result.queryClient).toBe(managerQueryClient)
+    expect(result.queryClient).toBe(result.clientManager.queryClient)
+  })
+
+  it("rejects an authentication manager bound to a different ClientManager", () => {
+    const ledger = defineReactor<TestActor>({ ...baseConfig, name: "ledger" })
+    const other = new ClientManager({ queryClient: new QueryClient() })
+
+    // Silently splitting them would make sign-in update one agent while the
+    // reactor calls through another.
+    expect(() =>
+      defineReactor<TestActor>({
+        ...baseConfig,
+        name: "index",
+        clientManager: other,
+        authentication: ledger.authentication,
+      })
+    ).toThrow(/clientManager/i)
+  })
+
+  it("rejects auth options passed alongside an existing authentication manager", () => {
+    const ledger = defineReactor<TestActor>({ ...baseConfig, name: "ledger" })
+
+    // The shared manager is already built, so `auth` could only be dropped —
+    // silently losing e.g. derivationOrigin would change the user's principal.
+    expect(() =>
+      defineReactor<TestActor>({
+        ...baseConfig,
+        name: "index",
+        authentication: ledger.authentication,
+        auth: { derivationOrigin: "https://app.example.com" },
+      })
+    ).toThrow(/derivationOrigin/)
+  })
 })

--- a/packages/react/src/defineReactor.test.ts
+++ b/packages/react/src/defineReactor.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest"
 import { ClientManager, Reactor, DisplayReactor } from "@ic-reactor/core"
 import { QueryClient } from "@tanstack/react-query"
 import { defineReactor } from "./defineReactor"
+import { AuthenticationManager } from "./auth/authentication-manager"
+import { IdentityAttributesManager } from "./auth/identity-attributes-manager"
 import { ActorMethod } from "@icp-sdk/core/agent"
 
 const idlFactory = ({ IDL }: any) =>
@@ -66,5 +68,58 @@ describe("defineReactor", () => {
 
     expect(index.clientManager).toBe(ledger.clientManager)
     expect(index.reactor).not.toBe(ledger.reactor)
+  })
+
+  it("does not construct the auth manager until auth is used", () => {
+    const result = defineReactor<TestActor>(baseConfig)
+
+    // Constructing AuthenticationManager dynamically imports the optional
+    // @icp-sdk/auth peer; reactors that never use auth must not trigger it.
+    expect(
+      Object.getOwnPropertyDescriptor(result, "authentication")?.get
+    ).toBeTypeOf("function")
+    expect(result.authentication).toBeInstanceOf(AuthenticationManager)
+    // Same instance on repeat access.
+    expect(result.authentication).toBe(result.authentication)
+  })
+
+  it("bootstraps Internet Identity alongside the actor hooks", () => {
+    const result = defineReactor<TestActor>(baseConfig)
+
+    expect(result.authentication).toBeInstanceOf(AuthenticationManager)
+    expect(result.identityAttributes).toBeInstanceOf(IdentityAttributesManager)
+    expect(result.authentication.clientManager).toBe(result.clientManager)
+    expect(typeof result.useAuth).toBe("function")
+    expect(typeof result.useUserPrincipal).toBe("function")
+    expect(typeof result.useAgentState).toBe("function")
+    expect(typeof result.useIdentityAttributes).toBe("function")
+  })
+
+  it("forwards auth options to the AuthenticationManager", async () => {
+    const { authentication } = defineReactor<TestActor>({
+      ...baseConfig,
+      auth: { identityProvider: "https://identity.example.com/authorize" },
+    })
+
+    // Exposed through the client the manager would build.
+    expect(
+      (
+        authentication as unknown as {
+          resolveClientOptions: (o?: unknown) => { identityProvider: string }
+        }
+      ).resolveClientOptions().identityProvider
+    ).toBe("https://identity.example.com/authorize")
+  })
+
+  it("lets multiple reactors share one Internet Identity session", () => {
+    const ledger = defineReactor<TestActor>({ ...baseConfig, name: "ledger" })
+    const index = defineReactor<TestActor>({
+      ...baseConfig,
+      name: "index",
+      clientManager: ledger.clientManager,
+      authentication: ledger.authentication,
+    })
+
+    expect(index.authentication).toBe(ledger.authentication)
   })
 })

--- a/packages/react/src/defineReactor.ts
+++ b/packages/react/src/defineReactor.ts
@@ -33,7 +33,25 @@
  *   name: "index",
  *   idlFactory: indexIdl,
  *   clientManager: ledger.clientManager,
+ *   authentication: ledger.authentication, // one Internet Identity session
  * })
+ * ```
+ *
+ * @example Internet Identity is wired up out of the box
+ * ```typescript
+ * const { useAuth, useIdentityAttributes } = defineReactor<_SERVICE>({
+ *   name: "backend",
+ *   idlFactory,
+ *   // Needed when the app is served from more than one origin.
+ *   auth: { derivationOrigin: "https://app.example.com" },
+ * })
+ *
+ * function LoginButton() {
+ *   const { login, logout, isAuthenticated, principal } = useAuth()
+ *   return isAuthenticated
+ *     ? <button onClick={() => logout()}>{principal?.toText()}</button>
+ *     : <button onClick={() => login()}>Sign in</button>
+ * }
  * ```
  */
 import { ClientManager, Reactor, DisplayReactor } from "@ic-reactor/core"
@@ -46,6 +64,13 @@ import type {
 } from "@ic-reactor/core"
 import { QueryClient } from "@tanstack/react-query"
 import { createActorHooks, ActorHooks } from "./createActorHooks"
+import { AuthenticationManager } from "./auth/authentication-manager"
+import { IdentityAttributesManager } from "./auth/identity-attributes-manager"
+import { createIdentityAttributeHooks } from "./auth/createIdentityAttributeHooks"
+import type { UseIdentityAttributesReturn } from "./auth/createIdentityAttributeHooks"
+import { createAuthHooks } from "./hooks/createAuthHooks"
+import type { CreateAuthHooksReturn } from "./hooks/createAuthHooks"
+import type { AuthenticationManagerParameters } from "./auth/authentication-manager"
 
 /** Options shared by both the standard and display variants of defineReactor. */
 export interface DefineReactorSharedParameters
@@ -62,6 +87,16 @@ export interface DefineReactorSharedParameters
    * QueryClient is reused, or a new one is created.
    */
   queryClient?: QueryClient
+  /**
+   * Reuse an existing AuthenticationManager, so several reactors share one
+   * Internet Identity session. When omitted, one is created for this reactor.
+   */
+  authentication?: AuthenticationManager
+  /**
+   * Internet Identity options forwarded to the AuthenticationManager
+   * (`identityProvider`, `derivationOrigin`, `idleOptions`, `storage`, …).
+   */
+  auth?: Omit<AuthenticationManagerParameters, "clientManager">
 }
 
 /** Parameters for a standard (raw Candid types) reactor. */
@@ -83,11 +118,17 @@ export type DefineReactorResult<
   Service,
   Transform extends TransformKey,
   R extends Reactor<Service, Transform>,
-> = ActorHooks<Service, Transform> & {
-  reactor: R
-  clientManager: ClientManager
-  queryClient: QueryClient
-}
+> = ActorHooks<Service, Transform> &
+  CreateAuthHooksReturn & {
+    reactor: R
+    clientManager: ClientManager
+    queryClient: QueryClient
+    /** Internet Identity session manager backing `useAuth`. */
+    authentication: AuthenticationManager
+    /** Signed identity attribute requests backing `useIdentityAttributes`. */
+    identityAttributes: IdentityAttributesManager
+    useIdentityAttributes: () => UseIdentityAttributesReturn
+  }
 
 export function defineReactor<Service = BaseActor>(
   params: DefineDisplayReactorParameters<Service>
@@ -104,6 +145,8 @@ export function defineReactor<Service = BaseActor>(
   const {
     clientManager: providedClientManager,
     queryClient: providedQueryClient,
+    authentication: providedAuthentication,
+    auth,
     display,
     agentOptions,
     name,
@@ -146,5 +189,46 @@ export function defineReactor<Service = BaseActor>(
 
   const hooks = createActorHooks(reactor)
 
-  return { ...hooks, reactor, clientManager, queryClient }
+  // Auth is built on first use. `AuthenticationManager` dynamically imports the
+  // optional `@icp-sdk/auth` peer as soon as it is constructed, and reactors
+  // that never touch authentication should not pay for that.
+  let authenticationInstance: AuthenticationManager | undefined
+  const getAuthentication = () =>
+    (authenticationInstance ??=
+      providedAuthentication ??
+      new AuthenticationManager({ ...auth, clientManager }))
+
+  let identityAttributesInstance: IdentityAttributesManager | undefined
+  const getIdentityAttributes = () =>
+    (identityAttributesInstance ??= new IdentityAttributesManager(
+      getAuthentication()
+    ))
+
+  let authHooks: CreateAuthHooksReturn | undefined
+  const getAuthHooks = () =>
+    (authHooks ??= createAuthHooks(getAuthentication()))
+
+  let attributeHooks:
+    ReturnType<typeof createIdentityAttributeHooks> | undefined
+  const getAttributeHooks = () =>
+    (attributeHooks ??= createIdentityAttributeHooks(getIdentityAttributes()))
+
+  return {
+    ...hooks,
+    reactor,
+    clientManager,
+    queryClient,
+    // Stable wrappers: the hook call order inside them never changes, so the
+    // rules of hooks still hold.
+    useAuth: () => getAuthHooks().useAuth(),
+    useAgentState: () => getAuthHooks().useAgentState(),
+    useUserPrincipal: () => getAuthHooks().useUserPrincipal(),
+    useIdentityAttributes: () => getAttributeHooks().useIdentityAttributes(),
+    get authentication() {
+      return getAuthentication()
+    },
+    get identityAttributes() {
+      return getIdentityAttributes()
+    },
+  }
 }

--- a/packages/react/src/defineReactor.ts
+++ b/packages/react/src/defineReactor.ts
@@ -80,21 +80,33 @@ export interface DefineReactorSharedParameters
   /**
    * Reuse an existing ClientManager (e.g. to share one agent across canisters).
    * When omitted, a ClientManager is created from the agent options below.
+   *
+   * A supplied or adopted manager brings its own agent and QueryClient, so
+   * `agentOptions` and `queryClient` apply only when this call creates one.
    */
   clientManager?: ClientManager
   /**
-   * Reuse an existing QueryClient. When omitted, the provided ClientManager's
-   * QueryClient is reused, or a new one is created.
+   * QueryClient for a ClientManager created by this call.
+   *
+   * Ignored when `clientManager` or `authentication` is supplied — queries run
+   * against that manager's own QueryClient, which is what is returned.
    */
   queryClient?: QueryClient
   /**
    * Reuse an existing AuthenticationManager, so several reactors share one
    * Internet Identity session. When omitted, one is created for this reactor.
+   *
+   * Its `clientManager` is adopted for this reactor, so sign-in updates the
+   * same agent the reactor calls through. Supplying a different `clientManager`
+   * alongside it is rejected.
    */
   authentication?: AuthenticationManager
   /**
    * Internet Identity options forwarded to the AuthenticationManager
    * (`identityProvider`, `derivationOrigin`, `idleOptions`, `storage`, …).
+   *
+   * Mutually exclusive with `authentication`: a manager built elsewhere is
+   * already configured, so these could not be applied to it.
    */
   auth?: Omit<AuthenticationManagerParameters, "clientManager">
 }
@@ -155,17 +167,43 @@ export function defineReactor<Service = BaseActor>(
     pollingOptions,
   } = params as DefineDisplayReactorParameters<Service>
 
-  const queryClient =
-    providedQueryClient ??
-    providedClientManager?.queryClient ??
-    new QueryClient()
+  // A shared AuthenticationManager updates the identity on its own
+  // ClientManager. Giving this reactor a different one would leave its calls
+  // anonymous after sign-in, so adopt the manager's rather than building a new
+  // one, and refuse an explicit mismatch instead of splitting them silently.
+  if (
+    providedClientManager &&
+    providedAuthentication &&
+    providedAuthentication.clientManager !== providedClientManager
+  ) {
+    throw new Error(
+      `[ic-reactor] defineReactor("${name}") received an \`authentication\` manager bound to a different \`clientManager\`. ` +
+        `Sign-in would update the authentication manager's agent while this reactor calls through another one, ` +
+        `leaving its calls anonymous. Pass \`clientManager: authentication.clientManager\`, or omit \`clientManager\` to adopt it.`
+    )
+  }
+
+  // `auth` configures a manager this call would build; an existing one is
+  // already constructed, so these options could only be dropped on the floor.
+  if (providedAuthentication && auth) {
+    throw new Error(
+      `[ic-reactor] defineReactor("${name}") received both \`authentication\` and \`auth\`. ` +
+        `The supplied manager is already configured, so \`auth\` (${Object.keys(auth).join(", ")}) would be ignored. ` +
+        `Pass those options where that AuthenticationManager is created, or drop \`authentication\` to build one here.`
+    )
+  }
 
   const clientManager =
     providedClientManager ??
+    providedAuthentication?.clientManager ??
     new ClientManager({
-      queryClient,
+      queryClient: providedQueryClient ?? new QueryClient(),
       agentOptions,
     })
+
+  // Always report the QueryClient actually in use: when a ClientManager is
+  // supplied or adopted, its own QueryClient is the one queries run against.
+  const queryClient = clientManager.queryClient
 
   const reactorConfig = {
     clientManager,

--- a/packages/react/src/hooks/createAuthHooks.ts
+++ b/packages/react/src/hooks/createAuthHooks.ts
@@ -90,7 +90,9 @@ export const createAuthHooks = (
     // Track if we've already initialized to avoid duplicate calls
     const initializedRef = useRef(false)
 
-    // Auto-initialize on first mount to restore previous session
+    // Auto-initialize on first mount to restore previous session.
+    // `prepareClient` also warms up the AuthClient so a later `login()` can
+    // open the identity provider window inside the click handler.
     useEffect(() => {
       if (!initializedRef.current) {
         initializedRef.current = true
@@ -99,6 +101,9 @@ export const createAuthHooks = (
           .catch(() => undefined)
           .then(() => clientManager.initialize())
           .then(() => authentication.authenticate())
+          // Failures are already reflected in authState/agentState; without
+          // this the rejection escapes as an unhandled promise rejection.
+          .catch(() => undefined)
       }
     }, [])
 

--- a/packages/react/test-setup.ts
+++ b/packages/react/test-setup.ts
@@ -6,3 +6,33 @@ import { TextEncoder, TextDecoder } from "util"
 
 globalThis.TextEncoder = TextEncoder
 globalThis.TextDecoder = TextDecoder as any
+
+// The jsdom build used here exposes `localStorage` as a bare object without the
+// Storage methods. `@icp-sdk/auth` caches the delegation expiration in
+// localStorage (that is what `AuthClient.isAuthenticated()` reads), so the real
+// client needs a working implementation to be exercised in tests.
+if (typeof globalThis.localStorage?.getItem !== "function") {
+  const store = new Map<string, string>()
+  const storage: Storage = {
+    get length() {
+      return store.size
+    },
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key: string, value: string) => void store.set(key, String(value)),
+    removeItem: (key: string) => void store.delete(key),
+    clear: () => store.clear(),
+  }
+  Object.defineProperty(globalThis, "localStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  })
+  if (typeof window !== "undefined") {
+    Object.defineProperty(window, "localStorage", {
+      value: storage,
+      configurable: true,
+      writable: true,
+    })
+  }
+}

--- a/packages/react/tests/auth/auth-client-compat.test.ts
+++ b/packages/react/tests/auth/auth-client-compat.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Compatibility guarantees across `@icp-sdk/auth` versions and the AuthClient
+ * options IC Reactor forwards.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { QueryClient } from "@tanstack/react-query"
+import { Principal } from "@icp-sdk/core/principal"
+import { ClientManager } from "@ic-reactor/core"
+import {
+  AuthenticationManager,
+  IdentityAttributesManager,
+} from "../../src/auth"
+
+const authClientMocks = vi.hoisted(() => ({ factory: vi.fn() }))
+
+vi.mock("@icp-sdk/auth/client", () => ({ AuthClient: authClientMocks.factory }))
+
+const identity = { getPrincipal: () => Principal.fromText("aaaaa-aa") } as never
+
+/**
+ * @param version `7` keeps the v7 surface; `8` adds `memoize`, which is how the
+ * v8 nonce contract is detected.
+ */
+function createAuthClientStub(version: 7 | 8) {
+  const client = {
+    getIdentity: vi.fn(() => identity),
+    isAuthenticated: vi.fn(() => true),
+    signIn: vi.fn(async () => identity),
+    signOut: vi.fn(async () => {}),
+    requestAttributes: vi.fn(async () => ({
+      data: new Uint8Array(),
+      signature: new Uint8Array(),
+    })),
+    ...(version === 8
+      ? { memoize: vi.fn(async (produce: () => unknown) => produce()) }
+      : {}),
+  }
+  return client as typeof client & Record<string, unknown>
+}
+
+function createManager(
+  params: Record<string, unknown> = {},
+  authClient?: ReturnType<typeof createAuthClientStub>
+) {
+  const clientManager = new ClientManager({ queryClient: new QueryClient() })
+  vi.spyOn(clientManager, "initializeAgent").mockResolvedValue()
+  const authentication = new AuthenticationManager({
+    clientManager,
+    ...(authClient ? { authClient } : {}),
+    ...params,
+  } as never)
+  return { clientManager, authentication }
+}
+
+beforeEach(() => {
+  authClientMocks.factory.mockReset()
+})
+
+describe("@icp-sdk/auth nonce contract", () => {
+  it("passes a promise to v7 clients", async () => {
+    const authClient = createAuthClientStub(7)
+    const { authentication } = createManager({}, authClient)
+    const attributes = new IdentityAttributesManager(authentication)
+
+    await attributes.request({ keys: ["email"], nonce: new Uint8Array([4, 2]) })
+
+    const [request] = authClient.requestAttributes.mock.calls[0] as [
+      { nonce: unknown },
+    ]
+    expect(typeof request.nonce).not.toBe("function")
+    await expect(request.nonce as Promise<Uint8Array>).resolves.toEqual(
+      new Uint8Array([4, 2])
+    )
+  })
+
+  it("passes a nonce callback to v8 clients", async () => {
+    const authClient = createAuthClientStub(8)
+    const { authentication } = createManager({}, authClient)
+    const attributes = new IdentityAttributesManager(authentication)
+
+    await attributes.request({ keys: ["email"], nonce: new Uint8Array([4, 2]) })
+
+    const [request] = authClient.requestAttributes.mock.calls[0] as [
+      { nonce: unknown },
+    ]
+    // v8 calls `nonce()`; handing it a Uint8Array would throw at runtime.
+    expect(typeof request.nonce).toBe("function")
+    await expect(
+      (request.nonce as () => Promise<Uint8Array>)()
+    ).resolves.toEqual(new Uint8Array([4, 2]))
+  })
+
+  it("defers a lazily produced nonce until the client asks for it", async () => {
+    const authClient = createAuthClientStub(8)
+    const { authentication } = createManager({}, authClient)
+    const attributes = new IdentityAttributesManager(authentication)
+
+    const produce = vi.fn(async () => new Uint8Array([7]))
+    await attributes.request({ keys: ["email"], nonce: produce })
+
+    // v8 journals the nonce itself, so it must stay unevaluated until called.
+    expect(produce).not.toHaveBeenCalled()
+    const [request] = authClient.requestAttributes.mock.calls[0] as [
+      { nonce: () => Promise<Uint8Array> },
+    ]
+    await expect(request.nonce()).resolves.toEqual(new Uint8Array([7]))
+    expect(produce).toHaveBeenCalledTimes(1)
+  })
+
+  it("resolves a lazily produced nonce eagerly for v7 clients", async () => {
+    const authClient = createAuthClientStub(7)
+    const { authentication } = createManager({}, authClient)
+    const attributes = new IdentityAttributesManager(authentication)
+
+    const produce = vi.fn(async () => new Uint8Array([7]))
+    await attributes.request({ keys: ["email"], nonce: produce })
+
+    // v7 has no thunk support, so the callback is invoked for it.
+    expect(produce).toHaveBeenCalledTimes(1)
+    const [request] = authClient.requestAttributes.mock.calls[0] as [
+      { nonce: Promise<Uint8Array> },
+    ]
+    await expect(request.nonce).resolves.toEqual(new Uint8Array([7]))
+  })
+
+  it("accepts a promise nonce", async () => {
+    const authClient = createAuthClientStub(7)
+    const { authentication } = createManager({}, authClient)
+    const attributes = new IdentityAttributesManager(authentication)
+
+    await attributes.request({
+      keys: ["email"],
+      nonce: Promise.resolve(new Uint8Array([1])),
+    })
+
+    const [request] = authClient.requestAttributes.mock.calls[0] as [
+      { nonce: Promise<Uint8Array> },
+    ]
+    await expect(request.nonce).resolves.toEqual(new Uint8Array([1]))
+  })
+})
+
+describe("AuthClient option pass-through", () => {
+  it("forwards derivationOrigin, keyType, storage and idleOptions", async () => {
+    const storage = {
+      get: async () => null,
+      set: async () => {},
+      remove: async () => {},
+    }
+    const idleOptions = { disableIdle: true }
+    const { authentication } = createManager({
+      derivationOrigin: "https://app.example.com",
+      keyType: "Ed25519",
+      storage,
+      idleOptions,
+    })
+
+    await authentication.prepareClient()
+
+    expect(authClientMocks.factory).toHaveBeenCalledTimes(1)
+    expect(authClientMocks.factory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        derivationOrigin: "https://app.example.com",
+        keyType: "Ed25519",
+        storage,
+        idleOptions,
+      })
+    )
+  })
+
+  it("lets a login call override constructor defaults", async () => {
+    authClientMocks.factory.mockImplementation(function () {
+      return createAuthClientStub(7)
+    })
+    const { authentication } = createManager({
+      derivationOrigin: "https://app.example.com",
+    })
+    await authentication.prepareClient()
+
+    await authentication.login({
+      derivationOrigin: "https://other.example.com",
+    })
+
+    expect(authClientMocks.factory).toHaveBeenCalledTimes(2)
+    expect(authClientMocks.factory).toHaveBeenLastCalledWith(
+      expect.objectContaining({ derivationOrigin: "https://other.example.com" })
+    )
+  })
+})
+
+describe("AuthClient reuse", () => {
+  it("reuses the prepared client instead of rebuilding it on every call", async () => {
+    authClientMocks.factory.mockImplementation(function () {
+      return createAuthClientStub(7)
+    })
+    const { authentication } = createManager()
+
+    await authentication.prepareClient()
+    await authentication.prepareClient()
+    await authentication.login()
+    await authentication.authenticate()
+
+    // Rebuilding would drop the warmed-up client and register another
+    // sign-out callback on the shared IdleManager singleton.
+    expect(authClientMocks.factory).toHaveBeenCalledTimes(1)
+  })
+
+  it("rebuilds only when the effective options change", async () => {
+    authClientMocks.factory.mockImplementation(function () {
+      return createAuthClientStub(7)
+    })
+    const { authentication } = createManager()
+
+    await authentication.prepareClient()
+    await authentication.prepareClient({ openIdProvider: "google" })
+    await authentication.prepareClient({ openIdProvider: "google" })
+
+    expect(authClientMocks.factory).toHaveBeenCalledTimes(2)
+  })
+
+  it("never rebuilds a caller-supplied client", async () => {
+    const authClient = createAuthClientStub(7)
+    const { authentication } = createManager(
+      { identityProvider: "https://id.ai/authorize" },
+      authClient
+    )
+
+    await authentication.prepareClient({ openIdProvider: "google" })
+    await authentication.login({ openIdProvider: "apple" })
+
+    expect(authClientMocks.factory).not.toHaveBeenCalled()
+    expect(authClient.signIn).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("session restore", () => {
+  it("does not invalidate the query cache when restoring an anonymous session", async () => {
+    const anonymous = {
+      getPrincipal: () => Principal.fromText("2vxsx-fae"),
+    } as never
+    authClientMocks.factory.mockImplementation(function () {
+      return {
+        getIdentity: vi.fn(() => anonymous),
+        isAuthenticated: vi.fn(() => false),
+        signIn: vi.fn(),
+        signOut: vi.fn(),
+        requestAttributes: vi.fn(),
+      }
+    })
+    const { clientManager, authentication } = createManager()
+    const invalidate = vi.spyOn(clientManager.queryClient, "invalidateQueries")
+
+    await authentication.authenticate()
+
+    expect(authentication.authState.isAuthenticated).toBe(false)
+    expect(invalidate).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/tests/auth/fake-identity-provider.ts
+++ b/packages/react/tests/auth/fake-identity-provider.ts
@@ -1,0 +1,319 @@
+/**
+ * A fake Internet Identity provider that speaks the real ICRC-29 (postMessage
+ * transport), ICRC-34 (delegation) and `ii-icrc3-attributes` wire protocols.
+ *
+ * These tests drive the *real* `AuthClient` from `@icp-sdk/auth/client` — no
+ * `vi.mock` of the auth package — so regressions in the actual integration
+ * (option pass-through, nonce contract, popup gesture chain, session restore)
+ * surface here instead of in production.
+ */
+import { vi } from "vitest"
+import {
+  DelegationChain,
+  Ed25519KeyIdentity,
+  type SignedDelegation,
+} from "@icp-sdk/core/identity"
+import { Principal } from "@icp-sdk/core/principal"
+import { IDL } from "@icp-sdk/core/candid"
+
+export const FAKE_II_ORIGIN = "https://id.ai"
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0"
+  id?: string | number | null
+  method: string
+  params?: Record<string, unknown>
+}
+
+export interface DelegationRequestRecord {
+  publicKey: string
+  targets?: string[]
+  maxTimeToLive?: string
+  icrc95DerivationOrigin?: string
+}
+
+export interface AttributesRequestRecord {
+  keys: string[]
+  nonce: string
+  icrc95DerivationOrigin?: string
+}
+
+export interface FakeIdentityProviderOptions {
+  /** Identity used as the delegation root (the "user" in Internet Identity). */
+  rootIdentity?: Ed25519KeyIdentity
+  /** Payload returned for `ii-icrc3-attributes`. Defaults to a Candid map. */
+  attributesResponse?: { data: Uint8Array; signature: Uint8Array }
+  /** Force `ii-icrc3-attributes` to answer with a JSON-RPC error. */
+  attributesError?: { code: number; message: string }
+  /** Delegation lifetime in ms, relative to now. */
+  delegationLifetimeMs?: number
+}
+
+export interface FakeIdentityProvider {
+  readonly rootIdentity: Ed25519KeyIdentity
+  /** URL each `window.open` call was made against. */
+  readonly openedUrls: string[]
+  /** Every window that was opened; `closed` reflects real `close()` calls. */
+  readonly windows: FakeSignerWindow[]
+  readonly delegationRequests: DelegationRequestRecord[]
+  readonly attributesRequests: AttributesRequestRecord[]
+  /** Number of `window.open` calls, i.e. distinct II popups shown to the user. */
+  readonly openCount: number
+  setAttributesResponse(payload: {
+    data: Uint8Array
+    signature: Uint8Array
+  }): void
+  setAttributesError(error: { code: number; message: string } | null): void
+  restore(): void
+}
+
+export interface FakeSignerWindow {
+  closed: boolean
+  close(): void
+  focus(): void
+  postMessage(message: unknown, targetOrigin?: string): void
+}
+
+/**
+ * Installs a fake II provider over `window.open` for the duration of a test.
+ */
+export function installFakeIdentityProvider(
+  options: FakeIdentityProviderOptions = {}
+): FakeIdentityProvider {
+  const rootIdentity = options.rootIdentity ?? Ed25519KeyIdentity.generate()
+  const delegationLifetimeMs =
+    options.delegationLifetimeMs ?? 8 * 60 * 60 * 1000
+
+  let attributesResponse =
+    options.attributesResponse ?? defaultAttributesResponse()
+  let attributesError = options.attributesError ?? null
+
+  const openedUrls: string[] = []
+  const windows: FakeSignerWindow[] = []
+  const delegationRequests: DelegationRequestRecord[] = []
+  const attributesRequests: AttributesRequestRecord[] = []
+
+  const originalOpen = window.open
+
+  const openSpy = vi.fn(
+    (url?: string | URL, _target?: string, _features?: string) => {
+      openedUrls.push(String(url ?? ""))
+      const signerWindow = createSignerWindow()
+      windows.push(signerWindow)
+      return signerWindow as unknown as Window
+    }
+  )
+
+  // jsdom types `window.open` more narrowly than the spy signature.
+  window.open = openSpy as unknown as typeof window.open
+
+  function createSignerWindow(): FakeSignerWindow {
+    const signerWindow: FakeSignerWindow = {
+      closed: false,
+      close() {
+        signerWindow.closed = true
+      },
+      focus() {},
+      postMessage(message: unknown) {
+        if (signerWindow.closed) return
+        void handleRequest(signerWindow, message as JsonRpcRequest)
+      },
+    }
+    return signerWindow
+  }
+
+  function respond(source: FakeSignerWindow, data: unknown) {
+    // The channel filters on `event.source` and `event.origin`, so both have to
+    // match the window the transport opened.
+    const event = new MessageEvent("message", {
+      data,
+      origin: FAKE_II_ORIGIN,
+    })
+    Object.defineProperty(event, "source", { value: source })
+    window.dispatchEvent(event)
+  }
+
+  async function handleRequest(
+    source: FakeSignerWindow,
+    request: JsonRpcRequest
+  ) {
+    if (!request || request.jsonrpc !== "2.0") return
+
+    switch (request.method) {
+      case "icrc29_status": {
+        respond(source, { jsonrpc: "2.0", id: request.id, result: "ready" })
+        return
+      }
+      case "icrc34_delegation": {
+        const params = (request.params ?? {}) as unknown as {
+          publicKey: string
+          targets?: string[]
+          maxTimeToLive?: string
+          icrc95DerivationOrigin?: string
+        }
+        delegationRequests.push({
+          publicKey: params.publicKey,
+          targets: params.targets,
+          maxTimeToLive: params.maxTimeToLive,
+          icrc95DerivationOrigin: params.icrc95DerivationOrigin,
+        })
+
+        const sessionKeyDer = fromBase64(params.publicKey)
+        const expiration = new Date(Date.now() + delegationLifetimeMs)
+        const targets = params.targets?.map((text) => Principal.fromText(text))
+
+        const chain = await DelegationChain.create(
+          rootIdentity,
+          { toDer: () => sessionKeyDer } as never,
+          expiration,
+          targets ? { targets } : undefined
+        )
+
+        respond(source, {
+          jsonrpc: "2.0",
+          id: request.id,
+          result: {
+            publicKey: toBase64(new Uint8Array(chain.publicKey)),
+            signerDelegation: chain.delegations.map(
+              (signed: SignedDelegation) => ({
+                delegation: {
+                  pubkey: toBase64(new Uint8Array(signed.delegation.pubkey)),
+                  expiration: signed.delegation.expiration.toString(),
+                  ...(signed.delegation.targets
+                    ? {
+                        targets: signed.delegation.targets.map((t) =>
+                          t.toText()
+                        ),
+                      }
+                    : {}),
+                },
+                signature: toBase64(new Uint8Array(signed.signature)),
+              })
+            ),
+          },
+        })
+        return
+      }
+      case "ii-icrc3-attributes": {
+        const params = (request.params ?? {}) as unknown as {
+          keys: string[]
+          nonce: string
+          icrc95DerivationOrigin?: string
+        }
+        attributesRequests.push({
+          keys: params.keys,
+          nonce: params.nonce,
+          icrc95DerivationOrigin: params.icrc95DerivationOrigin,
+        })
+
+        if (attributesError) {
+          respond(source, {
+            jsonrpc: "2.0",
+            id: request.id,
+            error: attributesError,
+          })
+          return
+        }
+
+        respond(source, {
+          jsonrpc: "2.0",
+          id: request.id,
+          result: {
+            data: toBase64(attributesResponse.data),
+            signature: toBase64(attributesResponse.signature),
+          },
+        })
+        return
+      }
+      default: {
+        respond(source, {
+          jsonrpc: "2.0",
+          id: request.id,
+          error: {
+            code: 2000,
+            message: `Unsupported method ${request.method}`,
+          },
+        })
+      }
+    }
+  }
+
+  return {
+    rootIdentity,
+    openedUrls,
+    windows,
+    delegationRequests,
+    attributesRequests,
+    get openCount() {
+      return openSpy.mock.calls.length
+    },
+    setAttributesResponse(payload) {
+      attributesResponse = payload
+    },
+    setAttributesError(error) {
+      attributesError = error
+    },
+    restore() {
+      window.open = originalOpen
+    },
+  }
+}
+
+/**
+ * Runs `fn` inside a real click dispatch so the ICRC-29 transport's
+ * `detectNonClickEstablishment` guard is satisfied — exactly like a browser
+ * running a click handler. If the library breaks the user-gesture chain by
+ * awaiting before `signIn()`, the transport rejects and the test fails.
+ */
+export async function withUserGesture<T>(fn: () => Promise<T>): Promise<T> {
+  let started: Promise<T> | undefined
+  const handler = () => {
+    started = fn()
+  }
+  // Registered after the transport's own capture listener, so `withinClick`
+  // is already true by the time `fn` runs.
+  window.addEventListener("click", handler, true)
+  try {
+    window.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+  } finally {
+    window.removeEventListener("click", handler, true)
+  }
+  if (!started) {
+    throw new Error("click handler did not run")
+  }
+  return started
+}
+
+/** Candid-encoded `vec { record { text; text } }` attribute payload. */
+export function encodeAttributes(entries: Array<[string, string]>): Uint8Array {
+  return new Uint8Array(
+    IDL.encode([IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))], [entries])
+  )
+}
+
+function defaultAttributesResponse() {
+  return {
+    data: encodeAttributes([
+      ["openid:https://accounts.google.com:email", "user@example.com"],
+      ["openid:https://accounts.google.com:name", "Test User"],
+    ]),
+    signature: new Uint8Array([1, 2, 3, 4]),
+  }
+}
+
+export function toBase64(bytes: Uint8Array): string {
+  let binary = ""
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary)
+}
+
+export function fromBase64(value: string): Uint8Array {
+  const binary = atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}

--- a/packages/react/tests/auth/identity-attributes-manager.test.ts
+++ b/packages/react/tests/auth/identity-attributes-manager.test.ts
@@ -61,10 +61,11 @@ describe("IdentityAttributesManager", () => {
     })
 
     expect(authClient.signIn).toHaveBeenCalledTimes(1)
-    expect(authClient.requestAttributes).toHaveBeenCalledWith({
-      keys: ["openid:https://issuer.example.com:email"],
-      nonce: new Uint8Array([9, 9]),
-    })
+    // The nonce is handed over in its deferred form so the auth client opens
+    // the identity provider window inside the user gesture.
+    const [request] = authClient.requestAttributes.mock.calls[0]
+    expect(request.keys).toEqual(["openid:https://issuer.example.com:email"])
+    await expect(request.nonce).resolves.toEqual(new Uint8Array([9, 9]))
     expect(result.principal).toBe("aaaaa-aa")
     expect(authentication.authState.isAuthenticated).toBe(true)
   })
@@ -78,10 +79,11 @@ describe("IdentityAttributesManager", () => {
       nonce: new Uint8Array([9]),
     })
 
-    expect(authClient.requestAttributes).toHaveBeenCalledWith({
-      keys: ["openid:https://login.microsoftonline.com/{tid}/v2.0:email"],
-      nonce: new Uint8Array([9]),
-    })
+    const [request] = authClient.requestAttributes.mock.calls[0]
+    expect(request.keys).toEqual([
+      "openid:https://login.microsoftonline.com/{tid}/v2.0:email",
+    ])
+    await expect(request.nonce).resolves.toEqual(new Uint8Array([9]))
     expect(result.requestedKeys).toEqual([
       "openid:https://login.microsoftonline.com/{tid}/v2.0:email",
     ])

--- a/packages/react/tests/auth/internet-identity-integration.test.ts
+++ b/packages/react/tests/auth/internet-identity-integration.test.ts
@@ -1,0 +1,330 @@
+/**
+ * End-to-end Internet Identity tests against the **real** `@icp-sdk/auth`
+ * AuthClient. Nothing in the auth package is mocked — only the browser
+ * boundary (`window.open`) is replaced by a fake II that speaks the real
+ * ICRC-29 / ICRC-34 / `ii-icrc3-attributes` wire protocol.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { QueryClient } from "@tanstack/react-query"
+import { Principal } from "@icp-sdk/core/principal"
+import { ClientManager } from "@ic-reactor/core"
+import {
+  AuthenticationManager,
+  IdentityAttributesManager,
+} from "../../src/auth"
+import {
+  installFakeIdentityProvider,
+  withUserGesture,
+  encodeAttributes,
+  fromBase64,
+  type FakeIdentityProvider,
+} from "./fake-identity-provider"
+
+let provider: FakeIdentityProvider
+
+function createManager(
+  params: Partial<ConstructorParameters<typeof AuthenticationManager>[0]> = {}
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const clientManager = new ClientManager({
+    queryClient,
+    agentOptions: { host: "https://icp-api.io", shouldFetchRootKey: false },
+  })
+  const authentication = new AuthenticationManager({
+    clientManager,
+    ...params,
+  })
+  return { queryClient, clientManager, authentication }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  provider = installFakeIdentityProvider()
+})
+
+afterEach(() => {
+  provider.restore()
+})
+
+describe("Internet Identity sign-in (real AuthClient)", () => {
+  it("signs in through the II popup and puts the delegated identity on the agent", async () => {
+    const { authentication, clientManager } = createManager()
+    await authentication.prepareClient()
+
+    await withUserGesture(() => authentication.login())
+
+    expect(provider.openCount).toBe(1)
+    expect(provider.delegationRequests).toHaveLength(1)
+
+    const { identity, isAuthenticated, isAuthenticating, error } =
+      authentication.authState
+    expect(error).toBeUndefined()
+    expect(isAuthenticating).toBe(false)
+    expect(isAuthenticated).toBe(true)
+    expect(identity).not.toBeNull()
+
+    // The agent must carry the delegated principal, not the anonymous one.
+    const principal = identity!.getPrincipal()
+    expect(principal.isAnonymous()).toBe(false)
+    expect((await clientManager.getUserPrincipal()).toText()).toBe(
+      principal.toText()
+    )
+    expect(principal.toText()).toBe(
+      provider.rootIdentity.getPrincipal().toText()
+    )
+  })
+
+  it("opens the popup synchronously so the browser gesture chain survives", async () => {
+    // `PostMessageTransport` rejects when `establishChannel` runs outside a
+    // click. A regression that awaits before `signIn()` fails here.
+    const { authentication } = createManager()
+    await authentication.prepareClient()
+
+    await expect(
+      withUserGesture(() => authentication.login())
+    ).resolves.toBeUndefined()
+  })
+
+  it("forwards maxTimeToLive and targets to the identity provider", async () => {
+    const { authentication } = createManager()
+    await authentication.prepareClient()
+
+    const maxTimeToLive = 3_600_000_000_000n
+    await withUserGesture(() =>
+      authentication.login({
+        maxTimeToLive,
+        targets: [Principal.fromText("rrkah-fqaaa-aaaaa-aaaaq-cai")],
+      })
+    )
+
+    const request = provider.delegationRequests[0]
+    expect(request.maxTimeToLive).toBe(maxTimeToLive.toString())
+    expect(request.targets).toEqual(["rrkah-fqaaa-aaaaa-aaaaq-cai"])
+  })
+
+  it("runs onSuccess after a completed sign-in", async () => {
+    const { authentication } = createManager()
+    await authentication.prepareClient()
+
+    const calls: string[] = []
+    await withUserGesture(() =>
+      authentication.login({
+        onSuccess: () => {
+          calls.push("success")
+        },
+        onError: () => {
+          calls.push("error")
+        },
+      })
+    )
+
+    expect(calls).toEqual(["success"])
+  })
+
+  it("restores the session on a fresh manager without reopening the popup", async () => {
+    const first = createManager()
+    await first.authentication.prepareClient()
+    await withUserGesture(() => first.authentication.login())
+    expect(provider.openCount).toBe(1)
+
+    // A new page load: new ClientManager + AuthenticationManager, same storage.
+    const second = createManager()
+    const identity = await second.authentication.authenticate()
+
+    expect(provider.openCount).toBe(1)
+    expect(identity).toBeDefined()
+    expect(identity!.getPrincipal().isAnonymous()).toBe(false)
+    expect(second.authentication.authState.isAuthenticated).toBe(true)
+    expect((await second.clientManager.getUserPrincipal()).toText()).toBe(
+      first.authentication.authState.identity!.getPrincipal().toText()
+    )
+  })
+
+  it("logs out, clears the session and resets the agent to anonymous", async () => {
+    const { authentication, clientManager } = createManager()
+    await authentication.prepareClient()
+    await withUserGesture(() => authentication.login())
+    expect((await clientManager.getUserPrincipal()).isAnonymous()).toBe(false)
+
+    await authentication.logout()
+
+    expect(authentication.authState.isAuthenticated).toBe(false)
+    expect((await clientManager.getUserPrincipal()).isAnonymous()).toBe(true)
+
+    // The stored session must be gone: a fresh manager stays anonymous.
+    const next = createManager()
+    const identity = await next.authentication.authenticate()
+    expect(identity?.getPrincipal().isAnonymous()).toBe(true)
+    expect(next.authentication.authState.isAuthenticated).toBe(false)
+  })
+
+  it("reports sign-in failures through authState and onError", async () => {
+    const { authentication } = createManager()
+    await authentication.prepareClient()
+
+    // Popup blocked.
+    provider.restore()
+    const blocked = () => null as unknown as Window
+    const original = window.open
+    window.open = blocked as unknown as typeof window.open
+
+    const errors: Array<string | undefined> = []
+    await expect(
+      withUserGesture(() =>
+        authentication.login({ onError: (e) => void errors.push(e) })
+      )
+    ).rejects.toThrow()
+
+    window.open = original
+    expect(authentication.authState.isAuthenticating).toBe(false)
+    expect(authentication.authState.isAuthenticated).toBe(false)
+    expect(authentication.authState.error).toBeInstanceOf(Error)
+    expect(errors).toHaveLength(1)
+  })
+})
+
+describe("identity provider resolution", () => {
+  it("uses the production II provider on mainnet", async () => {
+    const { authentication } = createManager()
+    await authentication.prepareClient()
+    await withUserGesture(() => authentication.login())
+
+    expect(provider.openedUrls[0]).toBe("https://id.ai/authorize")
+  })
+
+  it("honours an explicit identityProvider", async () => {
+    const { authentication } = createManager({
+      identityProvider: "https://identity.internetcomputer.org/authorize",
+    })
+    await authentication.prepareClient()
+    await withUserGesture(() => authentication.login())
+
+    expect(provider.openedUrls[0]).toBe(
+      "https://identity.internetcomputer.org/authorize"
+    )
+  })
+
+  it("adds the openid search param for one-click providers", async () => {
+    const { authentication } = createManager()
+    await authentication.prepareClient({ openIdProvider: "google" })
+    await withUserGesture(() =>
+      authentication.login({ openIdProvider: "google" })
+    )
+
+    expect(provider.openedUrls[0]).toContain(
+      "openid=https%3A%2F%2Faccounts.google.com"
+    )
+  })
+})
+
+describe("identity attributes (real AuthClient)", () => {
+  it("requests attributes and decodes them alongside sign-in", async () => {
+    const { authentication } = createManager()
+    const attributes = new IdentityAttributesManager(authentication)
+    await authentication.prepareClient()
+
+    const nonce = new Uint8Array(32).fill(7)
+    const result = await withUserGesture(() =>
+      attributes.request({
+        keys: [
+          "openid:https://accounts.google.com:email",
+          "openid:https://accounts.google.com:name",
+        ],
+        nonce,
+      })
+    )
+
+    // Sign-in and the attribute request share one popup.
+    expect(provider.openCount).toBe(1)
+    expect(provider.attributesRequests).toHaveLength(1)
+    expect(fromBase64(provider.attributesRequests[0].nonce)).toEqual(nonce)
+
+    expect(result.decodedAttributes).toEqual({
+      email: "user@example.com",
+      name: "Test User",
+    })
+    expect(result.principal).toBe(provider.rootIdentity.getPrincipal().toText())
+    expect(result.signedAttributes.signature).toEqual(
+      new Uint8Array([1, 2, 3, 4])
+    )
+    expect(authentication.authState.isAuthenticated).toBe(true)
+  })
+
+  it("scopes keys for requestOpenId", async () => {
+    const { authentication } = createManager()
+    const attributes = new IdentityAttributesManager(authentication)
+    await authentication.prepareClient()
+
+    provider.setAttributesResponse({
+      data: encodeAttributes([
+        ["openid:https://accounts.google.com:email", "scoped@example.com"],
+      ]),
+      signature: new Uint8Array([9]),
+    })
+
+    const result = await withUserGesture(() =>
+      attributes.requestOpenId({
+        nonce: new Uint8Array(32).fill(3),
+        openIdProvider: "google",
+        keys: ["email"],
+      })
+    )
+
+    expect(provider.attributesRequests[0].keys).toEqual([
+      "openid:https://accounts.google.com:email",
+    ])
+    expect(result.decodedAttributes.email).toBe("scoped@example.com")
+  })
+
+  it("opens the II window before an async nonce resolves", async () => {
+    const { authentication } = createManager()
+    const attributes = new IdentityAttributesManager(authentication)
+    await authentication.prepareClient()
+
+    // A nonce fetched from a canister: awaiting it before calling
+    // requestAttributes would end the user gesture and the transport would
+    // refuse to open the window.
+    let releaseNonce: (value: Uint8Array) => void = () => {}
+    const nonce = new Promise<Uint8Array>((resolve) => {
+      releaseNonce = resolve
+    })
+
+    const pending = withUserGesture(() =>
+      attributes.request({
+        keys: ["openid:https://accounts.google.com:email"],
+        nonce: () => nonce,
+      })
+    )
+
+    // The popup is already up while the nonce is still in flight.
+    await Promise.resolve()
+    expect(provider.openCount).toBe(1)
+
+    releaseNonce(new Uint8Array(32).fill(5))
+    const result = await pending
+
+    expect(fromBase64(provider.attributesRequests[0].nonce)).toEqual(
+      new Uint8Array(32).fill(5)
+    )
+    expect(result.decodedAttributes.email).toBe("user@example.com")
+  })
+
+  it("surfaces identity-provider errors", async () => {
+    const { authentication } = createManager()
+    const attributes = new IdentityAttributesManager(authentication)
+    await authentication.prepareClient()
+
+    provider.setAttributesError({ code: 3000, message: "User rejected" })
+
+    await expect(
+      withUserGesture(() =>
+        attributes.request({ keys: ["email"], nonce: new Uint8Array(32) })
+      )
+    ).rejects.toThrow("User rejected")
+
+    expect(authentication.authState.error?.message).toContain("User rejected")
+    expect(authentication.authState.isAuthenticating).toBe(false)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1196,7 +1196,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3))
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -1266,8 +1266,8 @@ importers:
         version: link:../core
     devDependencies:
       '@icp-sdk/auth':
-        specifier: ^7.1.0
-        version: 7.1.0(@icp-sdk/core@6.0.0)
+        specifier: ^8.0.0
+        version: 8.0.0(@icp-sdk/core@6.0.0)
       '@icp-sdk/core':
         specifier: ^6.0.0
         version: 6.0.0
@@ -2820,6 +2820,11 @@ packages:
     peerDependencies:
       '@icp-sdk/core': ^5
 
+  '@icp-sdk/auth@8.0.0':
+    resolution: {integrity: sha512-TAaIAhwkyqoS3D4rR7KYLl7s+USWlRN/r1QwQrk9oltRDyay046DEUmeilDu1WOIwjo1/z0jIXh4nb6vycTVew==}
+    peerDependencies:
+      '@icp-sdk/core': ^5
+
   '@icp-sdk/bindgen@0.4.0':
     resolution: {integrity: sha512-WXJoPIVnqCgFSNcprVpHwPBNWA1prwPh1/ezQYVrCP+Zj8CCJ7zj9L7p5cFcN7ghxoxfbx6tYT8t/HN9fyeYkA==}
     hasBin: true
@@ -2827,8 +2832,8 @@ packages:
   '@icp-sdk/core@6.0.0':
     resolution: {integrity: sha512-z+oHm+MTB/Xo27LQCYXDpVcUyFQwceupoyqkYCW6aaiZ2GJ1BvhRbSMsm7XDHAgCuZmWULPxpiTFUnHZLDEKzw==}
 
-  '@icp-sdk/signer@5.4.0':
-    resolution: {integrity: sha512-l7HKJ02ZszAWvBV0dSW7uNVNVwsVAlWp9zMirHk/wrtQpglMDSxh1kcXiha5R5YkIooy/d5Pt8QKHDPG4Orj6A==}
+  '@icp-sdk/signer@5.6.0':
+    resolution: {integrity: sha512-zL8SR7YvMaTrEq6/8+ZX5wvTsXSUOm79dyZz7dj8MvHNZpH8pOKxE8QNmqThW4112EKES4ZLGxnAr3BJV1Oryg==}
     peerDependencies:
       '@icp-sdk/core': ^5
 
@@ -10077,7 +10082,13 @@ snapshots:
   '@icp-sdk/auth@7.1.0(@icp-sdk/core@6.0.0)':
     dependencies:
       '@icp-sdk/core': 6.0.0
-      '@icp-sdk/signer': 5.4.0(@icp-sdk/core@6.0.0)
+      '@icp-sdk/signer': 5.6.0(@icp-sdk/core@6.0.0)
+      idb: 7.1.1
+
+  '@icp-sdk/auth@8.0.0(@icp-sdk/core@6.0.0)':
+    dependencies:
+      '@icp-sdk/core': 6.0.0
+      '@icp-sdk/signer': 5.6.0(@icp-sdk/core@6.0.0)
       idb: 7.1.1
 
   '@icp-sdk/bindgen@0.4.0':
@@ -10093,7 +10104,7 @@ snapshots:
       '@scure/bip39': 2.2.0
       asn1js: 3.0.10
 
-  '@icp-sdk/signer@5.4.0(@icp-sdk/core@6.0.0)':
+  '@icp-sdk/signer@5.6.0(@icp-sdk/core@6.0.0)':
     dependencies:
       '@icp-sdk/core': 6.0.0
 
@@ -11876,6 +11887,14 @@ snapshots:
       '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3))':
     dependencies:
@@ -16408,6 +16427,20 @@ snapshots:
     dependencies:
       vite: 8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3)
 
+  vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.1
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      yaml: 2.8.3
+
   vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -16425,6 +16458,36 @@ snapshots:
   vitefu@1.1.3(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3)):
     optionalDependencies:
       vite: 8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3)
+
+  vitest@4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.1.1
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.10.6
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
## Why

The Internet Identity auth tests all `vi.mock("@icp-sdk/auth/client")`, so the real integration was never exercised. This PR adds a fake identity provider that speaks the actual **ICRC-29 / ICRC-34 / `ii-icrc3-attributes`** wire protocol over `postMessage`, and drives the **unmocked** `AuthClient` through it. Two production-breaking bugs surfaced immediately.

## Bugs fixed

### 1. Identity attribute requests could never open the II window in a browser

`IdentityAttributesManager.request()` began with `await this.authentication.ensureClient(...)`. That `await` ends the user gesture, and the ICRC-29 transport's `detectNonClickEstablishment` guard then refuses to open the window:

```
Signer window should not be opened outside of click handler
```

The feature was dead on arrival outside of mocked tests. The client is now resolved **synchronously** via a new `getPreparedClient()`, and `signIn` is invoked before `requestAttributes` so both share one transport channel and one popup.

Verified by reverting only that line — the new tests fail with exactly the error above.

### 2. `@icp-sdk/auth` v8 breaks identity attributes entirely

v8 changed the nonce contract:

```diff
-requestAttributes(params: { keys: string[]; nonce: Uint8Array | Promise<Uint8Array> })  // v7
+requestAttributes(params: { keys: string[]; nonce: () => Promise<Uint8Array> })          // v8
```

Passing a `Uint8Array` under v8 throws `TypeError: nonce is not a function`. Since the peer range was `^7.1.0`, this was waiting for the first person to upgrade.

The nonce is now normalized to whichever contract the installed client understands, detected **synchronously** (so the gesture chain survives) via the presence of `memoize`, which only exists from v8. The public `nonce` option accepts a value, a promise, **or a callback**, and the peer range widens to `^7.1.0 || ^8.0.0`.

## Other fixes

- **`derivationOrigin` was silently dropped.** `getAuthClientOptions` whitelisted three fields, so apps served from more than one origin (custom domain + `<canisterId>.icp0.io`) resolved to different principals with no way to correct it. Now forwards `derivationOrigin`, `storage`, `keyType`, `idleOptions`, `identity` and `transport` — which also makes the default idle behaviour (sign out + reload after 10 minutes) configurable for the first time.
- **A new `AuthClient` was built on every `prepareClient` / `login` / `ensureClient`.** `hasAuthClientOptions()` was always true because `identityProvider` is always defaulted, so `shouldRecreateClient()` always returned true. Every rebuild discarded the warmed-up client and registered another sign-out callback on the shared `IdleManager` **singleton**. Rebuilds now happen only when the effective options actually change.
- **Unhandled promise rejection** in `useAuth`'s mount effect (`authenticate()` re-throws and nothing caught it).
- **Query cache nuked on every mount.** `authenticate()` pushed the restored *anonymous* identity through `updateAgent`, invalidating every query in the app on each page load. Now skipped when the identity has not changed.

## DX

`defineReactor` had no auth story at all — every app hand-wrote the four-step `ClientManager` → `AuthenticationManager` → `createAuthHooks` → `createIdentityAttributeHooks` wiring. It now returns `useAuth`, `useUserPrincipal`, `useAgentState` and `useIdentityAttributes` alongside the actor hooks:

```ts
const { useActorQuery, useAuth, useIdentityAttributes } = defineReactor<_SERVICE>({
  name: "backend",
  idlFactory,
  auth: {
    derivationOrigin: "https://app.example.com",
    idleOptions: { disableIdle: true },
  },
})
```

Pass `authentication` from one reactor into another to share a single session across canisters. Auth is built **lazily**, so reactors that never touch it do not trigger the optional peer's dynamic import.

The README and the identity-attributes demo both documented `const nonce = await api.registerBegin()` *before* the request — the exact pattern that breaks the gesture chain. Both now show the callback form.

## Tests

New `packages/react/tests/auth/`:

- `fake-identity-provider.ts` — a fake II implementing ICRC-29 status handshake, ICRC-34 delegation (real `DelegationChain` signed by a real `Ed25519KeyIdentity`) and `ii-icrc3-attributes`, plus a `withUserGesture` helper that dispatches a real click so the transport's gesture guard is enforced.
- `internet-identity-integration.test.ts` — end-to-end sign-in, agent identity propagation, `maxTimeToLive`/`targets` forwarding, `onSuccess`/`onError`, session restore across a simulated page load, logout, popup-blocked failure, provider resolution, OpenID scoping, attribute decoding, and window-opens-before-async-nonce-resolves.
- `auth-client-compat.test.ts` — v7 vs v8 nonce contracts, option pass-through, client reuse, and the anonymous-restore cache behaviour.

`test-setup.ts` gains a guarded `localStorage` polyfill: the jsdom build in use exposes `localStorage` as a bare object with no methods, and `AuthClient.isAuthenticated()` reads the cached delegation expiry from it.

## Verification

- **991 tests passing** across all packages (react: 290, was 261)
- Verified green against **real `@icp-sdk/auth` 7.1.0 *and* 8.0.0** — the dev dependency now tracks v8
- `pnpm exec tsc --noEmit` clean · builds clean · all 20 examples type-check · prettier clean
- Size limits comfortable: react 7.31 kB / 30 kB, core 8.68 kB / 50 kB, candid 15.9 kB / 30 kB

## Notes

Two findings are **not** addressed here and are filed separately — the unfiltered `invalidateQueries()` in `ClientManager.updateAgent`, and the stale `@dfinity/*` pnpm overrides.

`@icp-sdk/auth` still declares `peerDependencies: { "@icp-sdk/core": "^5" }` upstream, so installs emit `unmet peer @icp-sdk/core@^5: found 6.0.0`. That is DFINITY's to fix; v8 works correctly against core 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
