### PR TITLE
fix(react): scope infinite-query cache keys by call arguments

### DIFF
--- a/packages/react/src/createInfiniteQuery.ts
+++ b/packages/react/src/createInfiniteQuery.ts
@@ -126,6 +126,16 @@ export interface InfiniteQueryConfig<
   initialPageParam: TPageParam
   /** Function to get args from page parameter */
   getArgs: (pageParam: TPageParam) => ReactorArgs<Service, Method, Transform>
+  /**
+   * Narrows what the cache key derives from the call arguments.
+   *
+   * By default the key is scoped by `getArgs(initialPageParam)`, so two
+   * infinite queries on the same method with different arguments stay in
+   * separate cache entries. Supply this when those args embed the cursor and
+   * only part of them identifies the query — return the stable, serializable
+   * portion (typically everything except the pagination field).
+   */
+  getKeyArgs?: (args: ReactorArgs<Service, Method, Transform>) => unknown
   /** Function to determine next page parameter */
   getNextPageParam: (
     lastPage: InfiniteQueryPageData<Service, Method, Transform>,
@@ -155,17 +165,12 @@ export type InfiniteQueryFactoryConfig<
     TPageParam
   >,
 > = Omit<
+  // `getArgs` is supplied per factory call. `getKeyArgs` is inherited from
+  // InfiniteQueryConfig, which now applies it for every infinite query rather
+  // than only for factory-created ones.
   InfiniteQueryConfig<Service, Method, Transform, TPageParam, Selected>,
   "getArgs"
-> & {
-  /**
-   * Optional key-args derivation for factory calls.
-   * Receives the resolved args from `getArgs(initialPageParam)` and should return
-   * a stable serializable representation of the logical query identity
-   * (typically excluding pagination/cursor fields).
-   */
-  getKeyArgs?: (args: ReactorArgs<Service, Method, Transform>) => unknown
-}
+>
 
 // ============================================================================
 // Hook Interface
@@ -292,6 +297,7 @@ const createInfiniteQueryImpl = <
     queryKey: customQueryKey,
     initialPageParam,
     getArgs,
+    getKeyArgs,
     getNextPageParam,
     getPreviousPageParam,
     maxPages,
@@ -300,12 +306,22 @@ const createInfiniteQueryImpl = <
     ...rest
   } = config
 
