### PR TITLE
fix(react): make the @icp-sdk/auth peer genuinely optional for webpack builds

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -81,7 +81,10 @@ It returns the six `createActorHooks` hooks plus `useAuth`, `useAgentState`,
 `useUserPrincipal`, `useIdentityAttributes`, and the underlying `reactor`,
 `clientManager`, `queryClient`, `authentication`, and `identityAttributes`.
 `authentication` and `identityAttributes` are lazy getters, so the optional
-`@icp-sdk/auth` peer is only loaded once auth is actually touched.
+`@icp-sdk/auth` peer is only loaded once auth is actually touched. Omitting the
+peer builds everywhere; webpack-family bundlers print one `Module not found`
+warning for it because the import is declared optional, silenceable with
+`ignoreWarnings: [{ module: /@ic-reactor\/react/, message: /@icp-sdk\/auth/ }]`.
 
 To share one agent and one Internet Identity session across canisters, pass the
 first result's `authentication` into the next call:

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -14,9 +14,26 @@ pnpm add @icp-sdk/auth
 ```
 
 `@icp-sdk/auth` is an optional peer. `AuthenticationManager` reaches it through a
-literal `import("@icp-sdk/auth/client")`, so Vite, Rollup and webpack resolve it
-at build time and code-split it into its own chunk — and tree-shake it away
-entirely in apps that never reference the class.
+literal `import("@icp-sdk/auth/client")`, so Vite, Rollup and webpack code-split
+it into its own async chunk. That chunk is never fetched unless something
+touches authentication, and its bytes are dropped from the output entirely in
+apps that never reference the class.
+
+Bundlers still **resolve** that specifier while building the module graph, which
+happens before any tree-shaking — so a missing peer cannot simply be optimized
+away. The import therefore sits inside a `try` block, which webpack-family
+bundlers treat as declaring an optional dependency: with the peer absent the
+build succeeds and prints one warning,
+`Module not found: Can't resolve '@icp-sdk/auth/client'`. Only the login paths
+are affected, and they throw an actionable error if they are ever called.
+
+Install the peer to remove the warning, or silence it with
+[`ignoreWarnings`](https://webpack.js.org/configuration/other-options/#ignorewarnings):
+
+```js
+// webpack.config.js / next.config.js (webpack)
+ignoreWarnings: [{ module: /@ic-reactor\/react/, message: /@icp-sdk\/auth/ }]
+```
 
 ## Quick Start
 

--- a/packages/react/src/auth/authentication-manager.ts
+++ b/packages/react/src/auth/authentication-manager.ts
@@ -455,12 +455,7 @@ export class AuthenticationManager {
     }
 
     if (!this.authClientConstructorPromise) {
-      // The specifier must stay a literal: a variable specifier (or /* @vite-ignore */)
-      // makes bundlers skip this import entirely, so the bare specifier survives into
-      // the browser, where it cannot be resolved without an import map and every login
-      // path fails. A literal lets Vite/Rollup/webpack code-split the optional peer,
-      // and lets them tree-shake it away for apps that never reference this class.
-      this.authClientConstructorPromise = import("@icp-sdk/auth/client")
+      this.authClientConstructorPromise = importAuthClientModule()
         .then((authModule) => {
           const AuthClient = (
             authModule as { AuthClient?: AuthClientConstructor }
@@ -487,6 +482,37 @@ export class AuthenticationManager {
     }
 
     return this.authClientConstructorPromise
+  }
+}
+
+/**
+ * Loads the optional `@icp-sdk/auth` peer.
+ *
+ * The `try` is load-bearing, not defensive. webpack flags a dynamic import
+ * that sits lexically inside a `try` block as an *optional* dependency
+ * (`ImportParserPlugin`: `dep.optional = Boolean(parser.scope.inTry)`), and
+ * `Compilation` reports an unresolvable optional dependency as a build
+ * *warning* instead of a fatal "Module not found" error, emitting a module
+ * that rejects at runtime. Without the `try`, every webpack-based toolchain
+ * (webpack, `next build --webpack`, Rspack) fails to build for consumers who
+ * never touch authentication, because npm/pnpm do not install optional peers.
+ * Do not hoist this import out of the `try`, and do not wrap it in a nested
+ * function — webpack resets `inTry` at every function boundary.
+ *
+ * The specifier must also stay a literal: a variable specifier (or
+ * `@vite-ignore`) makes bundlers skip this import entirely, so the bare
+ * specifier survives into the browser, where it cannot be resolved without an
+ * import map and every login path fails. A literal lets Vite/Rollup/webpack
+ * code-split the optional peer, and lets them tree-shake it away for apps that
+ * never reference this class.
+ */
+function importAuthClientModule(): Promise<unknown> {
+  try {
+    return import("@icp-sdk/auth/client")
+  } catch (error) {
+    // Native ESM without an import map (and bundlers that neither resolve nor
+    // stub the specifier) throw synchronously rather than rejecting.
+    return Promise.reject(error)
   }
 }
 

--- a/packages/react/tests/auth/optional-auth-peer-import.test.ts
+++ b/packages/react/tests/auth/optional-auth-peer-import.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+/**
+ * Guards the mechanism that keeps `@icp-sdk/auth` genuinely optional on
+ * webpack-based toolchains (webpack, `next build --webpack`, Rspack).
+ *
+ * webpack marks a dynamic import that sits lexically inside a `try` block as an
+ * optional dependency (`ImportParserPlugin`: `dep.optional = inTry`), and
+ * `Compilation` downgrades an unresolvable optional dependency from a fatal
+ * "Module not found" error to a build warning plus a module that rejects at
+ * runtime. Hoisting the import out of the `try`, or moving it into a nested
+ * function (webpack resets `inTry` at every function boundary), silently breaks
+ * every consumer that did not install the optional peer — which is the default,
+ * because npm and pnpm never install optional peers.
+ */
+const source = readFileSync(
+  resolve(process.cwd(), "src/auth/authentication-manager.ts"),
+  "utf8"
+)
+
+/**
+ * Is the single `import("@icp-sdk/auth/client")` lexically inside a `try`?
+ *
+ * Tracked structurally by brace depth rather than by matching exact source
+ * text, so reformatting or renaming the caught error cannot fail this test for
+ * reasons unrelated to the invariant it guards.
+ */
+function importSitsInsideTryBlock(code: string): boolean {
+  const importIndex = code.indexOf('import("@icp-sdk/auth/client")')
+  if (importIndex === -1) return false
+
+  const before = code.slice(0, importIndex)
+  const openTryDepths: number[] = []
+  let depth = 0
+
+  for (let i = 0; i < before.length; i++) {
+    const char = before[i]
+    if (char === "{") {
+      // `try` immediately precedes the brace that opens its block.
+      if (/\btry\s*$/.test(before.slice(Math.max(0, i - 12), i))) {
+        openTryDepths.push(depth)
+      }
+      depth++
+    } else if (char === "}") {
+      depth--
+      // Leaving a block closes any `try` that opened at this depth.
+      while (
+        openTryDepths.length > 0 &&
+        openTryDepths[openTryDepths.length - 1] >= depth
+      ) {
+        openTryDepths.pop()
+      }
+    }
+  }
+
+  return openTryDepths.length > 0
+}
+
+describe("optional @icp-sdk/auth peer import", () => {
+  it("keeps the dynamic import lexically inside a try block", () => {
+    expect(importSitsInsideTryBlock(source)).toBe(true)
+  })
+
+  it("detects a hoisted import, which would silently make the peer mandatory", () => {
+    // Sanity-check the guard itself: the same import outside any `try` fails.
+    expect(
+      importSitsInsideTryBlock(
+        `function load() { return import("@icp-sdk/auth/client") }`
+      )
+    ).toBe(false)
+  })
+
+  it("imports the peer exactly once, as a literal specifier", () => {
+    const matches = source.match(/import\("@icp-sdk\/auth\/client"\)/g) ?? []
+    expect(matches).toHaveLength(1)
+  })
+
+  it("never references the peer through a static import", () => {
+    expect(source).not.toMatch(/^\s*import\s.*from\s+"@icp-sdk\/auth/m)
+  })
+})


### PR DESCRIPTION
Fixes #234.

## The problem

Any webpack-based toolchain — plain webpack, `next build --webpack`, CRA, Rspack — failed to build `@ic-reactor/react` when the optional `@icp-sdk/auth` peer was absent, **including for consumers who never touch authentication**. npm and pnpm never install optional peers, so this was the default state for anyone following the README's own install line.

```
ERROR in .../@ic-reactor/react/dist/auth/authentication-manager.js 429:48-78
Module not found: Error: Can't resolve '@icp-sdk/auth/client'
 @ .../dist/defineReactor.js 60:0-73
 @ .../dist/index.js 10:0-35
 @ ./src/no-auth-usage.js          <- imports only { ClientManager, Reactor }
webpack 5.109.2 compiled with 1 error
```

## Why the obvious fix doesn't work

Making the `defineReactor → AuthenticationManager` import lazy is **not** sufficient: `index.ts` re-exports `./auth/index.js` directly, so the auth module is in the graph regardless. And bundlers **resolve the module graph before tree-shaking**, so an unresolvable specifier is fatal no matter how unreachable the code is.

That is also why the README's claim that webpack would "tree-shake it away entirely in apps that never reference the class" was wrong — and that wrong belief is the origin of this bug. The README is corrected here.

## The fix

Wrap the dynamic import in a `try` block:

```ts
function importAuthClientModule(): Promise<unknown> {
  try {
    return import("@icp-sdk/auth/client")
  } catch (error) { /* … */ }
}
```

webpack marks a dynamic import that sits **lexically** inside a `try` as an optional dependency (`ImportParserPlugin`: `dep.optional = parser.scope.inTry`), and `Compilation` downgrades an unresolvable optional dependency from a fatal error to a build warning plus a module that rejects at runtime — which the existing `.catch()` already turns into the actionable "install the optional auth peer" message. Rspack and Turbopack implement the same semantics. This is the ESM analogue of the `try { require(x) } catch {}` convention `ws` uses for `bufferutil`.

The specifier stays a **literal**, so when the peer *is* installed bundlers still resolve, code-split and tree-shake it exactly as before.

## Verified

Reproduced the baseline failure and the fix in the same harness:

| Scenario | Before | After |
| --- | --- | --- |
| plain webpack 5.109.2, peer absent, no-auth entry | exit 1 | **exit 0**, 1 warning |
| `next build --webpack`, peer absent | exit 1 | **exit 0** |
| Rspack, peer absent | exit 1 | **exit 0** |
| Vite, peer absent | exit 0 | exit 0 (unchanged) |
| webpack + peer installed, auth at runtime | works | works — async chunk still emitted and fetched |

`packages/react`: 302 tests pass (was 294 + 8 here and on `main`). Root `typecheck`, `typecheck:examples` (21 examples), `check:ai-context`, `format:check` all clean. `size-limit` unchanged. No API, export, type, `package.json`, install-size or bundle-size change.

This also fixes a second case that was red on `main`: `next build --turbopack` failed whenever `AuthenticationManager` was referenced.

## Guard tests

Three source-text tests pin the invariant, because hoisting the import out of the `try` — or moving it into a nested function, where webpack resets `inTry` — would silently make the peer mandatory again with no test failure anywhere. The try-block check tracks **brace depth** rather than matching exact source text, so reformatting or renaming the caught error cannot fail it for unrelated reasons; a self-check asserts the guard rejects a hoisted import.

## Known limitations (documented in the README)

- Consumers who promote webpack warnings to errors (CRA with `CI=true`, `--bail`) still fail. Strictly better than today, but not universal.
- Every no-peer consumer sees one `Module not found` warning per build. Silenceable with the `ignoreWarnings` snippet now in the README, or by installing the peer.
- **Not verified:** a consumer transpiling our ESM `dist` to CJS with Babel `transform-modules-commonjs`. I attempted this three times and could not construct a harness that builds *at all* — the transform breaks webpack's export detection independently of this change ("module has no exports"). Flagging it as undemonstrated rather than cleared.

## Alternative considered

Promoting `@icp-sdk/auth` to a real dependency also works, and additionally fixes the confusing no-peer *runtime* DX. It was rejected because it makes `npm install --strict-peer-deps` fail for every consumer via an upstream `@icp-sdk/auth → @icp-sdk/core ^5` vs our `^6` conflict — trading a build warning for an install hard-failure. That upstream range bug is worth reporting to `dfinity/icp-js-auth` regardless.

Two other approaches were rejected as actively dangerous: opaque/ignored specifier variants (`const` concat, `webpackIgnore`, `@vite-ignore`) fix the build and **break login at runtime** in both webpack and Vite, some with no build diagnostic at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
