### PR TITLE
fix(core): remove the previous principal's cached data on an identity switch

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -325,8 +325,14 @@ export class ClientManager {
     })
 
     this.#agent.replaceIdentity(identity)
-    this.notifySubscribers(identity)
 
+    // Clean the cache BEFORE notifying, and after the agent already holds the
+    // new identity. A subscriber commonly reacts by starting an imperative
+    // `fetchQuery` for the new principal; that query has no observer yet, so it
+    // would be classified inactive and `removeQueries` would cancel it, leaving
+    // the subscriber's promise rejected with a TanStack CancelledError. Anything
+    // a subscriber starts must therefore outlive this sweep. Refetches triggered
+    // here are already signed by the new identity.
     canisterIds.forEach((canisterId) => {
       // Inactive entries are REMOVED, not just invalidated. Query keys carry no
       // principal, so a caller-scoped result (a balance-of-self, a deposit
@@ -345,6 +351,8 @@ export class ClientManager {
       // principal in the key itself.
       this.queryClient.invalidateQueries({ queryKey: [canisterId] })
     })
+
+    this.notifySubscribers(identity)
   }
 
   private notifySubscribers(identity: Identity) {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -328,6 +328,21 @@ export class ClientManager {
     this.notifySubscribers(identity)
 
     canisterIds.forEach((canisterId) => {
+      // Inactive entries are REMOVED, not just invalidated. Query keys carry no
+      // principal, so a caller-scoped result (a balance-of-self, a deposit
+      // address, my-profile) stays readable through getQueryData/fetchQuery
+      // under the new identity for as long as it lives in the cache —
+      // indefinitely for an entry whose component has unmounted, which is the
+      // normal case when a sign-out unmounts the authenticated tree.
+      // Invalidating alone left the data in place.
+      this.queryClient.removeQueries({
+        queryKey: [canisterId],
+        type: "inactive",
+      })
+      // Active entries stay invalidated rather than removed, so their mounted
+      // observers reliably refetch. They still show the previous identity's
+      // data for the length of that refetch; closing that window needs the
+      // principal in the key itself.
       this.queryClient.invalidateQueries({ queryKey: [canisterId] })
     })
   }

--- a/packages/core/tests/client-identity-switch.test.ts
+++ b/packages/core/tests/client-identity-switch.test.ts
@@ -84,4 +84,45 @@ describe("ClientManager.updateAgent — cached data across an identity switch", 
     expect(queryClient.getQueryState(key)?.isInvalidated).toBe(true)
     unsubscribe()
   })
+
+  it("does not cancel a fetch a subscriber starts on notification", async () => {
+    // Regression: the cache sweep used to run AFTER notifySubscribers. A
+    // subscriber reacting by kicking off an imperative fetch for the new
+    // principal created an observerless — therefore "inactive" — query, which
+    // removeQueries then cancelled, rejecting the subscriber's promise with a
+    // TanStack CancelledError and discarding the result.
+    let started: Promise<unknown> | undefined
+    clientManager.subscribe(() => {
+      started = queryClient.fetchQuery({
+        queryKey: [CANISTER_ID, "balance_after_switch"],
+        queryFn: async () => "FETCHED-FOR-NEW-IDENTITY",
+      })
+    })
+
+    clientManager.updateAgent(Ed25519KeyIdentity.generate())
+
+    await expect(started).resolves.toBe("FETCHED-FOR-NEW-IDENTITY")
+    expect(
+      queryClient.getQueryData([CANISTER_ID, "balance_after_switch"])
+    ).toBe("FETCHED-FOR-NEW-IDENTITY")
+  })
+
+  it("still clears the previous identity's data when a subscriber refetches", async () => {
+    // The reordering must not weaken the guarantee the sweep exists for.
+    const stale = [CANISTER_ID, "get_withdrawal_account"]
+    queryClient.setQueryData(stale, "ACCOUNT-OF-IDENTITY-A")
+
+    let started: Promise<unknown> | undefined
+    clientManager.subscribe(() => {
+      started = queryClient.fetchQuery({
+        queryKey: [CANISTER_ID, "something_else"],
+        queryFn: async () => "ok",
+      })
+    })
+
+    clientManager.updateAgent(Ed25519KeyIdentity.generate())
+    await started
+
+    expect(queryClient.getQueryData(stale)).toBeUndefined()
+  })
 })

