### PR TITLE
fix: sync AI-context and example versions to the release, and gate it

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -7,8 +7,8 @@ It leverages **TanStack Query** for state management and caching, and the repo u
 
 ## Package Surface
 
-- Runtime lane (`3.7.0`): `@ic-reactor/core`, `@ic-reactor/react`, `@ic-reactor/candid`. Internet Identity auth ships inside `@ic-reactor/react` (`packages/react/src/auth/`); there is no separate auth package.
-- Codegen lane (`0.11.1`): `@ic-reactor/codegen`, `@ic-reactor/cli`, `@ic-reactor/vite-plugin`.
+- Runtime lane (`3.8.0`): `@ic-reactor/core`, `@ic-reactor/react`, `@ic-reactor/candid`. Internet Identity auth ships inside `@ic-reactor/react` (`packages/react/src/auth/`); there is no separate auth package.
+- Codegen lane (`0.12.0`): `@ic-reactor/codegen`, `@ic-reactor/cli`, `@ic-reactor/vite-plugin`.
 - Parser lane (`0.4.7`): `@ic-reactor/parser`.
 
 ## Core Principles

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,8 +5,8 @@ Follow these repository-specific patterns when suggesting code:
 ## Project Snapshot
 
 - This branch publishes the IC Reactor v3 documentation and release line.
-- Runtime packages are `@ic-reactor/core`, `@ic-reactor/react`, and `@ic-reactor/candid` at `3.7.0`.
-- Code generation packages are `@ic-reactor/codegen`, `@ic-reactor/cli`, and `@ic-reactor/vite-plugin` at `0.11.1`.
+- Runtime packages are `@ic-reactor/core`, `@ic-reactor/react`, and `@ic-reactor/candid` at `3.8.0`.
+- Code generation packages are `@ic-reactor/codegen`, `@ic-reactor/cli`, and `@ic-reactor/vite-plugin` at `0.12.0`.
 - The WASM parser package is `@ic-reactor/parser` at `0.4.7`.
 - Prefer `@icp-sdk/*` dependencies in examples and docs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,18 +8,18 @@ Treat the published documentation and package manifests as the v3 release line.
 
 ### Packages
 
-- `@ic-reactor/core` (`packages/core`, `3.7.0`) — core runtime, `ClientManager`, `Reactor`, `DisplayReactor`, cache integration.
-- `@ic-reactor/react` (`packages/react`, `3.7.0`) — React bindings, actor hooks, query/mutation factories, Internet Identity auth, and identity-attribute hooks.
-- `@ic-reactor/candid` (`packages/candid`, `3.7.0`) — dynamic Candid adapter/reactors and metadata reactors.
+- `@ic-reactor/core` (`packages/core`, `3.8.0`) — core runtime, `ClientManager`, `Reactor`, `DisplayReactor`, cache integration.
+- `@ic-reactor/react` (`packages/react`, `3.8.0`) — React bindings, actor hooks, query/mutation factories, Internet Identity auth, and identity-attribute hooks.
+- `@ic-reactor/candid` (`packages/candid`, `3.8.0`) — dynamic Candid adapter/reactors and metadata reactors.
 - `@ic-reactor/parser` (`packages/parser`, `0.4.7`) — Rust/WASM Candid parser.
-- `@ic-reactor/codegen` (`packages/codegen`, `0.11.1`) — shared generation pipeline used by CLI and Vite plugin.
-- `@ic-reactor/cli` (`packages/cli`, `0.11.1`) — `ic-reactor` CLI for explicit declaration/reactor generation.
-- `@ic-reactor/vite-plugin` (`packages/vite-plugin`, `0.11.1`) — Vite plugin for watch-mode generation and local `ic_env` injection.
+- `@ic-reactor/codegen` (`packages/codegen`, `0.12.0`) — shared generation pipeline used by CLI and Vite plugin.
+- `@ic-reactor/cli` (`packages/cli`, `0.12.0`) — `ic-reactor` CLI for explicit declaration/reactor generation.
+- `@ic-reactor/vite-plugin` (`packages/vite-plugin`, `0.12.0`) — Vite plugin for watch-mode generation and local `ic_env` injection.
 
 ### Package alignment rules
 
 - Describe published documentation as IC Reactor v3.
