### PR TITLE
fix(core): scope callMethodWithValidation's validator removal to one tick

### DIFF
--- a/packages/core/src/display-reactor.ts
+++ b/packages/core/src/display-reactor.ts
@@ -269,21 +269,34 @@ export class DisplayReactor<
       }
     }
 
-    // Skip synchronous validation in transformArgs by temporarily removing validator
+    // The validator has already run above, so `transformArgs` must not run it
+    // again synchronously (it would reject an async validator outright). It is
+    // removed to achieve that — but `validators` is shared reactor state, so the
+    // removal must not outlive this call's synchronous section, or every other
+    // caller is unvalidated for the 2-15s an update takes: a second submit, a
+    // different component calling callMethod(), or a form calling validate() on
+    // change, which would report success for input it otherwise rejects.
+    //
+    // `callMethod` invokes `transformArgs` synchronously, before it awaits
+    // anything, so starting the call and restoring the validator in the same
+    // tick keeps the gap unobservable — no other code can interleave. The
+    // promise is awaited only after the validator is back in place.
     const validator = this.validators.get(params.functionName)
     if (validator) {
       this.validators.delete(params.functionName)
     }
 
+    let pending: Promise<ReactorReturnOk<A, M, T>>
     try {
       // @ts-ignore
-      return await this.callMethod(params)
+      pending = this.callMethod(params)
     } finally {
-      // Restore validator
       if (validator) {
         this.validators.set(params.functionName, validator)
       }
     }
+
+    return await pending
   }
 
   // ============================================================================

--- a/packages/core/tests/display-reactor-validation.test.ts
+++ b/packages/core/tests/display-reactor-validation.test.ts
@@ -364,3 +364,55 @@ describe("DisplayReactor with Validation", () => {
     })
   })
 })
+
+describe("DisplayReactor validator scoping", () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const clientManager = new ClientManager({ queryClient })
+
+  it("keeps the validator registered for concurrent callers during an in-flight call", async () => {
+    // Regression: the validator was removed for the whole duration of the call
+    // (2-15s for a real update), so every other consumer of the reactor was
+    // unvalidated in that window — and validate() actively reported success for
+    // input it otherwise rejects.
+    const reactor = new DisplayReactor<TestActor>({
+      name: "test-reactor",
+      idlFactory,
+      canisterId,
+      clientManager,
+    })
+
+    reactor.registerValidator("transfer", async ([input]) => {
+      if (input.to === "blocked-address") {
+        return {
+          success: false,
+          issues: [{ path: ["to"], message: "This address is blocked" }],
+        }
+      }
+      return { success: true }
+    })
+
+    // Hold the call open: callMethod returns a promise that never settles, so
+    // the reactor stays mid-flight for the rest of the test.
+    const callMethodSpy = vi
+      .spyOn(reactor, "callMethod")
+      .mockImplementation((() => new Promise(() => {})) as never)
+
+    const inFlight = reactor.callMethodWithValidation({
+      functionName: "transfer",
+      args: [{ to: "allowed", amount: "1" }],
+    })
+    inFlight.catch(() => undefined)
+
+    await vi.waitFor(() => expect(callMethodSpy).toHaveBeenCalled())
+
+    // Mid-flight, the reactor must look exactly as it does at rest.
+    expect(reactor.hasValidator("transfer")).toBe(true)
+    await expect(
+      reactor.validate("transfer", [
+        { to: "blocked-address", amount: "1" },
+      ] as never)
+    ).resolves.toMatchObject({ success: false })
+  })
+})


### PR DESCRIPTION
Fixes #241.

## The problem

`callMethodWithValidation` runs the async validator itself, then removes the validator so `transformArgs` will not run it again synchronously (which would reject an async validator outright). But `validators` is **shared reactor state**, and the removal spanned the entire awaited call — 2-15s for a real update on mainnet.

Verified live against the ckTESTBTC ledger:

```
baseline (lone call):   forbidden args -> ValidationError, validator saw ['1']

600 ms into an in-flight call:
  hasValidator('icrc1_transfer')            === false
  await validate('icrc1_transfer', [bad])   === { success: true }
  the concurrent forbidden call reached the ledger
  the validator never saw the forbidden input at all
```

So a second submit, another component calling `callMethod()`, or a form calling `reactor.validate()` on change all bypassed validation — and the form was actively told the bad input was valid.

## The fix

`callMethod` invokes `transformArgs` synchronously, before it awaits anything. Starting the call and restoring the validator **in the same tick** therefore keeps the gap unobservable — no other code can interleave — and the promise is awaited only after the validator is back in place.

Six lines; no API change.

## Verification

The regression test holds a call open by stubbing `callMethod` with a promise that never settles, then asserts the reactor looks exactly as it does at rest: `hasValidator()` is true and `validate()` still rejects forbidden args. **It fails with the source change reverted.**

core: 196 tests pass; root typecheck and format:check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)