### PR TITLE
docs: require request-scoped reactors under SSR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,10 @@ Skills are structured instruction sets stored in `skill-packages/`. When a task 
   - query `.fetch()` / `.invalidate()` / `.getCacheData()`
   - mutation `.execute()`
   - reactor `.fetchQuery()` / `.getQueryData()` / `.invalidateQueries()` / `.callMethod()`
+- On a server (SSR/RSC), build the reactor inside the request rather than at
+  module scope. A reactor owns its `QueryClient` and query keys carry no caller
+  principal, so a module-scope reactor shares one cache across all requests and
+  can serve one user's caller-scoped data to another.
 
 ## Cache Invalidation
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -314,9 +314,30 @@ Agents should account for these patterns in generated TypeScript:
 | App stack | Recommended path |
 | --------- | ---------------- |
 | Vite + React | `@ic-reactor/vite-plugin` + generated declarations/hooks |
-| Next.js (pages/app router) | CLI generation + reusable query/mutation factories in shared modules |
+| Next.js (pages/app router) | CLI generation + factories; hooks in `"use client"` modules. On the server build the reactor per request (see SSR rule below) |
 | TanStack Router | query/mutation factories with `.fetch()` for loaders and `.useQuery()` for components |
 | Plain TS/node scripts | `@ic-reactor/core` + imperative APIs (`callMethod`, `fetchQuery`, `invalidateQueries`) |
+
+### SSR rule
+
+A reactor owns its `QueryClient`, and query keys are
+`[canisterId, functionName, args]` with no caller principal. A module-scope
+reactor on a server is therefore shared by every request, so a cached
+caller-scoped result (`get_my_balance`, deposit address, `my_profile`) is served
+to the next request. Under SSR/RSC, construct the reactor inside the request:
+
+```ts
+const app = defineReactor<_SERVICE>({
+  name: "backend",
+  idlFactory,
+  canisterId,
+  queryClient: new QueryClient(),
+})
+```
+
+Module scope stays correct for client-only SPAs. Hooks are client-only; they
+also bind to their reactor's own `QueryClient`, so `HydrationBoundary` prefetch
+does not reach them unless the provider's client is that same instance.
 
 ## Generated File Boundaries
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -313,6 +313,54 @@ must send `signedAttributes.data` and `signedAttributes.signature` to the backen
 or canister and verify the signature, nonce, origin, timestamp, and requested keys
 before trusting or storing the attributes.
 
+## Server-Side Rendering
+
+**Build the reactor inside the request, not at module scope.**
+
+A reactor owns its `QueryClient`. On a server a module-scope reactor is created
+once per process and shared by every request, and query keys are
+`[canisterId, functionName, args]` — they do not include the caller. So a
+cached result for a caller-scoped method (`get_my_balance`, a deposit address,
+`my_profile`) is handed to whichever request asks next:
+
+```tsx
+// ❌ Shared by every request on the server
+export const app = defineReactor<_SERVICE>({
+  name: "backend",
+  idlFactory,
+  canisterId,
+})
+```
+
+```tsx
+// ✅ Per request: nothing is shared between users
+export default async function Page() {
+  const app = defineReactor<_SERVICE>({
+    name: "backend",
+    idlFactory,
+    canisterId,
+    queryClient: new QueryClient(),
+  })
+
+  const data = await app.reactor.fetchQuery({ functionName: "get_my_profile" })
+  return <Profile data={data} />
+}
+```
+
+Two further constraints on the App Router specifically:
+
+- Hooks are client-only, like every React hook — call them from a `"use client"`
+  module. A server component may import `Reactor` / `ClientManager` and make
+  imperative calls; that path works.
+- Hooks bind to their reactor's own `QueryClient` rather than to a
+  `QueryClientProvider`, so `HydrationBoundary` prefetch does not feed them
+  unless the provider's client _is_ that reactor's client. Next.js also
+  evaluates a shared module twice on the server (the RSC and SSR graphs), so a
+  module-scope reactor is two different instances there.
+
+If none of that applies — a client-only SPA — module-scope reactors are exactly
+right and none of this is a concern.
+
 ## Query Result Methods
 
 Every object returned by `createQuery`, `createSuspenseQuery`, and their


### PR DESCRIPTION
Addresses #235.

## What this does

Documents the constraint and the pattern that avoids it, rather than changing runtime behaviour. Making the reactor's `QueryClient` swappable per request is the follow-up; this unblocks the release with honest guidance.

## The problem

A reactor owns its `QueryClient`, and `generateQueryKey` produces `[canisterId, functionName, args]` with **no caller principal**. On a server a module-scope reactor is created once per process and shared by every request, so a cached result for a caller-scoped method (`get_my_balance`, a deposit address, `my_profile`) is handed to whichever request asks next.

Reproduced over real HTTP against `next start` — three requests to a `force-dynamic` route where the first seeds a caller-scoped value:

```
R1 alice  cache-before=ALICE-PRIVATE-VALUE  returned=ALICE-PRIVATE-VALUE  ms=0  leaked=false
R2 bob    cache-before=ALICE-PRIVATE-VALUE  returned=ALICE-PRIVATE-VALUE  ms=0  leaked=true
R3 carol  cache-before=ALICE-PRIVATE-VALUE  returned=ALICE-PRIVATE-VALUE  ms=0  leaked=true
```

`elapsed-ms=0` proves no network call — bob and carol were served alice's cached value.

**The docs pointed straight at it.** `llms-full.txt` listed Next.js as supported via "reusable query/mutation factories in shared modules", and `CLAUDE.md` sent non-React contexts to `reactor.fetchQuery()` with no server caveat. That combination is exactly what leaks.

## The fix works, and I verified it before documenting it

Constructing the reactor inside the request isolates it completely. Side by side on the same server, same build:

```
per-request route          module-scope route (control)
alice  cache-before=undefined -> ALICE-PRIVATE-VALUE seeded, leaked=false
bob    cache-before=undefined    cache-before=ALICE-PRIVATE-VALUE
       returned=ICP              leaked=true
       leaked=false
carol  cache-before=undefined
       returned=ICP  leaked=false
```

```tsx
// ✅ Per request
const app = defineReactor<_SERVICE>({
  name: "backend",
  idlFactory,
  canisterId,
  queryClient: new QueryClient(),
})
```

## Also documented

Two related App Router constraints that were previously undocumented and cost real debugging time during the audit:

- Hooks bind to their reactor's own `QueryClient` rather than to a `QueryClientProvider`, so `HydrationBoundary` prefetch does not reach them unless the provider's client *is* that reactor's client. Measured: two entries hydrated at the exact query key, `hook-status=pending`.
- Next.js evaluates a shared module **twice** on the server (the `[app-rsc]` and `[app-ssr]` graphs), so a module-scope reactor is two independent instances with two caches — an RSC prefetch cannot reach the hooks even in principle.

Module scope remains correct for client-only SPAs, and the README says so explicitly so this does not read as a blanket warning.

## Files

`packages/react/README.md` (new Server-Side Rendering section), `llms-full.txt` (routing table entry + SSR rule), `CLAUDE.md` (server caveat on the imperative-API guidance).

`check:ai-context`, `format:check`, `typecheck` and 305 react tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
