### PR TITLE
fix(react): memoize the chained select so the observer can reuse its result

### DIFF
--- a/packages/react/src/createInfiniteQuery.ts
+++ b/packages/react/src/createInfiniteQuery.ts
@@ -22,6 +22,7 @@
  * postsQuery.invalidate()
  */
 
+import { useMemo } from "react"
 import type {
   Reactor,
   FunctionName,
@@ -44,7 +45,11 @@ import {
 } from "@tanstack/react-query"
 import { CallConfig } from "@icp-sdk/core/agent"
 import { NoInfer } from "./types.js"
-import { mergeFactoryQueryKey, normalizeQueryData } from "./utils.js"
+import {
+  buildChainedSelect,
+  mergeFactoryQueryKey,
+  normalizeQueryData,
+} from "./utils.js"
 
 type InfiniteQueryFactoryFn<
   Service,
@@ -384,14 +389,12 @@ const createInfiniteQueryImpl = <
     Selected,
     TError
   > = (options: any): any => {
-    // Chain the selects: raw -> config.select -> options.select
-    const chainedSelect = (rawData: TInfiniteData) => {
-      const firstPass = select ? select(rawData) : rawData
-      if (options?.select) {
-        return options.select(firstPass)
-      }
-      return firstPass
-    }
+    // Memoized and identity-preserving; see buildChainedSelect for why the
+    // function identity matters to the observer's select-result cache.
+    const chainedSelect = useMemo(
+      () => buildChainedSelect(select as never, options?.select),
+      [options?.select]
+    )
 
     return useInfiniteQuery(
       {

--- a/packages/react/src/createQuery.ts
+++ b/packages/react/src/createQuery.ts
@@ -30,6 +30,7 @@ import type {
   ReactorArgs,
   TransformKey,
 } from "@ic-reactor/core"
+import { useMemo } from "react"
 import {
   QueryKey,
   useQuery,
@@ -110,6 +111,12 @@ const createQueryImpl = <
 
   const useQueryHook = ((options?: UseQueryHookOptions) => {
     const baseOptions = reactor.getQueryOptions(params)
+    // Memoized so the observer's select-result cache can hit; see
+    // buildChainedSelect. `select` comes from the factory config and is stable.
+    const chainedSelect = useMemo(
+      () => buildChainedSelect(select, options?.select),
+      [options?.select]
+    )
     return useQuery(
       {
         queryKey: baseOptions.queryKey,
@@ -117,7 +124,7 @@ const createQueryImpl = <
         ...rest,
         ...options,
         queryFn: baseOptions.queryFn,
-        select: buildChainedSelect(select, options?.select),
+        select: chainedSelect,
       },
       reactor.queryClient
     )

--- a/packages/react/src/createSuspenseInfiniteQuery.ts
+++ b/packages/react/src/createSuspenseInfiniteQuery.ts
@@ -24,6 +24,7 @@
  * const allPosts = data.pages.flatMap(page => page.posts)
  */
 
+import { useMemo } from "react"
 import type {
   Reactor,
   FunctionName,
@@ -46,7 +47,11 @@ import {
 } from "@tanstack/react-query"
 import { CallConfig } from "@icp-sdk/core/agent"
 import { NoInfer } from "./types.js"
-import { mergeFactoryQueryKey, normalizeQueryData } from "./utils.js"
+import {
+  buildChainedSelect,
+  mergeFactoryQueryKey,
+  normalizeQueryData,
+} from "./utils.js"
 
 type SuspenseInfiniteFactoryCallOptions = {
   queryKey?: QueryKey
@@ -380,14 +385,12 @@ const createSuspenseInfiniteQueryImpl = <
     Selected,
     TError
   > = (options: any): any => {
-    // Chain the selects: raw -> config.select -> options.select
-    const chainedSelect = (rawData: TInfiniteData) => {
-      const firstPass = select ? select(rawData) : rawData
-      if (options?.select) {
-        return options.select(firstPass)
-      }
-      return firstPass
-    }
+    // Memoized and identity-preserving; see buildChainedSelect for why the
+    // function identity matters to the observer's select-result cache.
+    const chainedSelect = useMemo(
+      () => buildChainedSelect(select as never, options?.select),
+      [options?.select]
+    )
 
     return useSuspenseInfiniteQuery(
       {

--- a/packages/react/src/createSuspenseQuery.ts
+++ b/packages/react/src/createSuspenseQuery.ts
@@ -25,6 +25,7 @@ import type {
   ReactorArgs,
   TransformKey,
 } from "@ic-reactor/core"
+import { useMemo } from "react"
 import { useSuspenseQuery } from "@tanstack/react-query"
 import type {
   QueryFnData,
@@ -95,6 +96,12 @@ const createSuspenseQueryImpl = <
     TError
   > = (options: any): any => {
     const baseOptions = reactor.getQueryOptions(params)
+    // Memoized so the observer's select-result cache can hit; see
+    // buildChainedSelect. `select` comes from the factory config and is stable.
+    const chainedSelect = useMemo(
+      () => buildChainedSelect(select, options?.select),
+      [options?.select]
+    )
     return useSuspenseQuery(
       {
         queryKey: baseOptions.queryKey,
@@ -102,7 +109,7 @@ const createSuspenseQueryImpl = <
         ...rest,
         ...options,
         queryFn: baseOptions.queryFn,
-        select: buildChainedSelect(select, options?.select),
+        select: chainedSelect,
       },
       reactor.queryClient
     )

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -46,20 +46,31 @@ export function mergeFactoryQueryKey(
 }
 
 /**
- * Build a chained select function that first applies the config-level select
- * (if any) and then the hook-level select (if any).
+ * Build a chained select that applies the config-level select (if any) and then
+ * the hook-level select (if any).
  *
- * This enables `createQuery` / `createSuspenseQuery` to support two-level
- * select chaining without duplicating the logic.
+ * Returns the caller's own function untouched when only one of the two is
+ * present, and `undefined` when neither is — allocating a wrapper only for the
+ * genuinely chained case. Identity matters here: `QueryObserver` memoizes a
+ * select result on `options.select === previousSelectFn`, so a wrapper rebuilt
+ * on every render defeats that check. The select then re-runs each render, and
+ * for a select returning a non-plain value (a `Map`, a `Date`, a `Principal`)
+ * `replaceEqualDeep` cannot structurally share the result either, so `data`
+ * gets a fresh reference every render and a `useEffect([data])` that sets state
+ * becomes an unbounded loop.
+ *
+ * Callers should still memoize the result, since the chained case allocates.
  */
 export function buildChainedSelect<TData, TSelected, TFinal = TSelected>(
   configSelect: ((data: TData) => TSelected) | undefined,
   hookSelect: ((data: TSelected) => TFinal) | undefined
-): (rawData: TData) => TSelected | TFinal {
-  return (rawData: TData) => {
-    const firstPass = configSelect
-      ? configSelect(rawData)
-      : (rawData as unknown as TSelected)
-    return hookSelect ? hookSelect(firstPass) : firstPass
+): ((rawData: TData) => TSelected | TFinal) | undefined {
+  if (!configSelect) {
+    // `hookSelect` receives the raw data when there is no config-level select,
+    // matching the previous behaviour.
+    return hookSelect as unknown as
+      ((rawData: TData) => TSelected | TFinal) | undefined
   }
+  if (!hookSelect) return configSelect
+  return (rawData: TData) => hookSelect(configSelect(rawData))
 }

--- a/packages/react/tests/createQuery.test.tsx
+++ b/packages/react/tests/createQuery.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ActorMethod } from "@icp-sdk/core/agent"
 import { Reactor } from "@ic-reactor/core"
 import { createQuery, createQueryFactory } from "../src/createQuery.js"
+import { buildChainedSelect } from "../src/utils.js"
 
 // Define Actor Interface
 interface User {
@@ -511,5 +512,76 @@ describe("createQuery - setData", () => {
     await waitFor(() => {
       expect(result.current.data).toEqual(updated)
     })
+  })
+})
+
+describe("createQuery - select memoization", () => {
+  let queryClient: QueryClient
+  let mockReactor: ReturnType<typeof createMockReactor>
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    mockReactor = createMockReactor(queryClient)
+  })
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  it("does not re-run a config select on every render", async () => {
+    // Regression: the chained select used to be a fresh closure each render, so
+    // QueryObserver's `options.select === previousSelectFn` memo never hit and
+    // the select re-ran per render.
+    const select = vi.fn((user: User) => user.name)
+    const query = createQuery(mockReactor, {
+      functionName: "get_user",
+      select,
+    })
+
+    const { result, rerender } = renderHook(() => query.useQuery(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const afterLoad = select.mock.calls.length
+    for (let i = 0; i < 5; i++) rerender()
+
+    expect(select.mock.calls.length).toBe(afterLoad)
+  })
+
+  it("keeps data reference-stable across renders for a non-plain select result", async () => {
+    // A Map cannot be structurally shared by replaceEqualDeep, so an unstable
+    // select handed the consumer a new reference every render — which turns any
+    // useEffect([data]) that sets state into an unbounded loop.
+    const query = createQuery(mockReactor, {
+      functionName: "get_user",
+      select: (user: User) => new Map([["name", user.name]]),
+    })
+
+    const { result, rerender } = renderHook(() => query.useQuery(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const seen = new Set<unknown>()
+    for (let i = 0; i < 5; i++) {
+      seen.add(result.current.data)
+      rerender()
+    }
+
+    expect(seen.size).toBe(1)
+  })
+
+  it("passes the caller's own function through when only one select is present", () => {
+    const configSelect = (user: User) => user.name
+    const query = createQuery(mockReactor, {
+      functionName: "get_user",
+      select: configSelect,
+    })
+    // No wrapper is allocated for the single-select case, so a module-scope
+    // select stays referentially stable for the observer.
+    expect(query).toBeDefined()
+    expect(buildChainedSelect(configSelect, undefined)).toBe(configSelect)
+    const hookSelect = (name: string) => name
+    expect(buildChainedSelect(undefined, hookSelect)).toBe(hookSelect)
+    expect(buildChainedSelect(undefined, undefined)).toBeUndefined()
   })
 })


### PR DESCRIPTION
Fixes #252.

## The problem

All four query factories rebuilt the chained select on every render. `QueryObserver` memoizes a select result on `options.select === previousSelectFn`, so a fresh closure each render meant that check never hit.

Two consequences, the second serious:

- The configured `select` re-ran on every render.
- When `select` returns a **non-plain value** — `new Map(metadata)`, `new Date(Number(ns / 1_000_000n))`, `Principal.fromText(...)`, all natural IC transforms — `replaceEqualDeep` cannot structurally share it, so `data` got a **new reference every render** and any `useEffect([data])` that sets state became an unbounded render loop.

Measured before the fix: 5 select invocations across 5 forced re-renders (control with a stable select: 0), and 5 distinct `data` references for a `Map`-returning select versus 1 for a plain object.

## The fix

`buildChainedSelect` now preserves identity — it returns the caller's own function when only one of the two selects is present, and `undefined` when neither is, allocating a wrapper only for the genuinely chained case. That alone makes the common single-select path referentially stable, since a factory config is created once.

Call sites memoize on the per-call select. The two infinite factories duplicated the chaining logic inline; they now share the helper.

## Verification

`packages/react`: 311 tests pass. Three new regression tests — a config select is not re-invoked across five forced renders, a `Map`-returning select keeps one stable `data` reference, and the single-select / no-select cases return the caller's function and `undefined`. **All three fail with the source change reverted.**

Root `typecheck`, `typecheck:examples` (21 examples) and `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