-  // Get query key from actor manager
+  // Fold the call arguments into the key. Without them every infinite query on
+  // a method shares one cache entry, so two lists with different `getArgs` (a
+  // different page size, a different filter) serve each other's pages — the
+  // arguments live in a closure, not in the config, so nothing else
+  // distinguishes them.
+  //
+  // The first page's args stand for the query's identity; `getKeyArgs` lets a
+  // caller drop the cursor field when it is part of those args.
   const getQueryKey = (): QueryKey => {
+    const initialArgs = getArgs(initialPageParam)
+    const keyArgs = getKeyArgs?.(initialArgs) ?? initialArgs
+
     return reactor.generateQueryKey(
       {
         functionName,
-        queryKey: customQueryKey,
+        queryKey: mergeFactoryQueryKey(customQueryKey, undefined, keyArgs),
       },
       callConfig
     )
@@ -535,10 +551,8 @@ export function createInfiniteQueryFactory<
   > = (
     getArgs: (pageParam: TPageParam) => ReactorArgs<Service, Method, Transform>
   ) => {
-    const initialArgs = getArgs(config.initialPageParam)
-    const keyArgs = config.getKeyArgs?.(initialArgs) ?? initialArgs
-    const queryKey = mergeFactoryQueryKey(config.queryKey, undefined, keyArgs)
-
+    // `getKeyArgs` and the args-derived key segment are applied by the impl,
+    // which now does it for every infinite query rather than only for factories.
     return createInfiniteQueryImpl<
       Service,
       Method,
@@ -546,16 +560,13 @@ export function createInfiniteQueryFactory<
       TPageParam,
       Selected
     >(reactor, {
-      ...(({ getKeyArgs: _getKeyArgs, ...rest }) => rest)(
-        config as InfiniteQueryFactoryConfig<
-          Service,
-          Method,
-          Transform,
-          TPageParam,
-          Selected
-        >
-      ),
-      queryKey,
+      ...(config as InfiniteQueryFactoryConfig<
+        Service,
+        Method,
+        Transform,
+        TPageParam,
+        Selected
+      >),
       getArgs,
     })
   }

--- a/packages/react/src/createSuspenseInfiniteQuery.ts
+++ b/packages/react/src/createSuspenseInfiniteQuery.ts
@@ -137,6 +137,15 @@ export interface SuspenseInfiniteQueryConfig<
   queryKey?: QueryKey
   /** Function to get args from page parameter */
   getArgs: (pageParam: TPageParam) => ReactorArgs<Service, Method, Transform>
+  /**
+   * Narrows what the cache key derives from the call arguments.
+   *
+   * By default the key is scoped by `getArgs(initialPageParam)`, so two
+   * infinite queries on the same method with different arguments stay in
+   * separate cache entries. Supply this when those args embed the cursor and
+   * only part of them identifies the query.
+   */
+  getKeyArgs?: (args: ReactorArgs<Service, Method, Transform>) => unknown
 }
 
 /**
@@ -152,17 +161,11 @@ export type SuspenseInfiniteQueryFactoryConfig<
     TPageParam
   >,
 > = Omit<
+  // `getArgs` is supplied per factory call. `getKeyArgs` is inherited from
+  // SuspenseInfiniteQueryConfig, which now applies it for every infinite query.
   SuspenseInfiniteQueryConfig<Service, Method, Transform, TPageParam, Selected>,
   "getArgs"
-> & {
-  /**
-   * Optional key-args derivation for factory calls.
-   * Receives the resolved args from `getArgs(initialPageParam)` and should return
-   * a stable serializable representation of the logical query identity
-   * (typically excluding pagination/cursor fields).
-   */
-  getKeyArgs?: (args: ReactorArgs<Service, Method, Transform>) => unknown
-}
+>
 
 // ============================================================================
 // Hook Interface
@@ -301,6 +304,7 @@ const createSuspenseInfiniteQueryImpl = <
     queryKey: customQueryKey,
     initialPageParam,
     getArgs,
+    getKeyArgs,
     getNextPageParam,
     getPreviousPageParam,
     maxPages,
@@ -309,12 +313,18 @@ const createSuspenseInfiniteQueryImpl = <
     ...rest
   } = config
 
