### PR TITLE
fix(react): scope the ic_env identity provider to non-mainnet networks

### DIFF
--- a/packages/react/src/auth/authentication-manager.ts
+++ b/packages/react/src/auth/authentication-manager.ts
@@ -6,8 +6,9 @@ import type {
   AuthenticationClientOptions,
   AuthenticationSignInOptions,
 } from "./types.js"
-import { ClientManager, isDev } from "@ic-reactor/core"
+import { ClientManager, isDev, isMainnetHost } from "@ic-reactor/core"
 
+import { Principal } from "@icp-sdk/core/principal"
 import { safeGetCanisterEnv } from "@icp-sdk/core/agent/canister-env"
 import {
   IC_INTERNET_IDENTITY_PROVIDER,
@@ -80,13 +81,18 @@ export class AuthenticationManager {
       typeof window !== "undefined" ? getAuthenticationCanisterEnv() : undefined
     this.identityProvider =
       identityProvider ||
-      canisterEnv?.[INTERNET_IDENTITY_PROVIDER_ENV_KEY] ||
-      canisterEnv?.["PUBLIC_INTERNET_IDENTITY_PROVIDER"]
+      acceptEnvIdentityProvider(
+        canisterEnv?.[INTERNET_IDENTITY_PROVIDER_ENV_KEY] ||
+          canisterEnv?.["PUBLIC_INTERNET_IDENTITY_PROVIDER"],
+        clientManager
+      )
     this.internetIdentityId =
       internetIdentityId ||
-      canisterEnv?.["internet_identity"] ||
-      canisterEnv?.["PUBLIC_CANISTER_ID:internet_identity"] ||
-      canisterEnv?.["CANISTER_ID_INTERNET_IDENTITY"]
+      acceptEnvCanisterId(
+        canisterEnv?.["internet_identity"] ||
+          canisterEnv?.["PUBLIC_CANISTER_ID:internet_identity"] ||
+          canisterEnv?.["CANISTER_ID_INTERNET_IDENTITY"]
+      )
     this.defaultClientOptions = clientOptions
 
     if (authClient) {
@@ -543,6 +549,80 @@ function isSameAuthClientOptions(
     current.identity === next.identity &&
     current.transport === next.transport
   )
+}
+
+/**
+ * Decides whether an Internet Identity provider carried by the `ic_env` cookie
+ * may be used.
+ *
+ * The cookie is written by the replica serving a local or testnet deployment,
+ * and it is only authoritative in that setting: cookies are not origin-isolated
+ * the way script-accessible storage is, so on a mainnet deployment the identity
+ * provider is configuration that belongs in code rather than something read
+ * back out of the environment at runtime. `AuthClient` treats `identityProvider`
+ * as trusted developer configuration and does not re-check it.
+ *
+ * This mirrors the root-key guard in `ClientManager` (see `packages/core`):
+ * both values arrive from the same cookie and get the same treatment — adopted
+ * off-mainnet, ignored on mainnet in favour of the pinned default.
+ *
+ * A provider on the app's own origin is always accepted: it is exactly as
+ * trustworthy as the page doing the asking. Callers that need a custom provider
+ * on mainnet pass `identityProvider` explicitly.
+ */
+function acceptEnvIdentityProvider(
+  value: string | undefined,
+  clientManager: ClientManager
+): string | undefined {
+  if (!value) return undefined
+
+  const pageOrigin =
+    typeof window !== "undefined" ? window.location?.origin : undefined
+
+  let url: URL
+  try {
+    url = new URL(value, pageOrigin)
+  } catch {
+    return undefined
+  }
+
+  if (pageOrigin && url.origin === pageOrigin) {
+    return url.toString()
+  }
+
+  // `isMainnetHost` matches only the real boundary domains and defaults to true
+  // for an unknown host, so custom testnets keep working while anything that
+  // looks like mainnet fails closed. `clientManager.isLocal` would be wrong
+  // here: it treats every unrecognized hostname as "ic".
+  if (isMainnetHost(clientManager.agentHost?.toString())) {
+    console.warn(
+      `[ic-reactor] Ignoring the Internet Identity provider from the ic_env cookie ` +
+        `("${url.origin}") because this reactor targets mainnet, where the provider ` +
+        `is taken from configuration rather than the environment. Pass ` +
+        `\`identityProvider\` to AuthenticationManager to use a custom provider on mainnet.`
+    )
+    return undefined
+  }
+
+  return url.toString()
+}
+
+/**
+ * Accepts an Internet Identity canister ID from `ic_env` only when it parses as
+ * a principal.
+ *
+ * The value is interpolated into a provider URL
+ * (`http://<id>.localhost:<port>/authorize`), so anything that is not a bare
+ * principal can change the shape of that URL rather than just its subdomain.
+ * Only reachable on local networks, since mainnet uses the pinned provider.
+ */
+function acceptEnvCanisterId(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  try {
+    return Principal.fromText(value).toText()
+  } catch {
+    return undefined
+  }
 }
 
 function getAuthenticationCanisterEnv(): Record<string, string> | undefined {

--- a/packages/react/tests/auth/authentication-manager.test.ts
+++ b/packages/react/tests/auth/authentication-manager.test.ts
@@ -311,4 +311,121 @@ describe("AuthenticationManager", () => {
       openIdProvider: undefined,
     })
   })
+
+  describe("ic_env identity provider is scoped to non-mainnet networks", () => {
+    function mainnetManager() {
+      const manager = new ClientManager({
+        queryClient: new QueryClient(),
+        agentOptions: { host: "https://icp-api.io" },
+      })
+      vi.spyOn(manager, "initializeAgent").mockResolvedValue()
+      return manager
+    }
+
+    it("ignores a cross-origin provider from the ic_env cookie", async () => {
+      // On mainnet the provider comes from configuration, not the environment,
+      // matching how ClientManager treats the cookie's root key.
+      vi.stubGlobal("window", {
+        location: { origin: "https://app.example.com" },
+      })
+      vi.stubGlobal("document", {
+        cookie:
+          "ic_env=INTERNET_IDENTITY_PROVIDER%3Dhttps%3A%2F%2Fother.example%2Fauthorize",
+      })
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+      const authClient = createAuthClient()
+      const AuthClient = mockAuthClientModule(authClient)
+
+      const authentication = new AuthenticationManager({
+        clientManager: mainnetManager(),
+      })
+      await authentication.login()
+
+      expect(AuthClient).toHaveBeenCalledWith({
+        identityProvider: "https://id.ai/authorize",
+        windowOpenerFeatures: undefined,
+        openIdProvider: undefined,
+      })
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("https://other.example")
+      )
+      warn.mockRestore()
+    })
+
+    it("still accepts a same-origin provider from the ic_env cookie", async () => {
+      vi.stubGlobal("window", {
+        location: { origin: "https://app.example.com" },
+      })
+      vi.stubGlobal("document", {
+        cookie:
+          "ic_env=INTERNET_IDENTITY_PROVIDER%3Dhttps%3A%2F%2Fapp.example.com%2Fauthorize",
+      })
+      const authClient = createAuthClient()
+      const AuthClient = mockAuthClientModule(authClient)
+
+      const authentication = new AuthenticationManager({
+        clientManager: mainnetManager(),
+      })
+      await authentication.login()
+
+      expect(AuthClient).toHaveBeenCalledWith({
+        identityProvider: "https://app.example.com/authorize",
+        windowOpenerFeatures: undefined,
+        openIdProvider: undefined,
+      })
+    })
+
+    it("keeps an explicitly configured provider, which is never cookie-sourced", async () => {
+      vi.stubGlobal("window", {
+        location: { origin: "https://app.example.com" },
+      })
+      vi.stubGlobal("document", {
+        cookie:
+          "ic_env=INTERNET_IDENTITY_PROVIDER%3Dhttps%3A%2F%2Fother.example%2Fauthorize",
+      })
+      const authClient = createAuthClient()
+      const AuthClient = mockAuthClientModule(authClient)
+
+      const authentication = new AuthenticationManager({
+        clientManager: mainnetManager(),
+        identityProvider: "https://self-hosted-ii.example.com/authorize",
+      })
+      await authentication.login()
+
+      expect(AuthClient).toHaveBeenCalledWith({
+        identityProvider: "https://self-hosted-ii.example.com/authorize",
+        windowOpenerFeatures: undefined,
+        openIdProvider: undefined,
+      })
+    })
+  })
+
+  it("ignores an ic_env internet_identity id that is not a principal", async () => {
+    // Interpolated into `http://<id>.localhost:<port>/authorize`, so only a
+    // bare principal can be substituted in safely.
+    vi.stubGlobal("window", { location: { origin: "http://127.0.0.1:8000" } })
+    vi.stubGlobal("document", {
+      cookie: "ic_env=internet_identity%3Dnot-a-principal%2Fx%23",
+    })
+    const authClient = createAuthClient()
+    const AuthClient = mockAuthClientModule(authClient)
+    const localClientManager = new ClientManager({
+      queryClient: new QueryClient(),
+      agentOptions: { host: "http://127.0.0.1:8000" },
+    })
+    vi.spyOn(localClientManager, "initializeAgent").mockResolvedValue()
+
+    const authentication = new AuthenticationManager({
+      clientManager: localClientManager,
+    })
+    await authentication.login()
+
+    // Falls back to the well-known local II canister id.
+    expect(AuthClient).toHaveBeenCalledWith({
+      identityProvider:
+        "http://rdmx6-jaaaa-aaaaa-aaadq-cai.localhost:8000/authorize",
+      windowOpenerFeatures: undefined,
+      openIdProvider: undefined,
+    })
+  })
 })


