### PR TITLE
fix(core): only collapse a tuple vector to an object when the key is text

### DIFF
--- a/packages/core/src/display/visitor.ts
+++ b/packages/core/src/display/visitor.ts
@@ -220,9 +220,20 @@ export class DisplayCodecVisitor extends IDL.Visitor<unknown, z.ZodTypeAny> {
     // Regular array: codec each element
     const elemCodec = elemType.accept(this, null)
 
-    // Special case: Vec<Tuple(Text, Value)> → Map (for key-value pairs)
+    // Special case: Vec<Tuple(Text, Value)> → object keyed by the text.
+    //
+    // The key really must be `text`. This used to accept ANY 2-tuple, so a
+    // `vec record { Account; nat }` — a real shape, e.g. the ckBTC ledger's
+    // `InitArgs.initial_balances` — was run through `Object.fromEntries` and
+    // every entry collapsed onto the single key "[object Object]", losing all
+    // but the last. It also contradicted the declared type: `DisplayOf` maps to
+    // `Record<string, …>` only for `Array<[string, B]>` and leaves any other
+    // tuple vector as an array, so the runtime was returning an object where
+    // the types promised a list.
+    const tupleFields =
+      elemType instanceof IDL.TupleClass ? elemType._fields : undefined
     const isTextTuple =
-      elemType instanceof IDL.TupleClass && elemType._fields.length === 2
+      tupleFields?.length === 2 && tupleFields[0][1].name === "text"
 
     if (isTextTuple) {
       return z.codec(z.any(), z.any(), {

--- a/packages/core/tests/display-tuple-vec.test.ts
+++ b/packages/core/tests/display-tuple-vec.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest"
+import { IDL } from "@icp-sdk/core/candid"
+import { Principal } from "@icp-sdk/core/principal"
+import { didToDisplayCodec } from "../src/display/index.js"
+
+/**
+ * A `vec` of 2-tuples is displayed as an object keyed by the first element —
+ * but only when that element is `text`. It used to accept ANY 2-tuple, so a
+ * non-primitive key was stringified by `Object.fromEntries` and every entry
+ * collapsed onto "[object Object]".
+ *
+ * `DisplayOf` already declared the correct shape: `Record<string, …>` only for
+ * `Array<[string, B]>`, everything else stays an array. The runtime was the
+ * side that disagreed.
+ */
+describe("display codec — vec of 2-tuples", () => {
+  const owner = Principal.fromText("aaaaa-aa")
+
+  describe("non-text keys keep the array shape", () => {
+    const accountPairs = () =>
+      didToDisplayCodec(
+        IDL.Vec(IDL.Tuple(IDL.Record({ owner: IDL.Principal }), IDL.Nat))
+      )
+
+    it("preserves every entry when the key is a record", () => {
+      // `vec record { Account; nat }` is a real shape — the ckBTC ledger's
+      // InitArgs.initial_balances. Both entries must survive.
+      const display = accountPairs().asDisplay([
+        [{ owner }, 1n],
+        [{ owner }, 2n],
+      ])
+
+      expect(Array.isArray(display)).toBe(true)
+      expect(display).toHaveLength(2)
+      expect(display).toEqual([
+        [{ owner: "aaaaa-aa" }, "1"],
+        [{ owner: "aaaaa-aa" }, "2"],
+      ])
+    })
+
+    it("does not collapse identical record keys onto one entry", () => {
+      const display = accountPairs().asDisplay([
+        [{ owner }, 10n],
+        [{ owner }, 20n],
+        [{ owner }, 30n],
+      ]) as unknown[]
+
+      expect(display).toHaveLength(3)
+    })
+
+    it("keeps the array shape for a nat key too", () => {
+      const natKeyed = didToDisplayCodec(IDL.Vec(IDL.Tuple(IDL.Nat, IDL.Text)))
+      expect(
+        natKeyed.asDisplay([
+          [1n, "x"],
+          [2n, "y"],
+        ])
+      ).toEqual([
+        ["1", "x"],
+        ["2", "y"],
+      ])
+    })
+  })
+
+  describe("text keys keep the object ergonomic", () => {
+    const metadata = () =>
+      didToDisplayCodec(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat)))
+
+    it("maps text-keyed pairs to an object", () => {
+      // This is the icrc1_metadata shape and the reason the special case exists.
+      expect(
+        metadata().asDisplay([
+          ["icrc1:decimals", 8n],
+          ["icrc1:fee", 10n],
+        ])
+      ).toEqual({ "icrc1:decimals": "8", "icrc1:fee": "10" })
+    })
+
+    it("round-trips back to candid pairs", () => {
+      expect(metadata().asCandid({ "icrc1:decimals": "8" } as never)).toEqual([
+        ["icrc1:decimals", 8n],
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Fixes #243 — the last data-loss item from the audit.

## The problem

The display transform maps a `vec` of 2-tuples to an object keyed by the first element. The check was:

```ts
const isTextTuple = elemType instanceof IDL.TupleClass && elemType._fields.length === 2
```

Despite the name and the comment above it, nothing verified the key was `text`. A non-primitive key got stringified by `Object.fromEntries`, so **every entry collapsed onto `"[object Object]"`** and only the last survived. `vec record { Account; nat }` is a real shape — the ckBTC ledger's `InitArgs.initial_balances`.

It also contradicted the declared type. `DisplayOf` maps to `Record<string, …>` only for `Array<[string, B]>` and leaves any other tuple vector as an array, so the runtime returned an object where the types promised a list. **The types were already correct; only the runtime disagreed** — so this brings them back into agreement rather than changing the contract.

## Before / after

```
vec (record { owner: principal }, nat), two entries:
  before: { "[object Object]": "2" }                      1 of 2 entries survive
  after:  [[{owner:"aaaaa-aa"},"1"], [{owner:"aaaaa-aa"},"2"]]

vec (nat, text):
  after:  [["1","x"], ["2","y"]]                          array, matching DisplayOf

vec (text, nat)  — icrc1_metadata:
  after:  { "icrc1:decimals": "8", "icrc1:fee": "10" }     unchanged
```

## Scope

The ergonomic that motivated the special case is preserved: `icrc1_metadata` and the recursive ICRC-3 maps still come back as objects. Only non-text keys change shape — and for those the array shape is what the types already declared.

Duplicate **text** keys still collapse, since `Record<string, …>` cannot express them. That is a property of the declared type rather than a runtime defect, so I left it alone; ICRC metadata keys are unique by spec.

## Verification

Five tests across record, nat and text keys — entry preservation, no collapse on identical record keys, array shape for nat keys, the metadata object, and the candid round-trip. **Three fail with the source change reverted.**

core 227 tests, react 320, typecheck, format:check all pass.

One note on the candid package: `tests/e2e/candid-reactor.test.ts` failed once during verification with `Test timed out in 5000ms`. I checked rather than assuming — it is a network-latency flake on a 5 s timeout fetching Candid from mainnet, and passes 3/3 with this change applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)