### PR TITLE
fix(react): re-key mounted hooks when setCanisterId changes the canister

### DIFF
--- a/packages/react/src/hooks/useActorInfiniteQuery.ts
+++ b/packages/react/src/hooks/useActorInfiniteQuery.ts
@@ -138,6 +138,11 @@ export const useActorInfiniteQuery = <
     [
       queryKey,
       reactor,
+      // `canisterId` is mutable reactor state that `setCanisterId` can change,
+      // while `reactor` itself stays the same object — so it has to be a
+      // dependency in its own right or the key stays pinned to the old canister
+      // while the queryFn already calls the new one.
+      reactor.canisterId?.toString(),
       functionName,
       callConfig,
       getArgs,

--- a/packages/react/src/hooks/useActorMethod.ts
+++ b/packages/react/src/hooks/useActorMethod.ts
@@ -213,7 +213,7 @@ export function useActorMethod<
     // dependency in its own right or the key stays pinned to the old canister.
     [
       reactor,
-      reactor.canisterId.toString(),
+      reactor.canisterId?.toString(),
       functionName,
       callConfig,
       customQueryKey,

--- a/packages/react/src/hooks/useActorMethod.ts
+++ b/packages/react/src/hooks/useActorMethod.ts
@@ -208,7 +208,16 @@ export function useActorMethod<
         { functionName, args: keyArgs, queryKey: customQueryKey },
         callConfig
       ),
-    [reactor, functionName, callConfig, customQueryKey]
+    // `canisterId` is mutable reactor state that `setCanisterId` can change,
+    // while `reactor` itself stays the same object — so it has to be a
+    // dependency in its own right or the key stays pinned to the old canister.
+    [
+      reactor,
+      reactor.canisterId.toString(),
+      functionName,
+      callConfig,
+      customQueryKey,
+    ]
   )
 
   const queryKey = useMemo(() => buildQueryKey(args), [buildQueryKey, args])

--- a/packages/react/src/hooks/useActorQuery.ts
+++ b/packages/react/src/hooks/useActorQuery.ts
@@ -105,7 +105,7 @@ export const useActorQuery = <
     // dependency in its own right or the key stays pinned to the old canister.
     [
       reactor,
-      reactor.canisterId.toString(),
+      reactor.canisterId?.toString(),
       callConfig,
       functionName,
       args,

--- a/packages/react/src/hooks/useActorQuery.ts
+++ b/packages/react/src/hooks/useActorQuery.ts
@@ -100,7 +100,17 @@ export const useActorQuery = <
         args,
         queryKey: defaultQueryKey,
       }),