-- Keep package-specific docs aligned with the released v3.7.0 runtime and its published tooling.
+- Keep package-specific docs aligned with the released v3.8.0 runtime and its published tooling.
 - Prefer `@icp-sdk/*` package names in docs and examples.
 - Prefer `defineReactor(...)` for React setup; use `ClientManager` + `Reactor` + `createActorHooks` when explicit construction order is needed.
 - `createAuthHooks` takes an `AuthenticationManager`, not a `ClientManager`. `useIdentityAttributes` comes from `createIdentityAttributeHooks`, not `createAuthHooks`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,13 @@ This file provides context for Claude-based AI agents working in the IC Reactor 
 
 ### Core Packages
 
-- `@ic-reactor/core` (`packages/core`, `3.7.0`) — Core runtime, `ClientManager`, `Reactor`, `DisplayReactor`, cache integration
-- `@ic-reactor/react` (`packages/react`, `3.7.0`) — React bindings, actor hooks, query/mutation factories, Internet Identity auth, and identity-attribute hooks
-- `@ic-reactor/candid` (`packages/candid`, `3.7.0`) — Dynamic Candid adapter/reactors and metadata reactors
+- `@ic-reactor/core` (`packages/core`, `3.8.0`) — Core runtime, `ClientManager`, `Reactor`, `DisplayReactor`, cache integration
+- `@ic-reactor/react` (`packages/react`, `3.8.0`) — React bindings, actor hooks, query/mutation factories, Internet Identity auth, and identity-attribute hooks
+- `@ic-reactor/candid` (`packages/candid`, `3.8.0`) — Dynamic Candid adapter/reactors and metadata reactors
 - `@ic-reactor/parser` (`packages/parser`, `0.4.7`) — Rust/WASM Candid parser
-- `@ic-reactor/codegen` (`packages/codegen`, `0.11.1`) — Shared generation pipeline used by CLI and Vite plugin
-- `@ic-reactor/cli` (`packages/cli`, `0.11.1`) — `ic-reactor` CLI for explicit declaration/reactor generation
-- `@ic-reactor/vite-plugin` (`packages/vite-plugin`, `0.11.1`) — Vite plugin for watch-mode generation and local `ic_env` injection
+- `@ic-reactor/codegen` (`packages/codegen`, `0.12.0`) — Shared generation pipeline used by CLI and Vite plugin
+- `@ic-reactor/cli` (`packages/cli`, `0.12.0`) — `ic-reactor` CLI for explicit declaration/reactor generation
+- `@ic-reactor/vite-plugin` (`packages/vite-plugin`, `0.12.0`) — Vite plugin for watch-mode generation and local `ic_env` injection
 
 ## Package Ownership Map
 

--- a/examples/all-in-one-demo/package.json
+++ b/examples/all-in-one-demo/package.json
@@ -27,7 +27,7 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
-    "@ic-reactor/vite-plugin": "^0.11.1",
+    "@ic-reactor/vite-plugin": "^0.12.0",
     "@icp-sdk/bindgen": "^0.4.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/react": "^19.2.17",

--- a/examples/candid-codegen-playground/package.json
+++ b/examples/candid-codegen-playground/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@ic-reactor/cod": "workspace:*",
-    "@ic-reactor/codegen": "workspace:*",
-    "@ic-reactor/parser": "workspace:*"
+    "@ic-reactor/codegen": "^0.12.0",
+    "@ic-reactor/parser": "^0.4.7"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/examples/codegen-in-action/package.json
+++ b/examples/codegen-in-action/package.json
@@ -18,8 +18,8 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@ic-reactor/cli": "^0.11.1",
-    "@ic-reactor/vite-plugin": "^0.11.1",
+    "@ic-reactor/cli": "^0.12.0",
+    "@ic-reactor/vite-plugin": "^0.12.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.4",

--- a/examples/custom-provider/package.json
+++ b/examples/custom-provider/package.json
@@ -18,7 +18,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@ic-reactor/vite-plugin": "^0.11.1",
+    "@ic-reactor/vite-plugin": "^0.12.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.4",

