### PR TITLE
fix(ci): stop the shared release concurrency group from dropping a release

### DIFF
--- a/.github/workflows/release-tools.yml
+++ b/.github/workflows/release-tools.yml
@@ -10,7 +10,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-npm
+  # Keyed per tag, NOT per lane. A shared group serialises publishes, but GitHub
+  # keeps only ONE run pending per group: when a third run arrives, the run that
+  # was already waiting is cancelled outright. Pushing parser-v*, tools-v* and v*
+  # back to back therefore silently dropped the middle release.
+  #
+  # Ordering across lanes is enforced where it actually matters instead -- the
+  # release-tools matrix publishes parser before its dependents with
+  # max-parallel: 1 and fail-fast: true, and codegen's pinned parser version is
+  # asserted to exist on npm before it publishes.
+  group: release-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -126,6 +135,25 @@ jobs:
           set -euo pipefail
           PACKAGE_NAME=$(node -p "require('./package.json').name")
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          # pnpm pack rewrites `workspace:*` to an EXACT version, so a dependency
+          # that is not yet on the registry makes this package permanently
+          # uninstallable -- npm versions are immutable, so recovery means bumping
+          # everything again. The matrix orders parser first, but that only holds
+          # within a single run; assert it rather than assume it.
+          for DEP in $(node -p "
+            const d = require('./package.json').dependencies || {};
+            Object.keys(d).filter((k) => k.startsWith('@ic-reactor/')).join('\n')
+          "); do
+            DEP_DIR="${DEP#@ic-reactor/}"
+            DEP_VERSION=$(node -p "require('${GITHUB_WORKSPACE}/packages/${DEP_DIR}/package.json').version")
+            if ! npm view "${DEP}@${DEP_VERSION}" version > /dev/null 2>&1; then
+              echo "::error::$PACKAGE_NAME depends on ${DEP}@${DEP_VERSION}, which is not on npm."
+              echo "::error::Publishing now would ship a package nobody can install. Release ${DEP} first."
+              exit 1
+            fi
+            echo "dependency ${DEP}@${DEP_VERSION} is on npm"
+          done
 
           echo "Checking if $PACKAGE_NAME@$PACKAGE_VERSION exists on npm..."
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-npm
+  # Keyed per tag, NOT per lane. A shared group serialises publishes, but GitHub
+  # keeps only ONE run pending per group: when a third run arrives, the run that
+  # was already waiting is cancelled outright. Pushing parser-v*, tools-v* and v*
+  # back to back therefore silently dropped the middle release.
+  #
+  # Ordering across lanes is enforced where it actually matters instead -- the
+  # release-tools matrix publishes parser before its dependents with
+  # max-parallel: 1 and fail-fast: true, and codegen's pinned parser version is
+  # asserted to exist on npm before it publishes.
+  group: release-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
**This explains the "nothing happened" on the v3.8.0 release — it wasn't nothing, it was one release silently cancelled.** Not urgent to merge (the current release can be recovered with a re-run), but it will bite again on the next one.

## What happened

Pushing the three tags back to back produced:

| tag | time | result |
| --- | --- | --- |
| `parser-v0.4.7` | 14:34:56 | ✅ success — **published, and `latest` moved off the stranded 0.4.5** |
| `tools-v0.12.0` | 14:34:59 | ❌ **cancelled** |
| `v3.8.0` | 14:35:03 | 🔄 in progress |

Both release workflows declared `concurrency: group: release-npm` — my change, added to serialise publishes so two tag pushes could not race on the same dist-tag (#224). The intent was right. The mechanism was not:

**GitHub keeps only ONE run pending per concurrency group.** When a third run arrives, whatever was already waiting is cancelled outright.

```
14:34:56  parser-v0.4.7  -> running (holds release-npm)
14:34:59  tools-v0.12.0  -> pending
14:35:03  v3.8.0         -> arrives, takes the single pending slot,
                            cancelling tools-v0.12.0
```

The evicted run reports as **cancelled**, not failed — so a mechanism added to make releases *safer* instead made one disappear quietly. Same shape as the other silent-pass defects this branch has been fixing: the zero-file `tsc` gate, the no-op type-guard injection, `check:ai-context` validating one file while five drifted.

## The fix

Concurrency is now keyed **per tag** — `release-${{ github.ref_name }}` — so no release can ever evict another.

That removes the implicit cross-lane ordering the shared group provided, so the ordering requirement is now enforced where it actually matters rather than assumed. Before publishing, each tools package asserts that every `@ic-reactor` dependency it pins is already on the registry:

```
::error::@ic-reactor/codegen depends on @ic-reactor/parser@0.4.7, which is not on npm.
::error::Publishing now would ship a package nobody can install. Release @ic-reactor/parser first.
```

That assertion is the one that counts. `pnpm pack` rewrites `workspace:*` to an **exact** version, so publishing codegen before parser exists ships a permanently uninstallable package — npm versions are immutable, so recovery means bumping the whole lane again. The matrix already orders parser first, but that only holds *within* a single run; across tags it was nothing but operator discipline.

## Verification

- Both workflows parse as valid YAML.
- The dependency guard passes for `codegen` against the now-published `@ic-reactor/parser@0.4.7`, and blocks on a version that does not exist. Both paths exercised, not just the happy one.

## Recovering the current release

No code change needed — re-run the cancelled `tools-v0.12.0` workflow once `v3.8.0` finishes. The tag already points at the right commit, and the parser leg will skip itself (0.4.7 is published), so codegen/vite-plugin/cli publish normally.

---
_Generated by [Claude Code](https://claude.ai/code/session_0169aK9fYvvvZo5R5RsGuhu8)_