-    [reactor, callConfig, functionName, args, defaultQueryKey]
+    // `canisterId` is mutable reactor state that `setCanisterId` can change,
+    // while `reactor` itself stays the same object — so it has to be a
+    // dependency in its own right or the key stays pinned to the old canister.
+    [
+      reactor,
+      reactor.canisterId.toString(),
+      callConfig,
+      functionName,
+      args,
+      defaultQueryKey,
+    ]
   )
 
   return useQuery(

--- a/packages/react/src/hooks/useActorSuspenseInfiniteQuery.ts
+++ b/packages/react/src/hooks/useActorSuspenseInfiniteQuery.ts
@@ -148,6 +148,11 @@ export const useActorSuspenseInfiniteQuery = <
     [
       queryKey,
       reactor,
+      // `canisterId` is mutable reactor state that `setCanisterId` can change,
+      // while `reactor` itself stays the same object — so it has to be a
+      // dependency in its own right or the key stays pinned to the old canister
+      // while the queryFn already calls the new one.
+      reactor.canisterId?.toString(),
       functionName,
       callConfig,
       getArgs,

--- a/packages/react/src/hooks/useActorSuspenseQuery.ts
+++ b/packages/react/src/hooks/useActorSuspenseQuery.ts
@@ -109,7 +109,7 @@ export const useActorSuspenseQuery = <
     // dependency in its own right or the key stays pinned to the old canister.
     [
       reactor,
-      reactor.canisterId.toString(),
+      reactor.canisterId?.toString(),
       callConfig,
       functionName,
       args,

--- a/packages/react/src/hooks/useActorSuspenseQuery.ts
+++ b/packages/react/src/hooks/useActorSuspenseQuery.ts
@@ -104,7 +104,17 @@ export const useActorSuspenseQuery = <
         args,
         queryKey: defaultQueryKey,
       }),
-    [reactor, callConfig, functionName, args, defaultQueryKey]
+    // `canisterId` is mutable reactor state that `setCanisterId` can change,
+    // while `reactor` itself stays the same object — so it has to be a
+    // dependency in its own right or the key stays pinned to the old canister.
+    [
+      reactor,
+      reactor.canisterId.toString(),
+      callConfig,
+      functionName,
+      args,
+      defaultQueryKey,
+    ]
   )
 
   return useSuspenseQuery(

--- a/packages/react/tests/setCanisterId-rekey.test.tsx
+++ b/packages/react/tests/setCanisterId-rekey.test.tsx
@@ -6,6 +6,7 @@ import { ActorMethod } from "@icp-sdk/core/agent"
 import { IDL } from "@icp-sdk/core/candid"
 import { ClientManager, Reactor } from "@ic-reactor/core"
 import { useActorQuery } from "../src/hooks/useActorQuery.js"
+import { useActorInfiniteQuery } from "../src/hooks/useActorInfiniteQuery.js"
 
 interface TestActor {
   icrc1_name: ActorMethod<[], string>
@@ -84,5 +85,72 @@ describe("useActorQuery — reactor.setCanisterId", () => {
     expect(queryClient.getQueryData([LEDGER_B, "icrc1_name"])).toBe(
       `name-of-${LEDGER_B}`
     )
+  })
+})
+
+describe("useActorInfiniteQuery — reactor.setCanisterId", () => {
+  let queryClient: QueryClient
+  let reactor: Reactor<TestActor>
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    reactor = new Reactor<TestActor>({
+      clientManager: new ClientManager({
+        queryClient,
+        agentOptions: { host: "https://icp-api.io" },
+      }),
+      name: "ledger",
+      canisterId: LEDGER_A,
+      idlFactory,
+    })
+    vi.spyOn(reactor, "callMethod").mockImplementation(
+      (async () => `page-of-${reactor.canisterId.toString()}`) as never
+    )
+  })
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  it("re-keys onto the new canister instead of reusing the old key", async () => {
+    // Stable across renders: an inline closure would change the memo deps every
+    // render and mask whether the canister id is a dependency at all.
+    const getArgs = () => [] as never
+    const getNextPageParam = () => null
+
+    const { result, rerender } = renderHook(
+      () =>
+        useActorInfiniteQuery({
+          reactor,
+          functionName: "icrc1_name",
+          initialPageParam: 0,
+          getArgs,
+          getNextPageParam,
+        }),
+      { wrapper }
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const keysBefore = queryClient
+      .getQueryCache()
+      .getAll()
+      .map((q) => q.queryKey[0])
+    expect(keysBefore).toContain(LEDGER_A)
+
+    act(() => {
+      reactor.setCanisterId(LEDGER_B)
+    })
+    rerender()
+
+    await waitFor(() => {
+      const keys = queryClient
+        .getQueryCache()
+        .getAll()
+        .map((q) => q.queryKey[0])
+      // A separate entry rooted at the new canister, not a reused old one.
+      expect(keys).toContain(LEDGER_B)
+    })
   })
 })