--- a/examples/icp-reactor-demo/frontend/package.json
+++ b/examples/icp-reactor-demo/frontend/package.json
@@ -19,7 +19,7 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@ic-reactor/vite-plugin": "^0.11.1",
+    "@ic-reactor/vite-plugin": "^0.12.0",
     "@icp-sdk/bindgen": "^0.4.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/examples/identity-attributes-demo/package.json
+++ b/examples/identity-attributes-demo/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@ic-reactor/vite-plugin": "^0.11.1",
+    "@ic-reactor/vite-plugin": "^0.12.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.4",

--- a/examples/suspense-infinite-query-demo/package.json
+++ b/examples/suspense-infinite-query-demo/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@ic-reactor/react": "^3.8.0",
-    "@ic-reactor/vite-plugin": "0.11.1",
+    "@ic-reactor/vite-plugin": "^0.12.0",
     "@icp-sdk/core": "^6.0.0",
     "@tanstack/react-query": "^5.101",
     "@tanstack/react-query-devtools": "^5.101",

--- a/examples/tanstack-router/package.json
+++ b/examples/tanstack-router/package.json
@@ -27,7 +27,7 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
-    "@ic-reactor/vite-plugin": "^0.11.1",
+    "@ic-reactor/vite-plugin": "^0.12.0",
     "@tanstack/devtools-vite": "^0.8",
     "@tanstack/router-plugin": "^1.168",
     "@testing-library/dom": "^10.4.1",

--- a/examples/vite-plugin-demo/package.json
+++ b/examples/vite-plugin-demo/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@ic-reactor/vite-plugin": "^0.11.1",
+    "@ic-reactor/vite-plugin": "^0.12.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.4",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11,7 +11,7 @@ typed canister calls with TanStack Query caching, reusable query/mutation
 objects, React hooks, optional Internet Identity auth helpers, runtime Candid
 parsing, and code generation from `.did` files.
 
-This documentation targets the stable v3.7.0 runtime release.
+This documentation targets the stable v3.8.0 runtime release.
 
 ## Package Boundaries
 

--- a/llms.txt
+++ b/llms.txt
@@ -13,7 +13,7 @@ Repository: `https://github.com/B3Pay/ic-reactor`
 Docs: `https://ic-reactor.b3pay.net/v3/`
 
 Release posture: the published documentation and package manifests target the
-stable v3.7.0 runtime release.
+stable v3.8.0 runtime release.
 
 ## Package Versions
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,8 +231,8 @@ importers:
         version: 3.6.0
     devDependencies:
       '@ic-reactor/vite-plugin':
-        specifier: ^0.11.1
-        version: 0.11.1(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3))
+        specifier: ^0.12.0
+        version: link:../../packages/vite-plugin
       '@icp-sdk/bindgen':
         specifier: ^0.4.0
         version: 0.4.0
@@ -270,10 +270,10 @@ importers:
         specifier: workspace:*
         version: link:../../packages/cod
       '@ic-reactor/codegen':
-        specifier: workspace:*
+        specifier: ^0.12.0
         version: link:../../packages/codegen
       '@ic-reactor/parser':
-        specifier: workspace:*
+        specifier: ^0.4.7
         version: link:../../packages/parser
     devDependencies:
       typescript:
@@ -395,11 +395,11 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@ic-reactor/cli':
-        specifier: ^0.11.1
-        version: 0.11.1
+        specifier: ^0.12.0
+        version: link:../../packages/cli
       '@ic-reactor/vite-plugin':
-        specifier: ^0.11.1
-        version: 0.11.1(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3))
+        specifier: ^0.12.0
+        version: link:../../packages/vite-plugin
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -441,8 +441,8 @@ importers:
         version: 6.0.3
     devDependencies:
       '@ic-reactor/vite-plugin':
-        specifier: ^0.11.1
-        version: 0.11.1(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3))
+        specifier: ^0.12.0
+        version: link:../../packages/vite-plugin
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -487,8 +487,8 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@ic-reactor/vite-plugin':
-        specifier: ^0.11.1
-        version: 0.11.1(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3))
+        specifier: ^0.12.0
+        version: link:../../../packages/vite-plugin
       '@icp-sdk/bindgen':
         specifier: ^0.4.0
         version: 0.4.0
