### PR TITLE
fix(react): re-observe delegation expiry and stop stranding isAuthenticating

### DIFF
--- a/packages/react/src/auth/authentication-manager.ts
+++ b/packages/react/src/auth/authentication-manager.ts
@@ -156,7 +156,24 @@ export class AuthenticationManager {
 
   public authenticate = async (): Promise<Identity | undefined> => {
     if (this.authState.isAuthenticated) {
-      return this.authState.identity || undefined
+      // Returning on the cached flag alone meant a delegation that expired
+      // mid-session was never re-observed: the UI kept rendering a signed-in
+      // state while every update call failed, and only a reload recovered.
+      // Re-ask the client, which reads the cached expiry rather than hitting
+      // storage. A throw here is treated as "still valid" so a transient
+      // failure cannot sign anyone out.
+      if (!this.authClient) {
+        return this.authState.identity || undefined
+      }
+      const stillValid = await Promise.resolve(
+        this.authClient.isAuthenticated()
+      ).catch(() => true)
+      if (stillValid) {
+        return this.authState.identity || undefined
+      }
+      // Expired — drop the stale flag and fall through to re-derive state,
+      // which resets the agent to the anonymous identity.
+      this.updateState({ isAuthenticated: false })
     }
     if (this.authPromise) {
       return this.authPromise
@@ -279,14 +296,22 @@ export class AuthenticationManager {
       )
     }
     this.updateState({ isAuthenticating: true, error: undefined })
-    await this.authClient.signOut(options)
-    const identity = await this.authClient.getIdentity()
-    this.clientManager.updateAgent(identity)
-    this.updateState({
-      identity,
-      isAuthenticated: false,
-      isAuthenticating: false,
-    })
+    try {
+      await this.authClient.signOut(options)
+      const identity = await this.authClient.getIdentity()
+      this.clientManager.updateAgent(identity)
+      this.updateState({
+        identity,
+        isAuthenticated: false,
+        isAuthenticating: false,
+      })
+    } catch (error) {
+      // Without this the manager was left with `isAuthenticating: true` and no
+      // recorded error, so a button disabled on `isAuthenticating` stayed stuck
+      // and nothing told the app why.
+      this.updateState({ error: error as Error, isAuthenticating: false })
+      throw error
+    }
   }
 
   private async initializeClient(

--- a/packages/react/tests/auth/authentication-manager.test.ts
+++ b/packages/react/tests/auth/authentication-manager.test.ts
@@ -429,3 +429,72 @@ describe("AuthenticationManager", () => {
     })
   })
 })
+
+describe("AuthenticationManager session hygiene", () => {
+  let clientManager: ClientManager
+
+  beforeEach(() => {
+    authClientMocks.factory.mockReset()
+    vi.clearAllMocks()
+    ;(safeGetCanisterEnv as any).mockReturnValue(undefined)
+    clientManager = new ClientManager({ queryClient: new QueryClient() })
+    vi.spyOn(clientManager, "initializeAgent").mockResolvedValue()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("re-observes an expired delegation instead of trusting the cached flag", async () => {
+    // Regression: once authenticated, authenticate() returned on the cached
+    // flag and never consulted the client again, so a delegation that lapsed
+    // mid-session left the UI rendering a signed-in state indefinitely.
+    const authClient = createAuthClient()
+    const authentication = new AuthenticationManager({
+      clientManager,
+      authClient,
+    })
+
+    await authentication.login()
+    expect(authentication.authState.isAuthenticated).toBe(true)
+
+    // The delegation lapses; the client now reports signed out.
+    authClient.isAuthenticated.mockResolvedValue(false)
+    authClient.getIdentity.mockReturnValue(identity("2vxsx-fae"))
+
+    await authentication.authenticate()
+
+    expect(authentication.authState.isAuthenticated).toBe(false)
+  })
+
+  it("keeps the session when the expiry check itself fails", async () => {
+    // A transient failure must not sign anyone out.
+    const authClient = createAuthClient()
+    const authentication = new AuthenticationManager({
+      clientManager,
+      authClient,
+    })
+
+    await authentication.login()
+    authClient.isAuthenticated.mockRejectedValue(new Error("storage blip"))
+
+    await authentication.authenticate()
+
+    expect(authentication.authState.isAuthenticated).toBe(true)
+  })
+
+  it("does not strand isAuthenticating when signOut fails", async () => {
+    const authClient = createAuthClient()
+    authClient.signOut.mockRejectedValue(new Error("storage unavailable"))
+    const authentication = new AuthenticationManager({
+      clientManager,
+      authClient,
+    })
+    await authentication.login()
+
+    await expect(authentication.logout()).rejects.toThrow("storage unavailable")
+
+    expect(authentication.authState.isAuthenticating).toBe(false)
+    expect(authentication.authState.error).toBeInstanceOf(Error)
+  })
+})


### PR DESCRIPTION
Fixes #246. Partially addresses #250.

## 1. Delegation expiry was never re-observed (#246)

`authenticate()` returned on the cached flag, so once a session was established the auth client was never consulted again:

```
stub.isAuthenticated()                     false   (delegation expired)
authentication.authState.isAuthenticated   true
useAuth().isAuthenticated                  true
authClient calls after expiry:             []      <- never consulted again
```

The UI kept rendering a signed-in state while every update call failed with a generic `CallError`; only a reload recovered. Mitigated in practice by `@icp-sdk/auth`'s default idle-reload, so the reachable case is apps that set `idleOptions.disableIdle` — common for dashboards.

It now re-asks the client, which reads the cached expiry rather than hitting storage. A throw from that check is treated as "still valid", so a transient failure cannot sign anyone out.

## 2. logout() could strand isAuthenticating (#250, first item)

`logout()` set `isAuthenticating: true` then awaited `signOut()` with no catch:

```
logout() rejected with "signOut failed: storage unavailable"
authState.isAuthenticating === true
authState.error === undefined        <- a disabled={isAuthenticating} button is stuck
```

The failure is now recorded and the flag cleared before the error is rethrown.

## Verification

Three tests: an expired delegation flips the state, a failing expiry check keeps the session, and a failing `signOut` clears the flag and records the error. **The first and third fail with the source change reverted.**

311 react tests pass; root typecheck and format:check clean.

## Not covered here

The remaining #250 items live in other files and are left for separate PRs: identity-attribute PII retained across logout (`createIdentityAttributeHooks.ts`), the logout/authenticate race (`authentication-manager.ts`, needs the auth-state revision guard), and the fallback attribute decoder presenting wrong values (`identity-attributes.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)