-  // Get query key from actor manager
+  // Fold the call arguments into the key — see the matching comment in
+  // createInfiniteQuery. Without them every infinite query on a method shares
+  // one cache entry, because the arguments live in a `getArgs` closure rather
+  // than in the config.
   const getQueryKey = (): QueryKey => {
+    const initialArgs = getArgs(initialPageParam)
+    const keyArgs = getKeyArgs?.(initialArgs) ?? initialArgs
+
     return reactor.generateQueryKey(
       {
         functionName,
-        queryKey: customQueryKey,
+        queryKey: mergeFactoryQueryKey(customQueryKey, undefined, keyArgs),
       },
       callConfig
     )
@@ -550,12 +560,13 @@ export function createSuspenseInfiniteQueryFactory<
     getArgs: (pageParam: TPageParam) => ReactorArgs<Service, Method, Transform>,
     options?: SuspenseInfiniteFactoryCallOptions
   ) => {
-    const initialArgs = getArgs(config.initialPageParam)
-    const keyArgs = config.getKeyArgs?.(initialArgs) ?? initialArgs
+    // Only the caller-supplied segments are merged here; the args-derived
+    // segment is added by the impl, which does it for every infinite query.
+    // Applying it in both places would append the args twice.
     const queryKey = mergeFactoryQueryKey(
       config.queryKey,
       options?.queryKey,
-      keyArgs
+      undefined
     )
 
     return createSuspenseInfiniteQueryImpl<
@@ -565,15 +576,13 @@ export function createSuspenseInfiniteQueryFactory<
       TPageParam,
       Selected
     >(reactor, {
-      ...(({ getKeyArgs: _getKeyArgs, ...rest }) => rest)(
-        config as SuspenseInfiniteQueryFactoryConfig<
-          Service,
-          Method,
-          Transform,
-          TPageParam,
-          Selected
-        >
-      ),
+      ...(config as SuspenseInfiniteQueryFactoryConfig<
+        Service,
+        Method,
+        Transform,
+        TPageParam,
+        Selected
+      >),
       queryKey,
       getArgs,
     } as SuspenseInfiniteQueryConfig<

--- a/packages/react/src/hooks/useActorInfiniteQuery.ts
+++ b/packages/react/src/hooks/useActorInfiniteQuery.ts
@@ -16,7 +16,7 @@ import {
   ReactorReturnErr,
 } from "@ic-reactor/core"
 import { CallConfig } from "@icp-sdk/core/agent"
-import { normalizeQueryData } from "../utils.js"
+import { mergeFactoryQueryKey, normalizeQueryData } from "../utils.js"
 
 /**
  * Parameters for useActorInfiniteQuery hook.
@@ -119,8 +119,30 @@ export const useActorInfiniteQuery = <
   // reactor/function identity. Using the custom key verbatim would cause cache
   // collisions if two different actors or methods share the same key string.
   const baseQueryKey = useMemo(
-    () => reactor.generateQueryKey({ functionName, queryKey }, callConfig),
-    [queryKey, reactor, functionName, callConfig]
+    () =>
+      reactor.generateQueryKey(
+        {
+          functionName,
+          // Fold the call arguments into the key. They live in the `getArgs`
+          // closure rather than in the config, so without this two hooks on the
+          // same method with different arguments share one cache entry and
+          // serve each other's pages.
+          queryKey: mergeFactoryQueryKey(
+            queryKey,
+            undefined,
+            getArgs(options.initialPageParam)
+          ),
+        },
+        callConfig
+      ),
+    [
+      queryKey,
+      reactor,
+      functionName,
+      callConfig,
+      getArgs,
+      options.initialPageParam,
+    ]
   )
 
   // Memoize queryFn to prevent recreation on every render

--- a/packages/react/src/hooks/useActorSuspenseInfiniteQuery.ts
+++ b/packages/react/src/hooks/useActorSuspenseInfiniteQuery.ts
@@ -16,7 +16,7 @@ import {
   ReactorReturnErr,
 } from "@ic-reactor/core"
 import { CallConfig } from "@icp-sdk/core/agent"
-import { normalizeQueryData } from "../utils.js"
+import { mergeFactoryQueryKey, normalizeQueryData } from "../utils.js"
 
 /**
  * Parameters for useActorSuspenseInfiniteQuery hook.
@@ -129,8 +129,30 @@ export const useActorSuspenseInfiniteQuery = <
   // reactor/function identity. Using the custom key verbatim would cause cache
   // collisions if two different actors or methods share the same key string.
   const baseQueryKey = useMemo(
-    () => reactor.generateQueryKey({ functionName, queryKey }, callConfig),
-    [queryKey, reactor, functionName, callConfig]
+    () =>
+      reactor.generateQueryKey(
+        {
+          functionName,
+          // Fold the call arguments into the key. They live in the `getArgs`
+          // closure rather than in the config, so without this two hooks on the
+          // same method with different arguments share one cache entry and
+          // serve each other's pages.
+          queryKey: mergeFactoryQueryKey(
+            queryKey,
+            undefined,
+            getArgs(options.initialPageParam)
+          ),
+        },
+        callConfig
+      ),
+    [
+      queryKey,
+      reactor,
+      functionName,
+      callConfig,
+      getArgs,
+      options.initialPageParam,
+    ]
   )
 
   // Memoize queryFn to prevent recreation on every render

--- a/packages/react/tests/createInfiniteQuery.test.tsx
+++ b/packages/react/tests/createInfiniteQuery.test.tsx
@@ -129,7 +129,15 @@ describe("createInfiniteQuery", () => {
       })
 
       const queryKey = postsQuery.getQueryKey()
-      expect(queryKey).toEqual(["test-canister", "getPosts"])
+      expect(queryKey).toEqual([
+        "test-canister",
+        "getPosts",
+        // Scoped by the first page's args, so two infinite queries on this
+        // method with different arguments cannot share a cache entry.
+        {
+          __ic_reactor_factory_key_args: '[{"cursor":0,"limit":10}]',
+        },
+      ])
     })
 
     it("should return correct refetch key", () => {
@@ -141,7 +149,68 @@ describe("createInfiniteQuery", () => {
       })
 
       const refetchKey = postsQuery.getQueryKey()
-      expect(refetchKey).toEqual(["test-canister", "getPosts"])
+      expect(refetchKey).toEqual([
+        "test-canister",
+        "getPosts",
+        // Scoped by the first page's args, so two infinite queries on this
+        // method with different arguments cannot share a cache entry.
+        {
+          __ic_reactor_factory_key_args: '[{"cursor":0,"limit":10}]',
+        },
+      ])
+    })
+  })
+
+  describe("cache-key scoping by call arguments", () => {
+    it("gives two queries on the same method with different args distinct keys", () => {
+      // Regression guard: the args live in the `getArgs` closure, not in the
+      // config, so before this was fixed both queries produced
+      // ["test-canister","getPosts"] and served each other's pages.
+      const small = createInfiniteQuery(mockReactor, {
+        functionName: "getPosts",
+        initialPageParam: 0,
+        getArgs: (cursor) => [{ cursor, limit: 3 }] as const,
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+      })
+      const large = createInfiniteQuery(mockReactor, {
+        functionName: "getPosts",
+        initialPageParam: 0,
+        getArgs: (cursor) => [{ cursor, limit: 10 }] as const,
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+      })
+
+      expect(small.getQueryKey()).not.toEqual(large.getQueryKey())
+    })
+
+    it("keeps the key stable across calls for identical args", () => {
+      const query = createInfiniteQuery(mockReactor, {
+        functionName: "getPosts",
+        initialPageParam: 0,
+        getArgs: (cursor) => [{ cursor, limit: 10 }] as const,
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+      })
+
+      expect(query.getQueryKey()).toEqual(query.getQueryKey())
+    })
+
+    it("lets getKeyArgs drop the cursor so pages share one entry", () => {
+      const withCursor = createInfiniteQuery(mockReactor, {
+        functionName: "getPosts",
+        initialPageParam: 0,
+        getArgs: (cursor) => [{ cursor, limit: 10 }] as const,
+        getKeyArgs: ([args]) => [{ limit: args.limit }],
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+      })
+      const startedElsewhere = createInfiniteQuery(mockReactor, {
+        functionName: "getPosts",
+        initialPageParam: 25,
+        getArgs: (cursor) => [{ cursor, limit: 10 }] as const,
+        getKeyArgs: ([args]) => [{ limit: args.limit }],
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+      })
+
+      // Same logical query, different starting cursor -> same cache entry.
+      expect(withCursor.getQueryKey()).toEqual(startedElsewhere.getQueryKey())
     })
   })
 

--- a/packages/react/tests/createSuspenseInfiniteQuery.test.tsx
+++ b/packages/react/tests/createSuspenseInfiniteQuery.test.tsx
@@ -138,7 +138,15 @@ describe("createSuspenseInfiniteQuery", () => {
       })
 
       const queryKey = postsQuery.getQueryKey()
-      expect(queryKey).toEqual(["test-canister", "getPosts"])
+      expect(queryKey).toEqual([
+        "test-canister",
+        "getPosts",
+        // Scoped by the first page's args, so two infinite queries on this
+        // method with different arguments cannot share a cache entry.
+        {
+          __ic_reactor_factory_key_args: '[{"cursor":0,"limit":10}]',
+        },
+      ])
     })
 
     it("should return correct refetch key", () => {
@@ -149,7 +157,13 @@ describe("createSuspenseInfiniteQuery", () => {
         getNextPageParam: (lastPage) => lastPage.nextCursor,
       })
 
-      expect(postsQuery.getQueryKey()).toEqual(["test-canister", "getPosts"])
+      expect(postsQuery.getQueryKey()).toEqual([
+        "test-canister",
+        "getPosts",
+        {
+          __ic_reactor_factory_key_args: '[{"cursor":0,"limit":10}]',
+        },
+      ])
     })
   })
 


### PR DESCRIPTION
Fixes #236. Also closes the hook half tracked as F11 in #262.

## The problem

`createInfiniteQuery`, `createSuspenseInfiniteQuery` and both `useActor*InfiniteQuery` hooks built their key from `{ functionName, queryKey }` only. The call arguments live in the `getArgs` closure rather than in the config, so **every infinite query over a method shared one cache entry** and served each other's pages — silently, with no error and no type violation.

Verified live against the ckTESTBTC ledger (`icrc3_get_blocks`) before this change:

```
two createInfiniteQuery objects, page size 3 vs 10:
  small.getQueryKey() === large.getQueryKey() === ["mc6ru-…","icrc3_get_blocks"]
  cache entries for the method: 1
  the 10-per-page query rendered pages[0].blocks.length === 3
    isSuccess=true, fetchStatus="idle"   <- it never called the canister

two useActorInfiniteQuery hooks, page size 2 vs 7:
  hook B mounted showing A's 2 blocks
  after B refetched, hook A re-rendered with 7 blocks; a.data === b.data
```

This directly undercuts the "define reusable query objects at module scope" pattern in `CLAUDE.md`: per-user feeds, per-filter tables, or different page sizes on mobile and desktop silently render each other's rows, and whichever consumer refetches last overwrites what every other one displays.

## The fix

The correct behaviour already existed for **factory**-created queries, which fold `getArgs(initialPageParam)` through `mergeFactoryQueryKey`. This moves that into the shared impl so every infinite query gets it, and stops the factories from pre-merging so the args are not appended twice — that double-merge hazard is the reason the fix is a small refactor rather than a one-liner.

`getKeyArgs` moves from the factory config onto the base config for the same reason. It now narrows the key for **every** infinite query, which is what you want when the args embed the cursor and only part of them identifies the query:

```ts
createInfiniteQuery(reactor, {
  functionName: "get_posts",
  initialPageParam: 0n,
  getArgs: (cursor) => [{ cursor, limit: 10n }],
  getKeyArgs: ([args]) => [{ limit: args.limit }],  // cursor excluded
  getNextPageParam: (page) => page.next,
})
```

Applied consistently across all four call sites: `createInfiniteQuery`, `createSuspenseInfiniteQuery`, `useActorInfiniteQuery`, `useActorSuspenseInfiniteQuery`.

## Verification

`packages/react`: 301 tests pass. Three new tests cover distinct keys for distinct args, key stability across calls, and `getKeyArgs` collapsing cursor-bearing args onto one entry. **With the source change reverted, the distinct-keys guard fails**, so it is not vacuous.

Two existing key-shape assertions were updated to expect the args segment — that shape change is the fix.

Root `typecheck`, `typecheck:examples` (21 examples) and `format:check` are clean. Re-ran the live mainnet infinite-query suite: the only failures are the audit's own defect-documenting tests correctly inverting, plus one assertion of the old key shape. Pagination itself is unaffected — BigInt cursors still advance, pages still accumulate, `hasNextPage` still flips at the tip.

## Note for reviewers

This changes infinite-query cache keys, so those caches invalidate once on upgrade. Same class of change as #265; worth one combined release note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
