### PR TITLE
fix(react): skip undefined invalidateQueries entries in useActorMutation

### DIFF
--- a/packages/react/src/hooks/useActorMutation.ts
+++ b/packages/react/src/hooks/useActorMutation.ts
@@ -35,7 +35,14 @@ export interface UseActorMutationParameters<
   reactor: Reactor<Service, Transform>
   functionName: Method
   callConfig?: CallConfig
-  invalidateQueries?: QueryKey[]
+  /**
+   * Queries to invalidate upon successful mutation.
+   *
+   * `undefined` entries are skipped, so the common
+   * `[maybeQuery?.getQueryKey()]` idiom is safe when the optional query object
+   * is absent.
+   */
+  invalidateQueries?: (QueryKey | undefined)[]
   /**
    * Callback for canister-level business logic errors.
    * Called when the canister returns a Result { Err: E } variant.
@@ -126,10 +133,18 @@ export const useActorMutation = <
       >
     ) => {
       if (invalidateQueries) {
+        // Skip undefined entries. React Query reads `{ queryKey: undefined }`
+        // as "match everything", so a single undefined — which the natural
+        // `invalidateQueries: [maybeQuery?.getQueryKey()]` idiom produces
+        // whenever the optional query object is absent — would invalidate every
+        // query in the client, including an app's unrelated non-canister ones.
+        // `createMutation.invalidateAll` already filters the same way.
         await Promise.all(
-          invalidateQueries.map((queryKey) =>
-            reactor.queryClient.invalidateQueries({ queryKey })
-          )
+          invalidateQueries
+            .filter((queryKey) => queryKey !== undefined)
+            .map((queryKey) =>
+              reactor.queryClient.invalidateQueries({ queryKey })
+            )
         )
       }
       await onSuccess?.(...params)

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -356,8 +356,14 @@ export interface MutationConfig<
   functionName: Method
   /** Call configuration for the actor method */
   callConfig?: CallConfig
-  /** Queries to invalidate upon successful mutation */
-  invalidateQueries?: QueryKey[]
+  /**
+   * Queries to invalidate upon successful mutation.
+   *
+   * `undefined` entries are skipped, so the common
+   * `[maybeQuery?.getQueryKey()]` idiom is safe when the optional query object
+   * is absent.
+   */
+  invalidateQueries?: (QueryKey | undefined)[]
   /**
    * Callback for canister-level business logic errors.
    * Called when the canister returns a Result { Err: E } variant.

--- a/packages/react/tests/useActorMutation-invalidate.test.tsx
+++ b/packages/react/tests/useActorMutation-invalidate.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { ActorMethod } from "@icp-sdk/core/agent"
+import { Reactor } from "@ic-reactor/core"
+import { useActorMutation } from "../src/hooks/useActorMutation.js"
+
+interface TestActor {
+  update_profile: ActorMethod<[{ name: string }], boolean>
+}
+
+const createMockReactor = (queryClient: QueryClient) =>
+  ({
+    queryClient,
+    callMethod: vi.fn().mockResolvedValue(true),
+    generateQueryKey: vi
+      .fn()
+      .mockImplementation(({ functionName }) => [
+        "test-canister",
+        functionName,
+      ]),
+    getQueryOptions: vi.fn().mockImplementation((params) => ({
+      queryKey: ["test-canister", params.functionName],
+      queryFn: () => Promise.resolve(true),
+    })),
+  }) as unknown as Reactor<TestActor>
+
+describe("useActorMutation — invalidateQueries entries", () => {
+  let queryClient: QueryClient
+  let reactor: Reactor<TestActor>
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    reactor = createMockReactor(queryClient)
+  })
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  it("skips undefined entries instead of invalidating the entire client", async () => {
+    // Regression: React Query reads `{ queryKey: undefined }` as "match
+    // everything", so one undefined entry wiped every query in the client —
+    // including an app's unrelated non-canister queries. The natural
+    // `[maybeQuery?.getQueryKey()]` idiom produces exactly that.
+    queryClient.setQueryData(["unrelated", "a"], "A")
+    queryClient.setQueryData(["unrelated", "b"], "B")
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+
+    const { result } = renderHook(
+      () =>
+        useActorMutation({
+          reactor,
+          functionName: "update_profile",
+          invalidateQueries: [undefined],
+        }),
+      { wrapper }
+    )
+
+    result.current.mutate([{ name: "Alice" }])
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidateSpy).not.toHaveBeenCalled()
+    expect(queryClient.getQueryState(["unrelated", "a"])?.isInvalidated).toBe(
+      false
+    )
+    expect(queryClient.getQueryState(["unrelated", "b"])?.isInvalidated).toBe(
+      false
+    )
+  })
+
+  it("still invalidates the defined entries alongside an undefined one", async () => {
+    queryClient.setQueryData(["test-canister", "get_profile"], "old")
+    queryClient.setQueryData(["unrelated", "a"], "A")
+
+    const { result } = renderHook(
+      () =>
+        useActorMutation({
+          reactor,
+          functionName: "update_profile",
+          invalidateQueries: [undefined, ["test-canister", "get_profile"]],
+        }),
+      { wrapper }
+    )
+
+    result.current.mutate([{ name: "Alice" }])
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(
+      queryClient.getQueryState(["test-canister", "get_profile"])?.isInvalidated
+    ).toBe(true)
+    expect(queryClient.getQueryState(["unrelated", "a"])?.isInvalidated).toBe(
+      false
+    )
+  })
+})


### PR DESCRIPTION
Fixes #255.

## The problem

React Query reads `{ queryKey: undefined }` as "match everything", so a single undefined entry invalidated **every query in the client** — including an app's unrelated non-canister queries.

```
invalidateQueries: [undefined]
  -> unrelatedA_invalidated: true
  -> unrelatedB_invalidated: true
```

`createMutation.invalidateAll` already filtered undefined (createMutation.ts:49-58); the hook path did not.

## The types pushed users into it

`MutationHookOptions.invalidateQueries` was `(QueryKey | undefined)[]` (types.ts:424) while `useActorMutation`'s own parameter and `MutationConfig` (types.ts:360) were the stricter `QueryKey[]` — so `[maybeQuery?.getQueryKey()]` compiled at one level and errored at another. All three now accept `(QueryKey | undefined)[]`, which is safe because every path filters.

## Verification

Two tests: one undefined entry leaves unrelated queries untouched and calls `invalidateQueries` zero times; a mixed list still invalidates the defined entries and only those. **Both fail with the source change reverted.**

310 react tests pass; root typecheck and format:check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)