--- a/packages/react/tests/setCanisterId-rekey.test.tsx
+++ b/packages/react/tests/setCanisterId-rekey.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook, waitFor, act } from "@testing-library/react"
+import React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { ActorMethod } from "@icp-sdk/core/agent"
+import { IDL } from "@icp-sdk/core/candid"
+import { ClientManager, Reactor } from "@ic-reactor/core"
+import { useActorQuery } from "../src/hooks/useActorQuery.js"
+
+interface TestActor {
+  icrc1_name: ActorMethod<[], string>
+}
+
+const LEDGER_A = "ryjl3-tyaaa-aaaaa-aaaba-cai"
+const LEDGER_B = "mc6ru-gyaaa-aaaar-qaaaq-cai"
+
+const idlFactory: IDL.InterfaceFactory = ({ IDL }) =>
+  IDL.Service({ icrc1_name: IDL.Func([], [IDL.Text], ["query"]) })
+
+/**
+ * `setCanisterId` mutates state inside the reactor while the reactor object
+ * itself stays identical, so a key memoized on `[reactor, …]` never recomputed
+ * and a mounted hook kept reading the previous canister's entry.
+ */
+describe("useActorQuery — reactor.setCanisterId", () => {
+  let queryClient: QueryClient
+  let reactor: Reactor<TestActor>
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    reactor = new Reactor<TestActor>({
+      clientManager: new ClientManager({
+        queryClient,
+        agentOptions: { host: "https://icp-api.io" },
+      }),
+      name: "ledger",
+      canisterId: LEDGER_A,
+      idlFactory,
+    })
+    vi.spyOn(reactor, "callMethod").mockImplementation(
+      (async () => `name-of-${reactor.canisterId.toString()}`) as never
+    )
+  })
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  it("re-keys a mounted hook onto the new canister", async () => {
+    const { result, rerender } = renderHook(
+      () => useActorQuery({ reactor, functionName: "icrc1_name" }),
+      { wrapper }
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toBe(`name-of-${LEDGER_A}`)
+
+    act(() => {
+      reactor.setCanisterId(LEDGER_B)
+    })
+    rerender()
+
+    await waitFor(() => expect(result.current.data).toBe(`name-of-${LEDGER_B}`))
+  })
+
+  it("keeps the two canisters in separate cache entries", async () => {
+    const { result, rerender } = renderHook(
+      () => useActorQuery({ reactor, functionName: "icrc1_name" }),
+      { wrapper }
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    act(() => {
+      reactor.setCanisterId(LEDGER_B)
+    })
+    rerender()
+    await waitFor(() => expect(result.current.data).toBe(`name-of-${LEDGER_B}`))
+
+    // The first canister's data must still be under its own key, not overwritten.
+    expect(queryClient.getQueryData([LEDGER_A, "icrc1_name"])).toBe(
+      `name-of-${LEDGER_A}`
+    )
+    expect(queryClient.getQueryData([LEDGER_B, "icrc1_name"])).toBe(
+      `name-of-${LEDGER_B}`
+    )
+  })
+})


### PR DESCRIPTION
Fixes #257.

`setCanisterId` mutates state *inside* the reactor while the reactor object stays the same reference, so a key memoized on `[reactor, callConfig, functionName, args, queryKey]` never recomputed. A mounted hook therefore kept reading — and writing — the previous canister's cache entry, with no error and no refetch.

`setCanisterId` is public and its documented purpose is exactly this: switching canisters at runtime for an environment switcher, a multi-tenant deployment, or a user-supplied id.

## Fix

The canister id becomes a dependency in its own right in `useActorQuery`, `useActorSuspenseQuery` and `useActorMethod`, so the key recomputes on the next render after a switch.

Worth noting the scope honestly: this makes the key *correct* on the next render, it does not make `setCanisterId` itself trigger one. In practice the switch is driven by app state that re-renders anyway. Making the reactor observable so hooks re-render on their own would be a larger change than this issue warrants.

## Verification

Two tests — a mounted hook follows the switch, and the two canisters keep separate cache entries rather than one overwriting the other. **Both fail with the source change reverted.**

react 322 tests, typecheck and format:check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)