### PR TITLE
fix(core): scope query keys by transform and make custom key segments BigInt-safe

### DIFF
--- a/packages/core/src/reactor.ts
+++ b/packages/core/src/reactor.ts
@@ -23,7 +23,11 @@ import type {
 import { DEFAULT_POLLING_OPTIONS } from "@icp-sdk/core/agent"
 import { IDL } from "@icp-sdk/core/candid"
 import { Principal } from "@icp-sdk/core/principal"
-import { generateKey, extractOkResult } from "./utils/helper.js"
+import {
+  generateKey,
+  extractOkResult,
+  toHashableKeySegment,
+} from "./utils/helper.js"
 import { toReactorQueryData } from "./utils/query-data.js"
 import {
   processQueryCallResponse,
@@ -217,6 +221,16 @@ export class Reactor<A = BaseActor, T extends TransformKey = "candid"> {
 
     const queryKeys: any[] = [resolvedCanisterId, params.functionName]
 
+    // Two reactors over the same canister return differently-shaped data when
+    // their transforms differ (a DisplayReactor's string nats vs a Reactor's
+    // bigints), so they must not share a cache entry. Only non-default
+    // transforms add a segment, which keeps existing candid keys byte-identical.
+    // It sits before the args segment so that the prefix built by
+    // `invalidateQueries({ functionName })` still matches keys that carry args.
+    if (this.transform !== "candid") {
+      queryKeys.push({ transform: this.transform })
+    }
+
     const effectiveTarget =
       callConfig?.effectiveTarget ??
       (callConfig?.effectiveCanisterId
@@ -242,7 +256,11 @@ export class Reactor<A = BaseActor, T extends TransformKey = "candid"> {
       queryKeys.push(argKey)
     }
     if (params.queryKey) {
-      queryKeys.push(...params.queryKey)
+      // Caller-supplied segments are hashed by React Query with JSON.stringify,
+      // which throws on a BigInt. Args and factory key-args are already routed
+      // through a BigInt-safe serializer; do the same here so a natural key like
+      // `queryKey: [tokenId]` cannot blank the component tree.
+      queryKeys.push(...params.queryKey.map(toHashableKeySegment))
     }
 
     return queryKeys

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -8,6 +8,34 @@ export const generateKey = (args: any[]) => {
   )
 }
 
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  if (typeof value !== "object" || value === null) return false
+  const proto = Object.getPrototypeOf(value)
+  return proto === Object.prototype || proto === null
+}
+
+/**
+ * Make one query-key segment safe for React Query's `JSON.stringify` hashing by
+ * rendering BigInt values as strings.
+ *
+ * Only arrays and plain objects are walked. Class instances (a `Principal`, a
+ * `Date`) are returned untouched so their existing hash is preserved — this
+ * converts what would otherwise throw, and changes nothing else.
+ */
+export const toHashableKeySegment = (value: unknown): unknown => {
+  if (typeof value === "bigint") return value.toString()
+  if (Array.isArray(value)) return value.map(toHashableKeySegment)
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        toHashableKeySegment(item),
+      ])
+    )
+  }
+  return value
+}
+
 const getEnv = () => {
   try {
     return process.env

--- a/packages/core/tests/reactor-query-key.test.ts
+++ b/packages/core/tests/reactor-query-key.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { QueryClient } from "@tanstack/query-core"
+import { hashKey } from "@tanstack/query-core"
+import { IDL } from "@icp-sdk/core/candid"
+import { Reactor } from "../src/reactor.js"
+import { DisplayReactor } from "../src/display-reactor.js"
+import { ClientManager } from "../src/client.js"
+
+const CANISTER_ID = "ryjl3-tyaaa-aaaaa-aaaba-cai"
+
+const idlFactory: IDL.InterfaceFactory = ({ IDL }) =>
+  IDL.Service({
+    total_supply: IDL.Func([], [IDL.Nat], ["query"]),
+    balance_of: IDL.Func([IDL.Principal], [IDL.Nat], ["query"]),
+  })
+
+describe("Reactor.generateQueryKey", () => {
+  let clientManager: ClientManager
+
+  beforeEach(() => {
+    clientManager = new ClientManager({
+      queryClient: new QueryClient(),
+      agentOptions: { host: "https://icp-api.io" },
+    })
+  })
+
+  const makeReactor = () =>
+    new Reactor<any>({
+      clientManager,
+      name: "raw",
+      canisterId: CANISTER_ID,
+      idlFactory,
+    })
+
+  const makeDisplayReactor = () =>
+    new DisplayReactor<any>({
+      clientManager,
+      name: "display",
+      canisterId: CANISTER_ID,
+      idlFactory,
+    })
+
+  describe("transform scoping", () => {
+    it("keeps candid keys free of a transform segment", () => {
+      expect(
+        makeReactor().generateQueryKey({ functionName: "total_supply" })
+      ).toEqual([CANISTER_ID, "total_supply"])
+    })
+
+    it("separates a DisplayReactor from a Reactor over the same canister", () => {
+      // Both return the same method's data in different shapes (string nats vs
+      // bigints), so sharing one cache entry would serve one the other's values.
+      const raw = makeReactor().generateQueryKey({
+        functionName: "total_supply",
+      })
+      const display = makeDisplayReactor().generateQueryKey({
+        functionName: "total_supply",
+      })
+
+      expect(display).not.toEqual(raw)
+      expect(hashKey(display)).not.toBe(hashKey(raw))
+      expect(display).toEqual([
+        CANISTER_ID,
+        "total_supply",
+        { transform: "display" },
+      ])
+    })
+
+    it("keeps the transform segment ahead of args so prefix invalidation matches", () => {
+      const display = makeDisplayReactor()
+      const withArgs = display.generateQueryKey({
+        functionName: "balance_of",
+        args: ["aaaaa-aa"] as never,
+      })
+      // The prefix `invalidateQueries({ functionName })` builds must still be a
+      // prefix of a key that carries args.
+      const prefix = display.generateQueryKey({ functionName: "balance_of" })
+
+      expect(withArgs.slice(0, prefix.length)).toEqual(prefix)
+    })
+
+    it("still starts every key with the canister id for identity-switch invalidation", () => {
+      // ClientManager.updateAgent cancels/invalidates by the [canisterId] prefix.
+      expect(
+        makeDisplayReactor().generateQueryKey({
+          functionName: "total_supply",
+        })[0]
+      ).toBe(CANISTER_ID)
+    })
+  })
+
+  describe("custom queryKey segments", () => {
+    it("renders a BigInt segment as a string instead of throwing when hashed", () => {
+      const key = makeReactor().generateQueryKey({
+        functionName: "balance_of",
+        queryKey: ["blocks", 7n],
+      })
+
+      expect(key).toEqual([CANISTER_ID, "balance_of", "blocks", "7"])
+      expect(() => hashKey(key)).not.toThrow()
+    })
+
+    it("converts BigInts nested in plain objects and arrays", () => {
+      const key = makeReactor().generateQueryKey({
+        functionName: "balance_of",
+        queryKey: [{ page: { size: 10n } }, [1n, 2n]],
+      })
+
+      expect(key).toEqual([
+        CANISTER_ID,
+        "balance_of",
+        { page: { size: "10" } },
+        ["1", "2"],
+      ])
+      expect(() => hashKey(key)).not.toThrow()
+    })
+
+    it("leaves ordinary segments untouched", () => {
+      expect(
+        makeReactor().generateQueryKey({
+          functionName: "balance_of",
+          queryKey: ["v2", 3, true, null],
+        })
+      ).toEqual([CANISTER_ID, "balance_of", "v2", 3, true, null])
+    })
+  })
+})


### PR DESCRIPTION
Fixes #237. Fixes #240.

Two defects in `Reactor.generateQueryKey`, both of which produced wrong data or a crash with nothing pointing at the cache as the cause.

## 1. Query keys carried no notion of the transform (#237)

The key was `[canisterId, functionName, args?]`, so a `Reactor` and a `DisplayReactor` over the **same canister sharing one `ClientManager`** occupied the same cache entry. Whichever fetched first won, and the other silently received values of the wrong type.

Verified live against the ckTESTBTC ledger before and after:

```
                                    before            after
raw key       [canister,"icrc1_total_supply"]     (unchanged)
display key   [canister,"icrc1_total_supply"]     [canister,"icrc1_total_supply",{transform:"display"}]
keys collide  true                                false
cache entries 1                                   2

raw fetchQuery (runs first)   24888747843  bigint      24888747843  bigint
display hook afterwards       24888747843  bigint  ->  "24888747843"  string
                              ^ contract says string   ^ contract honoured
```

Because it was order-dependent, the behaviour could differ between page loads.

This is reachable from the project's own guidance: `CLAUDE.md` says to prefer `DisplayReactor` for UI **and** to use `Reactor` when raw types are needed, while `defineReactor`'s documented composition example shares one `ClientManager` to get a single agent and session.

**Only a non-default transform adds a segment**, so existing candid keys stay byte-identical and no cache is invalidated for the common case.

Placement matters and is covered by tests: the segment sits after `functionName` and **before** the args segment, so the prefix built by `invalidateQueries({ functionName })` still matches keys that carry args; and every key still starts with the canister id that `ClientManager.updateAgent` uses to cancel and invalidate on identity change.

## 2. Custom `queryKey` segments were not BigInt-safe (#240)

Caller-supplied segments were pushed verbatim, while args and factory key-args already went through a BigInt-safe serializer. React Query hashes keys with `JSON.stringify`, so a natural key in this BigInt-heavy domain threw out of the component render:

```
generateQueryKey({ functionName, queryKey: ["blocks", 7n] })
  -> ["mc6ru-…","icrc3_get_blocks","blocks",7n]
  -> TypeError: Do not know how to serialize a BigInt   (from getQueryData AND from render)
```

Segments now pass through a new `toHashableKeySegment`, which renders BigInts as strings inside arrays and plain objects and leaves everything else untouched — class instances such as `Principal` and `Date` keep their existing hash, so this only converts what would otherwise throw.

This one compounds with #236: the documented workaround for arg-less infinite keys is "pass your own `queryKey`", and the most natural disambiguator (a cursor or page size) is exactly what crashed.

## Verification

`packages/core`: 7 new tests. With the source change reverted, **3 of the 7 fail** — the three behavioural ones — so they are not vacuous; the other 4 are invariant guards (candid keys unchanged, transform-before-args ordering, canister id first) that correctly hold either way.

Existing suites unchanged: core 188 passed, react 298 passed. Root `typecheck` and `format:check` clean.

Also re-ran the full live mainnet suite against the packed tarballs. No regressions: of the failures, three are pre-existing findings already filed (#242, plus a test-harness artifact and a live-chain flake) and the rest are defect-documenting tests from the audit correctly inverting now that the defects are fixed.

## Note for reviewers

This changes cache keys for `DisplayReactor` users, so their caches invalidate once on upgrade. Candid keys are untouched. Worth a line in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
