### PR TITLE
fix(core): surface argument codec failures instead of swallowing them

### DIFF
--- a/packages/core/src/display/helper.ts
+++ b/packages/core/src/display/helper.ts
@@ -45,18 +45,28 @@ export function transformArgsWithCodec<T extends unknown[]>(
     return (args || []) as T
   }
 
+  // A codec failure is the most precise diagnostic available — it names the
+  // field and the expected shape. Swallowing it and passing the untransformed
+  // display args on to IDL.encode replaced that with a generic Candid error
+  // raised far from the real cause, or silently encoded something the caller
+  // did not intend. Fail here instead, preserving the original error as `cause`.
+  const failed = (err: unknown, shape: string): never => {
+    const error = new Error(
+      `[ic-reactor] Could not convert ${shape} from display types to Candid: ` +
+        `${err instanceof Error ? err.message : String(err)}`
+    )
+    // Assigned rather than passed to the constructor: the package targets a lib
+    // without the ErrorOptions overload.
+    ;(error as Error & { cause?: unknown }).cause = err
+    throw error
+  }
+
   // Single argument - unwrap from array and transform
   if (args.length === 1) {
     try {
       return [argsCodec.asCandid(args[0])] as T
     } catch (err) {
-      // Log the failure so it is visible during development; return as-is as
-      // a best-effort fallback so callers can still surface IDL encode errors.
-      console.error(
-        "[ic-reactor] transformArgsWithCodec failed (single arg):",
-        err
-      )
-      return args as T
+      return failed(err, "the argument")
     }
   }
 
@@ -64,11 +74,7 @@ export function transformArgsWithCodec<T extends unknown[]>(
   try {
     return argsCodec.asCandid(args) as T
   } catch (err) {
-    console.error(
-      "[ic-reactor] transformArgsWithCodec failed (tuple args):",
-      err
-    )
-    return args as T
+    return failed(err, "the arguments")
   }
 }
 

--- a/packages/core/tests/display-args-codec-errors.test.ts
+++ b/packages/core/tests/display-args-codec-errors.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest"
+import { IDL } from "@icp-sdk/core/candid"
+import {
+  didToDisplayCodec,
+  transformArgsWithCodec,
+} from "../src/display/index.js"
+
+/**
+ * A codec failure is the most precise diagnostic available — it names the field
+ * and the expected shape. It used to be swallowed and the untransformed display
+ * args passed on to `IDL.encode`, which produced a generic Candid error far
+ * from the real cause, or silently encoded something the caller did not intend.
+ */
+describe("transformArgsWithCodec — argument conversion failures", () => {
+  const accountCodec = didToDisplayCodec(
+    IDL.Record({ owner: IDL.Principal, amount: IDL.Nat })
+  )
+
+  it("throws instead of returning the untransformed args", () => {
+    expect(() =>
+      transformArgsWithCodec(accountCodec, [{ owner: 42, amount: "1" }])
+    ).toThrow(/could not convert the argument/i)
+  })
+
+  it("preserves the codec's own error as `cause`", () => {
+    let caught: unknown
+    try {
+      transformArgsWithCodec(accountCodec, [{ owner: 42, amount: "1" }])
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(Error)
+    expect((caught as Error & { cause?: unknown }).cause).toBeDefined()
+  })
+
+  it("does not log to console.error any more", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    try {
+      transformArgsWithCodec(accountCodec, [{ owner: 42, amount: "1" }])
+    } catch {
+      // expected
+    }
+    expect(spy).not.toHaveBeenCalled()
+    spy.mockRestore()
+  })
+
+  it("still passes valid args through untouched", () => {
+    const codec = didToDisplayCodec(IDL.Record({ amount: IDL.Nat }))
+    expect(transformArgsWithCodec(codec, [{ amount: "10" }])).toEqual([
+      { amount: 10n },
+    ])
+  })
+
+  it("leaves empty args alone", () => {
+    expect(transformArgsWithCodec(accountCodec, [])).toEqual([])
+    expect(transformArgsWithCodec(accountCodec, undefined)).toEqual([])
+  })
+})


### PR DESCRIPTION
Fixes #244.

## The problem

`transformArgsWithCodec` caught **every** error from the args codec, `console.error`d it, and returned the caller's display args unchanged as a "best-effort fallback" (helper.ts:49-72).

Two consequences:

1. The library's own precise diagnostics — e.g. visitor.ts's `Cannot encode …`, which names the offending field and the expected shape — never reached the caller.
2. Untransformed display values (principal **strings**, bigint-as-string, hex blobs) were handed to `IDL.encode`, which then failed with a generic Candid error far from the real cause — or silently encoded something the caller did not intend.

This is why the rejected canonical-optional forms in #242 surfaced as an opaque failure rather than the targeted message the codec had already generated.

## The fix

Throw, wrapping the codec's error as `cause` so the original diagnostic is still reachable.

## Deliberately not changed

The mirror-image swallow on the **result** path stays. It was investigated during the audit and found unreachable: 30 live display results were deep-walked with zero leaks, and the fallback never fired once, because `transformResult` only ever sees values produced by `IDL.decode` against the very service that built the codec. The args side has no such protection, since the caller supplies the input directly.

## Verification

Five tests: it throws rather than returning untransformed args, the codec error is preserved as `cause`, nothing is logged to `console.error` any more, valid args still pass through, and empty args are untouched. **Three fail with the source change reverted.**

core 200 tests and react 312 tests pass; root typecheck and format:check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)