--- a/packages/core/tests/client-identity-switch.test.ts
+++ b/packages/core/tests/client-identity-switch.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { QueryClient, QueryObserver } from "@tanstack/query-core"
+import { AnonymousIdentity } from "@icp-sdk/core/agent"
+import { Ed25519KeyIdentity } from "@icp-sdk/core/identity"
+import { ClientManager } from "../src/client.js"
+
+const CANISTER_ID = "ryjl3-tyaaa-aaaaa-aaaba-cai"
+
+/**
+ * Query keys carry no principal, so a caller-scoped result stays readable under
+ * the next identity for as long as it lives in the cache. Invalidating alone
+ * left it there indefinitely once the component observing it unmounted.
+ */
+describe("ClientManager.updateAgent — cached data across an identity switch", () => {
+  let queryClient: QueryClient
+  let clientManager: ClientManager
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    clientManager = new ClientManager({
+      queryClient,
+      agentOptions: { host: "https://icp-api.io" },
+    })
+    clientManager.registerCanisterId(CANISTER_ID)
+  })
+
+  it("removes an inactive entry so the next identity cannot read it", () => {
+    const key = [CANISTER_ID, "get_withdrawal_account"]
+    queryClient.setQueryData(key, "ACCOUNT-OF-IDENTITY-A")
+    expect(queryClient.getQueryData(key)).toBe("ACCOUNT-OF-IDENTITY-A")
+
+    clientManager.updateAgent(Ed25519KeyIdentity.generate())
+
+    expect(queryClient.getQueryData(key)).toBeUndefined()
+  })
+
+  it("removes it on sign-out too, not only on a switch between users", () => {
+    const key = [CANISTER_ID, "my_profile"]
+    queryClient.setQueryData(key, { name: "Ada" })
+
+    clientManager.updateAgent(new AnonymousIdentity())
+
+    expect(queryClient.getQueryData(key)).toBeUndefined()
+  })
+
+  it("leaves other canisters' and unrelated app queries alone", () => {
+    // updateAgent is scoped to registered canister ids precisely so it does not
+    // wipe an app's REST/GraphQL cache on every sign-in.
+    const otherCanister = ["mc6ru-gyaaa-aaaar-qaaaq-cai", "icrc1_name"]
+    const appQuery = ["rest", "user-settings"]
+    queryClient.setQueryData(otherCanister, "ckTESTBTC")
+    queryClient.setQueryData(appQuery, { theme: "dark" })
+    queryClient.setQueryData([CANISTER_ID, "balance"], 42n)
+
+    clientManager.updateAgent(Ed25519KeyIdentity.generate())
+
+    expect(queryClient.getQueryData(otherCanister)).toBe("ckTESTBTC")
+    expect(queryClient.getQueryData(appQuery)).toEqual({ theme: "dark" })
+    expect(queryClient.getQueryData([CANISTER_ID, "balance"])).toBeUndefined()
+  })
+
+  it("marks an actively observed entry stale so its observer refetches", () => {
+    // Active entries are invalidated rather than removed, so a mounted observer
+    // reliably refetches instead of being torn out from under React.
+    const key = [CANISTER_ID, "balance"]
+    queryClient.setQueryData(key, 1n)
+
+    // A query counts as active only while it has a subscribed, ENABLED
+    // observer; one whose observers are all disabled is inactive and is removed
+    // along with the rest. staleTime keeps this one from fetching on subscribe.
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: async () => 2n,
+      staleTime: Infinity,
+    })
+    const unsubscribe = observer.subscribe(() => {})
+
+    clientManager.updateAgent(Ed25519KeyIdentity.generate())
+
+    // Still present (not removed), and flagged for refetch.
+    expect(queryClient.getQueryData(key)).toBe(1n)
+    expect(queryClient.getQueryState(key)?.isInvalidated).toBe(true)
+    unsubscribe()
+  })
+})

--- a/packages/core/tests/client-manager.test.ts
+++ b/packages/core/tests/client-manager.test.ts
@@ -165,7 +165,7 @@ describe("ClientManager", () => {
     expect((await manager.getUserPrincipal()).isAnonymous()).toBe(true)
   })
 