### PR DESCRIPTION
## Summary

The `ic_env` cookie is written by the replica serving a local or testnet deployment, and it is authoritative only in that setting. `ClientManager` already applies that rule to the cookie's root key — adopted off-mainnet, ignored on mainnet in favour of the pinned key (`packages/core/src/client.ts`). `AuthenticationManager` adopted the cookie's **identity provider** unconditionally, so the same value got two different treatments depending on which class read it.

This applies the existing rule to the provider as well, and tightens one adjacent input.

## Changes

**Identity provider (`acceptEnvIdentityProvider`)**

- Off-mainnet: adopted, exactly as before — local `dfx` and testnet flows are unchanged.
- Same-origin: always accepted; a provider on the app's own origin is as trustworthy as the page.
- Mainnet: ignored, falling back to the pinned `https://id.ai/authorize`, with a `console.warn` naming the ignored origin so the reason is discoverable.
- An explicitly passed `identityProvider` is never affected — that stays the way to use a custom provider on mainnet.

**Internet Identity canister id (`acceptEnvCanisterId`)**

Accepted from `ic_env` only when it parses as a principal. It is interpolated into `http://<id>.localhost:<port>/authorize`, so only a bare principal can be substituted in without changing the shape of that URL. Reachable on local networks only, since mainnet uses the pinned provider.

