### PR TITLE
fix(react): bound the args-late factory memo caches

### DIFF
--- a/docs/src/content/docs/reference/factories/createQuery.mdx
+++ b/docs/src/content/docs/reference/factories/createQuery.mdx
@@ -326,6 +326,18 @@ const query2 = getUserQuery(["alice"])
 console.log(query1 === query2) // true
 ```
 
+The cache holds the 256 most recently used argument sets. That covers any
+realistic working set, but a factory called with an open-ended range of
+arguments — one query per principal in a long-lived session, a
+search-as-you-type filter, a cursor-keyed list — will eventually evict the
+oldest entries rather than grow without bound.
+
+Eviction costs memoization, not correctness: a query object is a closure over
+the reactor and its config, so one rebuilt after eviction behaves identically
+and only its reference identity differs. It matters only if you compare
+instances or put one in a dependency array *and* cycle through more than 256
+distinct argument sets.
+
 ---
 
 ## Notes

--- a/packages/react/src/createQuery.ts
+++ b/packages/react/src/createQuery.ts
@@ -46,7 +46,7 @@ import type {
   QueryFactoryConfig,
   NoInfer,
 } from "./types.js"
-import { buildChainedSelect } from "./utils.js"
+import { buildChainedSelect, createBoundedCache } from "./utils.js"
 
 // ============================================================================
 // Internal Implementation
@@ -205,14 +205,14 @@ export function createQueryFactory<
   Selected,
   QueryError<Service, Method, Transform>
 > {
-  const cache = new Map<
-    string,
-    QueryResult<
-      QueryFnData<Service, Method, Transform>,
-      Selected,
-      QueryError<Service, Method, Transform>
-    >
-  >()
+  const cache =
+    createBoundedCache<
+      QueryResult<
+        QueryFnData<Service, Method, Transform>,
+        Selected,
+        QueryError<Service, Method, Transform>
+      >
+    >()
 
   return (args: ReactorArgs<Service, Method, Transform>) => {
     const key = reactor.generateQueryKey({

--- a/packages/react/src/createSuspenseQuery.ts
+++ b/packages/react/src/createSuspenseQuery.ts
@@ -36,7 +36,7 @@ import type {
   SuspenseQueryFactoryConfig,
   NoInfer,
 } from "./types.js"
-import { buildChainedSelect } from "./utils.js"
+import { buildChainedSelect, createBoundedCache } from "./utils.js"
 
 // ============================================================================
 // Internal Implementation
@@ -195,14 +195,14 @@ export function createSuspenseQueryFactory<
   Selected,
   QueryError<Service, Method, Transform>
 > {
-  const cache = new Map<
-    string,
-    SuspenseQueryResult<
-      QueryFnData<Service, Method, Transform>,
-      Selected,
-      QueryError<Service, Method, Transform>
-    >
-  >()
+  const cache =
+    createBoundedCache<
+      SuspenseQueryResult<
+        QueryFnData<Service, Method, Transform>,
+        Selected,
+        QueryError<Service, Method, Transform>
+      >
+    >()
 
   return (args: ReactorArgs<Service, Method, Transform>) => {
     const key = reactor.generateQueryKey({

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -74,3 +74,48 @@ export function buildChainedSelect<TData, TSelected, TFinal = TSelected>(
   if (!hookSelect) return configSelect
   return (rawData: TData) => hookSelect(configSelect(rawData))
 }
+
+/**
+ * How many memoized query objects an args-late factory keeps.
+ *
+ * The memo exists so `getBalance(sameArgs)` returns the same object twice; it
+ * was unbounded, so an open-ended argument space — a per-principal balance in a
+ * long-lived SPA, a search-as-you-type filter, a cursor-keyed list — grew it
+ * forever (measured at ~2.9 kB per entry, 55.8 MB for 20k). A few hundred
+ * covers any realistic working set while capping the worst case.
+ */
+const FACTORY_CACHE_LIMIT = 256
+
+/**
+ * Smallest useful LRU: a `Map` already iterates in insertion order, so
+ * re-inserting on read is enough to track recency.
+ *
+ * Eviction is safe — it costs memoization, never correctness. A query object is
+ * a closure over the reactor and config, so one rebuilt after eviction behaves
+ * identically; only its reference identity differs.
+ */
+export function createBoundedCache<V>(limit: number = FACTORY_CACHE_LIMIT) {
+  const entries = new Map<string, V>()
+
+  return {
+    get(key: string): V | undefined {
+      const value = entries.get(key)
+      if (value === undefined) return undefined
+      // Touch: move to the most-recent end.
+      entries.delete(key)
+      entries.set(key, value)
+      return value
+    },
+    set(key: string, value: V): void {
+      if (entries.has(key)) entries.delete(key)
+      else if (entries.size >= limit) {
+        const oldest = entries.keys().next().value
+        if (oldest !== undefined) entries.delete(oldest)
+      }
+      entries.set(key, value)
+    },
+    get size(): number {
+      return entries.size
+    },
+  }
+}

--- a/packages/react/tests/factory-cache-bounded.test.ts
+++ b/packages/react/tests/factory-cache-bounded.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest"
+import { createBoundedCache } from "../src/utils.js"
+
+/**
+ * The args-late factories memoize one query object per argument set so
+ * `getBalance(sameArgs)` returns the same object twice. The memo was an
+ * unbounded Map, so an open-ended argument space — a per-principal balance in a
+ * long-lived SPA, a search-as-you-type filter, a cursor-keyed list — grew it
+ * forever (~2.9 kB per entry, 55.8 MB at 20k).
+ */
+describe("createBoundedCache", () => {
+  it("memoizes, which is the point of the cache", () => {
+    const cache = createBoundedCache<{ id: number }>(4)
+    const value = { id: 1 }
+    cache.set("a", value)
+
+    expect(cache.get("a")).toBe(value)
+  })
+
+  it("never grows past its limit", () => {
+    const cache = createBoundedCache<number>(4)
+    for (let i = 0; i < 1000; i++) cache.set(`k${i}`, i)
+
+    expect(cache.size).toBe(4)
+  })
+
+  it("evicts the least recently used entry", () => {
+    const cache = createBoundedCache<number>(3)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.set("c", 3)
+
+    // Touch "a" so "b" becomes the oldest.
+    expect(cache.get("a")).toBe(1)
+    cache.set("d", 4)
+
+    expect(cache.get("b")).toBeUndefined()
+    expect(cache.get("a")).toBe(1)
+    expect(cache.get("c")).toBe(3)
+    expect(cache.get("d")).toBe(4)
+  })
+
+  it("keeps a realistic working set fully memoized", () => {
+    // The pattern the memo exists for: a bounded set of args, hit repeatedly.
+    const cache = createBoundedCache<{ id: number }>(256)
+    const objects = new Map<string, { id: number }>()
+    for (let i = 0; i < 50; i++) {
+      const value = { id: i }
+      objects.set(`arg${i}`, value)
+      cache.set(`arg${i}`, value)
+    }
+
+    for (const [key, value] of objects) {
+      expect(cache.get(key)).toBe(value)
+    }
+  })
+
+  it("re-setting an existing key updates rather than duplicating", () => {
+    const cache = createBoundedCache<number>(2)
+    cache.set("a", 1)
+    cache.set("a", 2)
+
+    expect(cache.size).toBe(1)
+    expect(cache.get("a")).toBe(2)
+  })
+})


### PR DESCRIPTION
Fixes #258.

`createQueryFactory` and `createSuspenseQueryFactory` memoize one query object per argument set, so `getBalance(sameArgs)` returns the same object twice. The memo was an unbounded module-level `Map`:

```
20 000 distinct args -> entries: 20000, heapDelta: 55.84 MB, ~2.9 kB/entry, evicted: false
```

Harmless for a fixed set of arguments, which is the intended use. It grows without bound when the argument space is open-ended — a per-principal balance in a long-lived SPA, a search-as-you-type filter, a cursor-keyed list.

## Fix

A small LRU capped at 256 entries. A `Map` already iterates in insertion order, so re-inserting on read is enough to track recency — the whole thing is about 25 lines.

**Eviction costs memoization, never correctness.** A query object is a closure over the reactor and config, so one rebuilt after eviction behaves identically; only its reference identity differs. The cap is well above any realistic working set, so the memoization the factories exist for is unaffected in practice.

## Verification

Five tests for the cache — it memoizes, never exceeds its limit, evicts least-recently-used, keeps a realistic 50-entry working set fully memoized, and updates rather than duplicates on re-set.

The existing factory identity tests (`getBalance(args) === getBalance(args)`, distinct objects for distinct args) pass unchanged, which is the behaviour that matters.

react 325 tests, typecheck and format:check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)