-  describe("updateAgent invalidation scope", () => {
+  describe("updateAgent cache scope", () => {
     const canisterId = "ryjl3-tyaaa-aaaaa-aaaba-cai"
 
     it("invalidates registered canister queries but leaves non-IC queries alone", () => {
@@ -177,11 +177,17 @@ describe("ClientManager", () => {
 
       manager.updateAgent(new AnonymousIdentity())
 
+      // Inactive canister entries are removed outright, not merely marked
+      // stale: query keys carry no principal, so leaving the data in place kept
+      // the previous identity's caller-scoped results readable.
       expect(
-        queryClient.getQueryState([canisterId, "icrc1_name"])?.isInvalidated
-      ).toBe(true)
+        queryClient.getQueryState([canisterId, "icrc1_name"])
+      ).toBeUndefined()
       // Apps share one QueryClient with the rest of their app; signing in must not
-      // mark their unrelated queries stale.
+      // touch their unrelated queries.
+      expect(queryClient.getQueryData(["user-preferences"])).toEqual({
+        theme: "dark",
+      })
       expect(
         queryClient.getQueryState(["user-preferences"])?.isInvalidated
       ).toBe(false)
@@ -212,7 +218,8 @@ describe("ClientManager", () => {
       queryClient.setQueryData(key, { id: 1 })
       manager.updateAgent(new AnonymousIdentity())
 
-      expect(queryClient.getQueryState(key)?.isInvalidated).toBe(true)
+      // Same guarantee as for a normally-keyed canister: the entry is gone.
+      expect(queryClient.getQueryState(key)).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
Fixes #247. Does **not** fix #248 — see below for why that one needs a design decision.

## The problem

Query keys are `[canisterId, functionName, args]` and carry **no principal**, so a caller-scoped result stays readable under the next identity for as long as it lives in the cache. `updateAgent` only invalidated, which marks stale but leaves the data.

Verified live against the ckTESTBTC minter using `get_withdrawal_account` — a zero-arg, caller-scoped update whose result cannot be distinguished by the key:

```
queryKey = ["ml52i-…","get_withdrawal_account"]     no principal anywhere
subaccountA = 20163334…d220a0
subaccountB = 8ce553c0…47a975

immediately after updateAgent(B):
  getQueryData(key) === accountA        (identity-compare, same object)
  first paint for principal B: A's subaccount, then refetch

inactive query (component unmounted at switch — the normal case):
  after updateAgent(anonymous) and 3s, getQueryData(key) STILL === accountA
  only removeQueries cleared it
```

## The fix

Inactive canister-scoped entries are now **removed**. Active ones stay invalidated rather than removed, so their mounted observers reliably refetch instead of being torn out from under React.

That split is deliberate: removal is what actually closes the persistent exposure, while invalidation is the reliable refetch path for something currently on screen. Active entries therefore still show the previous identity's data for the length of one refetch — closing that last window needs the principal in the key itself, which is #269.

Scope is unchanged: still keyed on registered canister ids, so an app sharing one QueryClient does not lose its unrelated REST/GraphQL queries on every sign-in.

## Verification

Four new tests: removal on a switch, removal on sign-out, scope isolation (other canisters and app queries untouched), and that an actively observed entry is invalidated rather than removed. **Three of the four fail with the source change reverted.**

Two existing tests in `client-manager.test.ts` asserted the invalidate-only semantics; they now assert the stronger guarantee that the entry is gone. Worth a look in review — that is a deliberate behaviour change, not a test fix.

Live re-run of the auth suite confirms it: the two defect-documenting tests for this issue now fail with `expected undefined to be defined`, i.e. A's data is no longer there to read.

core 220 tests, react 320, typecheck, 21 examples and format:check all pass.

## Why #248 is not here

#248 (an identity switch during an in-flight update loses a result that already committed on-chain) cannot be fixed the same way. `updateAgent` calls `replaceIdentity` on the **shared** `HttpAgent`, and `executeCall` captures that same object, so the polling read_state gets signed by the new identity and the replica returns 403.

Capturing the agent reference does not help, because the object itself is mutated. The natural fix — construct a new `HttpAgent` per identity change so in-flight calls keep the old one — runs into two problems: `ClientManager` does not retain `agentOptions`, and more importantly a recreated agent loses a root key obtained via `fetchRootKey()`, which would break local replicas where that call is required. Doing it safely needs either root-key preservation across recreation or SDK support for signing a read_state with a specified identity.

That is a design decision rather than a patch, so I have left it for review rather than guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)