## Why `isMainnetHost` and not `ClientManager.isLocal`

`isLocal` is `network !== "ic"`, and `getNetworkByHostname` classifies every **unrecognized** hostname as `"ic"` — so a custom testnet on its own domain would be treated as mainnet and lose the cookie. `isMainnetHost` matches only the real boundary domains (`ic0.app`, `icp0.io`, `icp-api.io`) and defaults to `true` for an unknown host, which keeps custom testnets working while anything mainnet-shaped fails closed. It is the same predicate the root-key guard uses.

## Behaviour change

One case changes for existing users: an app on mainnet that relies on the cookie to point at a **self-hosted or third-party Internet Identity** must now pass `identityProvider` to `AuthenticationManager` explicitly. That is a one-line change, and it matches `@icp-sdk/auth`, where `identityProvider` is constructor-only configuration. Worth a line in the release notes.

## Tests

Four new cases in `packages/react/tests/auth/authentication-manager.test.ts`:

- a cross-origin cookie provider is ignored on mainnet (and the warning fires)
- a same-origin cookie provider is still honoured on mainnet
- an explicitly configured provider still wins on mainnet
- a non-principal `internet_identity` id is ignored, falling back to the well-known local canister id

The two behavioural cases were confirmed to **fail without the source change** — with the guards reverted, exactly those two go red, so they are not vacuous. The other two are regression guards for the escape hatches and pass either way by design.

Existing coverage is untouched: the local-replica and provider-from-cookie tests all target `http://127.0.0.1:8000`, so they stay green.

`packages/react`: 298 tests pass (was 294). Root `typecheck` and `format:check` are clean. The change was also verified against the **packed tarball** installed into a standalone consumer app, covering `icp-api.io` and `ic0.app` as well as the local flow.

## Note on bundle size

`size-limit` reports 7.81 kB → 8.1 kB, which is a measurement artifact rather than real cost: the config ignores `@ic-reactor/core` but not `@icp-sdk/core`, and `packages/core/src/reactor.ts` already imports `Principal` as a value. Any real consumer already has it loaded, and `@icp-sdk/core` is a required peer. Still far inside the 30 kB budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
