### PR TITLE
fix(core): include ValidationError in ReactorReturnErr

### DIFF
--- a/packages/core/src/types/reactor.ts
+++ b/packages/core/src/types/reactor.ts
@@ -7,7 +7,11 @@ import type {
 import type { Principal } from "@icp-sdk/core/principal"
 import type { QueryKey } from "@tanstack/query-core"
 import type { ClientManager } from "../client.js"
-import type { CallError, CanisterError } from "../errors/index.js"
+import type {
+  CallError,
+  CanisterError,
+  ValidationError,
+} from "../errors/index.js"
 import type { OkResult, ErrResult } from "./result.js"
 import type { DisplayOf, ActorDisplayCodec } from "../display/index.js"
 
@@ -157,6 +161,11 @@ export type ReactorReturnErr<
       >[Transform]
     >
   | CallError
+  // A DisplayReactor with a registered validator throws this before the call
+  // leaves the client, so it reaches exactly the same catch blocks and hook
+  // `error` slots as the other two. Omitting it made those handlers look
+  // exhaustive when they were not.
+  | ValidationError
 
 /**
  * Helper type for actor method codecs returend by getCodec


### PR DESCRIPTION
Fixes #249.

A `DisplayReactor` with a registered validator throws `ValidationError` before the call ever leaves the client, so it lands in exactly the same catch blocks and hook `error` slots as `CanisterError` and `CallError`. The published type listed only the latter two:

```ts
// core/dist/types/reactor.d.ts
export type ReactorReturnErr<...> = CanisterError<...> | CallError
```

and that type is the `TError` of `UseActorQueryResult` (react/src/hooks/useActorQuery.ts:56). So consumer error handling looked exhaustive when it was not — a `ValidationError` could arrive in `error` while being absent from the union the compiler checked against.

Type-only change; no runtime behaviour is affected.

## Verification

Root typecheck clean, all 21 examples type-check cleanly, core 200 and react 310 tests pass, format:check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)