@@ -530,8 +530,8 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@ic-reactor/vite-plugin':
-        specifier: ^0.11.1
-        version: 0.11.1(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3))
+        specifier: ^0.12.0
+        version: link:../../packages/vite-plugin
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -816,8 +816,8 @@ importers:
         specifier: ^3.8.0
         version: link:../../packages/react
       '@ic-reactor/vite-plugin':
-        specifier: 0.11.1
-        version: 0.11.1(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3))
+        specifier: ^0.12.0
+        version: link:../../packages/vite-plugin
       '@icp-sdk/core':
         specifier: ^6.0.0
         version: 6.0.0
@@ -948,8 +948,8 @@ importers:
         version: 1.4.0
     devDependencies:
       '@ic-reactor/vite-plugin':
-        specifier: ^0.11.1
-        version: 0.11.1(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3))
+        specifier: ^0.12.0
+        version: link:../../packages/vite-plugin
       '@tanstack/devtools-vite':
         specifier: ^0.8
         version: 0.8.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3))
@@ -1083,8 +1083,8 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@ic-reactor/vite-plugin':
-        specifier: ^0.11.1
-        version: 0.11.1(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.8.3))
+        specifier: ^0.12.0
+        version: link:../../packages/vite-plugin
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -2673,11 +2673,6 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@ic-reactor/cli@0.11.1':
-    resolution: {integrity: sha512-Ms7ns8uv1QqNn11z1ZQ+5LjwaukxDL3G9INxWKpcdSdP93veRFHUIVO59fmOJaBWdl26cbNMB8e0v2kQXxDzZw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   '@ic-reactor/codegen@0.11.1':
     resolution: {integrity: sha512-VEfRi5xPQj7K9QLPSxy+HLPeeIdkiazIDITLPal7+BpKMnw27vFbsKAa+r+PPOMbEWCA0ft1VgrBwzc0ZuWWGA==}
 
@@ -2699,16 +2694,9 @@ packages:
     peerDependencies:
       '@icp-sdk/core': ^5
 
-  '@icp-sdk/bindgen@0.3.0':
-    resolution: {integrity: sha512-yRG0EnzhmmsErGSrSGG2HGQIhf2u4FYs8DjLNd06B3WJ735Tx3sxyDxmWKHTqLKrniQSvAFErRKqJWwwpYdfVQ==}
-    hasBin: true
-
   '@icp-sdk/bindgen@0.4.0':
     resolution: {integrity: sha512-WXJoPIVnqCgFSNcprVpHwPBNWA1prwPh1/ezQYVrCP+Zj8CCJ7zj9L7p5cFcN7ghxoxfbx6tYT8t/HN9fyeYkA==}
     hasBin: true
-
-  '@icp-sdk/core@5.4.0':
-    resolution: {integrity: sha512-yedhCkHIhCxI65W8id99Mi8fUgSyqKSTbD57AphquNcFV2/3Rjykng0/6H08mHswKydDcv6Y0+e8aPdrznewCw==}
 
   '@icp-sdk/core@6.0.0':
     resolution: {integrity: sha512-z+oHm+MTB/Xo27LQCYXDpVcUyFQwceupoyqkYCW6aaiZ2GJ1BvhRbSMsm7XDHAgCuZmWULPxpiTFUnHZLDEKzw==}
@@ -3234,17 +3222,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@noble/curves@1.9.7':
-    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
-    engines: {node: ^14.21.3 || >=16}
-
   '@noble/curves@2.2.0':
     resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
     engines: {node: '>= 20.19.0'}
-
-  '@noble/hashes@1.8.0':
-    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
-    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@2.2.0':
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
@@ -4007,20 +3987,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@scure/base@1.2.6':
-    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
-
   '@scure/base@2.2.0':
     resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
 
-  '@scure/bip32@1.7.0':
-    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
-
   '@scure/bip32@2.2.0':
     resolution: {integrity: sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==}
-
-  '@scure/bip39@1.6.0':
-    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@scure/bip39@2.2.0':
     resolution: {integrity: sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==}
@@ -10092,15 +10063,6 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@ic-reactor/cli@0.11.1':
-    dependencies:
-      '@clack/prompts': 1.7.0
-      '@ic-reactor/codegen': 0.11.1
-      '@icp-sdk/bindgen': 0.3.0
-      '@icp-sdk/core': 5.4.0
-      commander: 14.0.3
-      picocolors: 1.1.1
-
   '@ic-reactor/codegen@0.11.1':
     dependencies:
       '@ic-reactor/parser': 0.4.6
@@ -10125,22 +10087,9 @@ snapshots:
       '@icp-sdk/signer': 5.6.0(@icp-sdk/core@6.0.0)
       idb: 7.1.1
 
-  '@icp-sdk/bindgen@0.3.0':
-    dependencies:
-      commander: 14.0.3
-
   '@icp-sdk/bindgen@0.4.0':
     dependencies:
       commander: 14.0.3
-
-  '@icp-sdk/core@5.4.0':
-    dependencies:
-      '@dfinity/cbor': 0.2.3
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      asn1js: 3.0.10
 
   '@icp-sdk/core@6.0.0':
     dependencies:
@@ -10686,15 +10635,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.12':
     optional: true
 
-  '@noble/curves@1.9.7':
-    dependencies:
-      '@noble/hashes': 1.8.0
-
   '@noble/curves@2.2.0':
     dependencies:
       '@noble/hashes': 2.2.0
-
-  '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.2.0': {}
 
@@ -11172,26 +11115,13 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
-  '@scure/base@1.2.6': {}
-
   '@scure/base@2.2.0': {}
-
-  '@scure/bip32@1.7.0':
-    dependencies:
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.6
 
   '@scure/bip32@2.2.0':
     dependencies:
       '@noble/curves': 2.2.0
       '@noble/hashes': 2.2.0
       '@scure/base': 2.2.0
-
-  '@scure/bip39@1.6.0':
-    dependencies:
-      '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.6
 
   '@scure/bip39@2.2.0':
     dependencies:

--- a/scripts/check-ai-context.js
+++ b/scripts/check-ai-context.js
@@ -50,6 +50,16 @@ const aiContextFiles = [
 /** The docs site is served under this base; see docs/astro.config.mjs. */
 const DOCS_BASE = "/v3/"
 
+/**
+ * Versions that legitimately appear in the AI-context files without belonging to
+ * an @ic-reactor package (a documented Node or pnpm version, for example).
+ *
+ * Deliberately starts empty: every version-like token in these files today is an
+ * @ic-reactor version, so anything else is drift until someone says otherwise.
+ * Adding an entry here is the explicit way to say "this one is not ours".
+ */
+const ALLOWED_EXTERNAL_VERSIONS = new Set([])
+
 const llmsPath = join(rootDir, "llms.txt")
 const llmsText = readFileSync(llmsPath, "utf8")
 
@@ -84,10 +94,18 @@ for (const packageDir of requiredPackageLlms) {
 }
 
 // ── 3. No stale version anywhere in the AI-context files ─────────────────────
-// Every semver-looking token in these files refers to an @ic-reactor package, so
-// any token that is not a current package version is stale prose. This is what
-// catches a release that bumps the manifests but leaves the guidance behind.
-const SEMVER = /`v?(\d+\.\d+\.\d+)`|(?<![\w.])v(\d+\.\d+\.\d+)(?![\w.])/g
+// Matches every semver-shaped token regardless of how it is written: backticked,
+// `v`-prefixed, or bare in prose. An earlier version of this check only matched
+// the first two forms, so a stale bare "3.7.0" in a sentence passed silently --
+// which defeats the point, since prose is exactly where these versions rot.
+//
+// The lookarounds keep it from matching a fragment of a longer dotted number
+// (1.2.3.4) while still allowing a version at the end of a sentence ("v3.8.0.").
+const SEMVER = /(?<![\d.])v?(\d+\.\d+\.\d+)(?![\d.]\d)/g
+
+// Any /vN/ path segment, not just one inside markdown link syntax -- the same
+// narrowness bug as above.
+const VERSIONED_DOC_PATH = /\/v\d+\//g
 
 for (const relPath of aiContextFiles) {
   const absPath = join(rootDir, relPath)
@@ -98,28 +116,25 @@ for (const relPath of aiContextFiles) {
   const text = readFileSync(absPath, "utf8")
 
   text.split("\n").forEach((line, i) => {
-    for (const match of line.matchAll(SEMVER)) {
-      const version = match[1] ?? match[2]
-      if (!validVersions.has(version)) {
-        failures.push(
-          `${relPath}:${i + 1} refers to version ${version}, which no @ic-reactor package is at. ` +
-            `Current: ${[...currentVersions]
-              .map(([n, v]) => `${n}@${v}`)
-              .join(", ")}`
-        )
-      }
+    for (const [, version] of line.matchAll(SEMVER)) {
+      if (validVersions.has(version)) continue
+      if (ALLOWED_EXTERNAL_VERSIONS.has(version)) continue
+
+      failures.push(
+        `${relPath}:${i + 1} refers to version ${version}, which no @ic-reactor package is at. ` +
+          `Current: ${[...currentVersions].map(([n, v]) => `${n}@${v}`).join(", ")}. ` +
+          `If this version is not an @ic-reactor package, add it to ` +
+          `ALLOWED_EXTERNAL_VERSIONS in scripts/check-ai-context.js.`
+      )
     }
 
     // 4. Doc links must use the served base. /v4/ was never published and the
     //    docs workflow deletes it on every deploy, so such links 404.
-    if (line.includes("ic-reactor.b3pay.net/v") || line.includes("](/v")) {
-      const bad = line.match(/\/v(\d+)\//g) ?? []
-      for (const seg of bad) {
-        if (seg !== DOCS_BASE) {
-          failures.push(
-            `${relPath}:${i + 1} links to ${seg} but the docs site is served under ${DOCS_BASE}`
-          )
-        }
+    for (const seg of line.match(VERSIONED_DOC_PATH) ?? []) {
+      if (seg !== DOCS_BASE) {
+        failures.push(
+          `${relPath}:${i + 1} references ${seg} but the docs site is served under ${DOCS_BASE}`
+        )
       }
     }
   })

--- a/scripts/check-ai-context.js
+++ b/scripts/check-ai-context.js
@@ -24,15 +24,49 @@ const requiredPackageLlms = [
   "vite-plugin",
 ]
 
+/**
+ * Files whose whole purpose is to orient an AI agent. They are the "package
+ * surface" source of truth, so a stale version here steers agents (and the
+ * humans reading their output) at a release that is no longer current.
+ *
+ * Until this check covered them, only the version table in the root llms.txt was
+ * validated, so a release could bump every manifest and leave all of these
+ * claiming the previous version with the gate still green.
+ */
+const aiContextFiles = [
+  "llms.txt",
+  "llms-full.txt",
+  "AGENTS.md",
+  "CLAUDE.md",
+  ".cursorrules",
+  ".github/copilot-instructions.md",
+  "skill-packages/README.md",
+  "skill-packages/ic-reactor-hooks/SKILL.md",
+  "skill-packages/ic-reactor-packages/SKILL.md",
+  "skill-packages/ic-reactor-packages/references/package-map.md",
+  ...requiredPackageLlms.map((dir) => `packages/${dir}/llms.txt`),
+]
+
+/** The docs site is served under this base; see docs/astro.config.mjs. */
+const DOCS_BASE = "/v3/"
+
 const llmsPath = join(rootDir, "llms.txt")
 const llmsText = readFileSync(llmsPath, "utf8")
 
 const failures = []
 
+// ── Current package versions ─────────────────────────────────────────────────
+const currentVersions = new Map()
 for (const { packageName, packageDir } of versionChecks) {
   const pkgPath = join(rootDir, "packages", packageDir, "package.json")
   const pkg = JSON.parse(readFileSync(pkgPath, "utf8"))
-  const expectedLine = `- \`${packageName}\`: \`${pkg.version}\``
+  currentVersions.set(packageName, pkg.version)
+}
+const validVersions = new Set(currentVersions.values())
+
+// ── 1. The root llms.txt version table ───────────────────────────────────────
+for (const { packageName } of versionChecks) {
+  const expectedLine = `- \`${packageName}\`: \`${currentVersions.get(packageName)}\``
 
   if (!llmsText.includes(expectedLine)) {
     failures.push(
@@ -41,11 +75,54 @@ for (const { packageName, packageDir } of versionChecks) {
   }
 }
 
+// ── 2. Every package ships an AI guide ───────────────────────────────────────
 for (const packageDir of requiredPackageLlms) {
   const packageLlmsPath = join(rootDir, "packages", packageDir, "llms.txt")
   if (!existsSync(packageLlmsPath)) {
     failures.push(`Missing package AI guide: packages/${packageDir}/llms.txt`)
   }
+}
+
+// ── 3. No stale version anywhere in the AI-context files ─────────────────────
+// Every semver-looking token in these files refers to an @ic-reactor package, so
+// any token that is not a current package version is stale prose. This is what
+// catches a release that bumps the manifests but leaves the guidance behind.
+const SEMVER = /`v?(\d+\.\d+\.\d+)`|(?<![\w.])v(\d+\.\d+\.\d+)(?![\w.])/g
+
+for (const relPath of aiContextFiles) {
+  const absPath = join(rootDir, relPath)
+  if (!existsSync(absPath)) {
+    failures.push(`Missing AI-context file: ${relPath}`)
+    continue
+  }
+  const text = readFileSync(absPath, "utf8")
+
+  text.split("\n").forEach((line, i) => {
+    for (const match of line.matchAll(SEMVER)) {
+      const version = match[1] ?? match[2]
+      if (!validVersions.has(version)) {
+        failures.push(
+          `${relPath}:${i + 1} refers to version ${version}, which no @ic-reactor package is at. ` +
+            `Current: ${[...currentVersions]
+              .map(([n, v]) => `${n}@${v}`)
+              .join(", ")}`
+        )
+      }
+    }
+
+    // 4. Doc links must use the served base. /v4/ was never published and the
+    //    docs workflow deletes it on every deploy, so such links 404.
+    if (line.includes("ic-reactor.b3pay.net/v") || line.includes("](/v")) {
+      const bad = line.match(/\/v(\d+)\//g) ?? []
+      for (const seg of bad) {
+        if (seg !== DOCS_BASE) {
+          failures.push(
+            `${relPath}:${i + 1} links to ${seg} but the docs site is served under ${DOCS_BASE}`
+          )
+        }
+      }
+    }
+  })
 }
 
 if (failures.length > 0) {
@@ -56,4 +133,6 @@ if (failures.length > 0) {
   process.exit(1)
 }
 
-console.log("AI context check passed.")
+console.log(
+  `AI context check passed (${aiContextFiles.length} files, versions: ${[...validVersions].join(", ")}).`
+)

--- a/scripts/sync-example-versions.js
+++ b/scripts/sync-example-versions.js
@@ -118,14 +118,14 @@ for (const pkgPath of packageJsonFiles) {
     let modified = false
 
     for (const pkgName of packages) {
-      if (
-        cliVersion &&
-        cliVersion !== "workspace" &&
-        !runtimePackages.has(pkgName)
-      ) {
-        continue
-      }
-
+      // Every @ic-reactor dependency is synced, including the independently
+      // versioned tooling lane. targetVersionFor() already keeps the lanes
+      // apart -- it only applies the CLI-supplied version to runtime packages
+      // and reads every other package's version from its own manifest. Skipping
+      // non-runtime packages here as well meant nothing ever synced the tooling
+      // lane into the examples: release-tools.js does not run this script at
+      // all, so examples stayed pinned to the previous tools release and
+      // external sandboxes (StackBlitz/CodeSandbox) installed stale plugins.
       const targetVersion = targetVersionFor(pkgName)
 
       // Check dependencies

--- a/skill-packages/README.md
+++ b/skill-packages/README.md
@@ -5,8 +5,8 @@ This directory contains AI agent skill packages for the IC Reactor v3 project. S
 ## Repository Package Surface
 
 - This branch is the stable v3 release line and should be described as IC Reactor v3.
-- Runtime packages: `@ic-reactor/core`, `@ic-reactor/react`, and `@ic-reactor/candid` (`3.7.0`).
-- Code generation packages: `@ic-reactor/codegen`, `@ic-reactor/cli`, and `@ic-reactor/vite-plugin` (`0.11.1`).
+- Runtime packages: `@ic-reactor/core`, `@ic-reactor/react`, and `@ic-reactor/candid` (`3.8.0`).
+- Code generation packages: `@ic-reactor/codegen`, `@ic-reactor/cli`, and `@ic-reactor/vite-plugin` (`0.12.0`).
 - Parser package: `@ic-reactor/parser` (`0.4.7`).
 - Shared AI package summary: [`../llms.txt`](../llms.txt).
 


### PR DESCRIPTION
Addresses the Copilot review on the already-merged #231. **Both findings were right**, and the second exposed a bug older than that PR. Worth landing before the release tags are pushed.

## 1. AI-context files still claimed the previous release

`AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md` and `skill-packages/README.md` all still stated runtime **3.7.0** and tools **0.11.1**. `llms.txt` was internally contradictory — its "Release posture" sentence said v3.7.0 while its version table three lines below said 3.8.0.

These files are the package-surface source of truth for agents, so publishing 3.8.0 with every one of them naming 3.7.0 is exactly the drift #219 catalogued.

**`check:ai-context` passed the entire time** — it only validated the version *table* in the root `llms.txt`, not the prose in that same file and none of the other five. I flagged that gap when closing #219 and then walked straight into it.

### The gate now covers what it claims to

It reads current versions from the manifests and asserts:

- every semver token across **16** AI-context files matches a current package version;
- no doc link uses a base other than the served `/v3/` — the other recurring drift from #219, since `/v4/` is deleted on every docs deploy.

Every version-like token in those files refers to an `@ic-reactor` package, so the rule is strict without false positives, and failures name `file:line`:

```
- AGENTS.md:11 refers to version 3.7.0, which no @ic-reactor package is at.
- CLAUDE.md:125 links to /v4/ but the docs site is served under /v3/
```

**On its first run it caught a file neither the review nor I had spotted:** `llms-full.txt` also targeted "the stable v3.7.0 runtime release". It wasn't in #231's diff, so nothing had reason to look at it.

I verified both new checks by reintroducing the drift — they fail, and pass once reverted. (I've been bitten this session by a "negative test" that silently no-op'd, so I no longer trust one that hasn't been seen to fail.)

## 2. Examples pinned the previous tools lane

Nine examples pinned `@ic-reactor/vite-plugin` and `@ic-reactor/cli` at `^0.11.1` while this release cuts 0.12.0. In-repo they resolve through workspace links so nothing failed — but external sandboxes (StackBlitz/CodeSandbox) install from npm and would have picked up the superseded plugin.

**Root cause, and it predates #231:** nothing ever synced the tooling lane. `release-tools.js` doesn't call `sync:examples` at all, and `sync-example-versions.js` skipped every non-runtime package whenever a version argument was supplied:

```js
if (cliVersion && cliVersion !== "workspace" && !runtimePackages.has(pkgName)) {
  continue
}
```

That guard was redundant. `targetVersionFor()` already keeps the lanes apart — it applies the supplied version *only* to runtime packages and reads every other package's version from its own manifest. Removing the guard fixes both scripts at once, with no risk of stamping a runtime version onto the tooling lane. Nine examples now sync to `^0.12.0` / `^0.4.7`.

One deliberate side effect: `candid-codegen-playground` had `workspace:*` for codegen/parser (it was the only example the guard had ever skipped entirely) and is now pinned like its siblings. Confirmed it still symlinks to the local packages after `pnpm install`.

`vite-environment-variables/frontend` is still skipped — it carries an npm lockfile, which cannot resolve a version until it's published. That's existing intended behaviour, handled by the post-publish example sync.

## Verification

| Gate | Result |
| --- | --- |
| `check:ai-context` | pass — 16 files, versions 3.8.0 / 0.12.0 / 0.4.7 |
| `typecheck` | 0 errors |
| `typecheck:examples` | 21/21 |
| `format:check` | pass |
| `pnpm install --frozen-lockfile` | clean; workspace links intact |

## Release status

No tags pushed yet — the three release tags should be cut from the merge commit of *this* PR rather than #231's, so the published tree matches the AI-context files.

---
_Generated by [Claude Code](https://claude.ai/code/session_0169aK9fYvvvZo5R5RsGuhu8)_