### PR TITLE
fix(react): drop attribute PII on identity change, and guard the logout race

### DIFF
--- a/packages/react/src/auth/authentication-manager.ts
+++ b/packages/react/src/auth/authentication-manager.ts
@@ -195,6 +195,11 @@ export class AuthenticationManager {
         )
       }
       this.updateState({ isAuthenticating: true })
+      // Anything that changes auth state — a logout, notably — bumps this. If
+      // it moves while the awaits below are in flight, the result we are
+      // holding describes a session that has since ended, and installing it
+      // would put the signed-out user's delegation back on the agent.
+      const revision = this.authStateRevision
       try {
         if (!this.authClient) {
           const authClient = await this.initializeClient(
@@ -207,6 +212,11 @@ export class AuthenticationManager {
         }
         const identity = await this.authClient!.getIdentity()
         const isAuthenticated = await this.authClient!.isAuthenticated()
+
+        if (revision !== this.authStateRevision) {
+          // Superseded — leave whatever ran in the meantime in place.
+          return this.authState.identity || undefined
+        }
         // Restoring an anonymous session is the common first-load case; pushing
         // it through updateAgent would invalidate the whole query cache on
         // every mount for nothing.

--- a/packages/react/src/auth/createIdentityAttributeHooks.ts
+++ b/packages/react/src/auth/createIdentityAttributeHooks.ts
@@ -28,16 +28,46 @@ export function createIdentityAttributeHooks(
     const [isRequestingAttributes, setIsRequestingAttributes] = useState(false)
     const [attributeError, setAttributeError] = useState<Error | null>(null)
 
+    /** The principal the session is currently signed in as, if any. */
+    const currentPrincipal = useCallback(() => {
+      const { authState } = identityAttributes.authentication
+      return authState.isAuthenticated
+        ? authState.identity?.getPrincipal().toText()
+        : undefined
+    }, [])
+
+    /**
+     * A request started before a sign-out or an account switch resolves after
+     * it, and publishing that result would put the previous user's decoded PII
+     * back on screen with no further auth event to clear it again. Results are
+     * therefore only committed while the principal that asked for them is still
+     * the one signed in.
+     */
+    const isCurrent = useCallback(
+      (requestedFor: string | undefined) => requestedFor === currentPrincipal(),
+      [currentPrincipal]
+    )
+
+    const publishIfCurrent = useCallback(
+      (requestedFor: string | undefined, result: IdentityAttributeResult) => {
+        if (!isCurrent(requestedFor)) return false
+        setAttributes(result)
+        return true
+      },
+      [isCurrent]
+    )
+
     const requestAttributes = useCallback(
       async (params: RequestIdentityAttributesParameters) => {
         setIsRequestingAttributes(true)
         setAttributeError(null)
+        const requestedFor = currentPrincipal()
         try {
           const result = await identityAttributes.request(params)
-          setAttributes(result)
+          publishIfCurrent(requestedFor, result)
           return result
         } catch (error) {
-          setAttributeError(error as Error)
+          if (isCurrent(requestedFor)) setAttributeError(error as Error)
           throw error
         } finally {
           setIsRequestingAttributes(false)
@@ -50,12 +80,13 @@ export function createIdentityAttributeHooks(
       async (params: RequestOpenIdIdentityAttributesParameters) => {
         setIsRequestingAttributes(true)
         setAttributeError(null)
+        const requestedFor = currentPrincipal()
         try {
           const result = await identityAttributes.requestOpenId(params)
-          setAttributes(result)
+          publishIfCurrent(requestedFor, result)
           return result
         } catch (error) {
-          setAttributeError(error as Error)
+          if (isCurrent(requestedFor)) setAttributeError(error as Error)
           throw error
         } finally {
           setIsRequestingAttributes(false)
@@ -76,11 +107,6 @@ export function createIdentityAttributeHooks(
     const attributedPrincipal = useRef<string | undefined>(undefined)
     useEffect(() => {
       const { authentication } = identityAttributes
-      const currentPrincipal = () =>
-        authentication.authState.isAuthenticated
-          ? authentication.authState.identity?.getPrincipal().toText()
-          : undefined
-
       attributedPrincipal.current ??= currentPrincipal()
 
       return authentication.subscribeAuthState(() => {

--- a/packages/react/src/auth/createIdentityAttributeHooks.ts
+++ b/packages/react/src/auth/createIdentityAttributeHooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import type { IdentityAttributesManager } from "./identity-attributes-manager.js"
 import type {
   IdentityAttributeResult,
@@ -67,6 +67,29 @@ export function createIdentityAttributeHooks(
     const clearAttributes = useCallback(() => {
       setAttributes(null)
       setAttributeError(null)
+    }, [])
+
+    // Decoded attributes are the signed-in user's personal data — a name, an
+    // email. They used to survive a sign-out or a switch to another account,
+    // so the next person to look at the screen saw the previous user's details.
+    // Drop them whenever the principal behind them changes.
+    const attributedPrincipal = useRef<string | undefined>(undefined)
+    useEffect(() => {
+      const { authentication } = identityAttributes
+      const currentPrincipal = () =>
+        authentication.authState.isAuthenticated
+          ? authentication.authState.identity?.getPrincipal().toText()
+          : undefined
+
+      attributedPrincipal.current ??= currentPrincipal()
+
+      return authentication.subscribeAuthState(() => {
+        const principal = currentPrincipal()
+        if (principal === attributedPrincipal.current) return
+        attributedPrincipal.current = principal
+        setAttributes(null)
+        setAttributeError(null)
+      })
     }, [])
 
     return {

--- a/packages/react/tests/auth/authentication-manager.test.ts
+++ b/packages/react/tests/auth/authentication-manager.test.ts
@@ -498,3 +498,70 @@ describe("AuthenticationManager session hygiene", () => {
     expect(authentication.authState.error).toBeInstanceOf(Error)
   })
 })
+
+describe("AuthenticationManager logout/authenticate race", () => {
+  let clientManager: ClientManager
+
+  beforeEach(() => {
+    authClientMocks.factory.mockReset()
+    vi.clearAllMocks()
+    ;(safeGetCanisterEnv as any).mockReturnValue(undefined)
+    clientManager = new ClientManager({ queryClient: new QueryClient() })
+    vi.spyOn(clientManager, "initializeAgent").mockResolvedValue()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("does not re-install the signed-out identity when logout wins the race", async () => {
+    // Regression: a stalled authenticate() applied its result unconditionally,
+    // putting the delegation of a user who had just signed out back on the
+    // agent.
+    const authClient = createAuthClient()
+    const authentication = new AuthenticationManager({
+      clientManager,
+      authClient,
+    })
+    await authentication.login()
+    const signedInPrincipal = authentication.authState.identity
+      ?.getPrincipal()
+      .toText()
+
+    // Stall the identity read so logout can complete underneath it.
+    let releaseIdentity: () => void = () => {}
+    const stalled = new Promise<void>((resolve) => {
+      releaseIdentity = resolve
+    })
+    const signedInIdentity = authClient.getIdentity()
+    const anonymous = identity("2vxsx-fae")
+    let stalledOnce = false
+    authClient.getIdentity.mockImplementation(async () => {
+      if (!stalledOnce) {
+        // Only authenticate()'s read stalls; logout() must be able to proceed.
+        stalledOnce = true
+        await stalled
+        return signedInIdentity
+      }
+      return anonymous
+    })
+    authClient.isAuthenticated.mockResolvedValue(false)
+    ;(authentication as any).authStateValue = {
+      ...authentication.authState,
+      isAuthenticated: false,
+    }
+
+    const pending = authentication.authenticate()
+    await authentication.logout()
+    releaseIdentity()
+    await pending
+
+    expect(authentication.authState.isAuthenticated).toBe(false)
+    expect(
+      authentication.authState.identity?.getPrincipal().isAnonymous()
+    ).toBe(true)
+    expect(authentication.authState.identity?.getPrincipal().toText()).not.toBe(
+      signedInPrincipal
+    )
+  })
+})

--- a/packages/react/tests/auth/createAuthHooks.test.tsx
+++ b/packages/react/tests/auth/createAuthHooks.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act, waitFor } from "@testing-library/react"
 import React from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ClientManager } from "@ic-reactor/core"
+import { Principal } from "@icp-sdk/core/principal"
 import {
   AuthenticationManager,
   IdentityAttributeResult,
@@ -423,5 +424,93 @@ describe("createIdentityAttributeHooks - useIdentityAttributes", () => {
 
     expect(result.current.attributes).toBeNull()
     expect(result.current.attributeError).toBeNull()
+  })
+})
+
+describe("useIdentityAttributes — PII is dropped when the principal changes", () => {
+  let queryClient: QueryClient
+  let clientManager: ClientManager
+  let authentication: ReturnType<typeof makeAuthentication>
+  let identityAttributes: IdentityAttributesManager
+
+  const seed = {
+    principal: "aaaaa-aa",
+    requestedKeys: ["openid:https://issuer.example.com:email"],
+    signedAttributes: {
+      data: new Uint8Array([1]),
+      signature: new Uint8Array([2]),
+    },
+    decodedAttributes: { email: "ada@example.com", name: "Ada Lovelace" },
+    completedAt: new Date().toISOString(),
+  }
+
+  beforeEach(() => {
+    queryClient = makeQueryClient()
+    clientManager = makeClientManager(queryClient)
+    authentication = makeAuthentication(clientManager)
+    identityAttributes = new IdentityAttributesManager(authentication)
+    vi.spyOn(clientManager, "initialize").mockResolvedValue(clientManager)
+    vi.spyOn(identityAttributes, "requestOpenId").mockResolvedValue(
+      seed as never
+    )
+    // The attributes belong to a signed-in principal — that is the state in
+    // which they are ever obtained.
+    ;(authentication as any).updateState({
+      identity: { getPrincipal: () => Principal.fromText("aaaaa-aa") },
+      isAuthenticated: true,
+    })
+  })
+
+  const request = async (result: { current: any }) => {
+    await act(async () => {
+      await result.current.requestOpenIdAttributes({
+        openIdProvider: "https://issuer.example.com",
+        keys: ["email"],
+        nonce: new Uint8Array([1, 2, 3]),
+      })
+    })
+  }
+
+  it("clears the previous user's decoded attributes on sign-out", async () => {
+    // Regression: a name and email survived a sign-out, so the next person to
+    // look at the screen saw the previous user's details.
+    const { useIdentityAttributes } =
+      createIdentityAttributeHooks(identityAttributes)
+    const { result } = renderHook(() => useIdentityAttributes(), {
+      wrapper: wrapper(queryClient),
+    })
+
+    await request(result)
+    expect(result.current.attributes?.decodedAttributes).toEqual(
+      seed.decodedAttributes
+    )
+
+    await act(async () => {
+      ;(authentication as any).updateState({
+        identity: null,
+        isAuthenticated: false,
+      })
+    })
+
+    expect(result.current.attributes).toBeNull()
+  })
+
+  it("leaves them alone while the same session continues", async () => {
+    const { useIdentityAttributes } =
+      createIdentityAttributeHooks(identityAttributes)
+    const { result } = renderHook(() => useIdentityAttributes(), {
+      wrapper: wrapper(queryClient),
+    })
+
+    await request(result)
+
+    // An unrelated state change (a loading flag) must not discard them.
+    await act(async () => {
+      ;(authentication as any).updateState({ isAuthenticating: true })
+    })
+
+    expect(result.current.attributes?.decodedAttributes).toEqual(
+      seed.decodedAttributes
+    )
   })
 })

--- a/packages/react/tests/auth/createAuthHooks.test.tsx
+++ b/packages/react/tests/auth/createAuthHooks.test.tsx
@@ -495,6 +495,48 @@ describe("useIdentityAttributes — PII is dropped when the principal changes", 
     expect(result.current.attributes).toBeNull()
   })
 
+  it("does not publish a request that resolves after the user signed out", async () => {
+    // The subscription clears on the principal change, but an in-flight request
+    // still resolving afterwards would call setAttributes and put the previous
+    // user's PII back with no further auth event to clear it again.
+    let release: (v: unknown) => void = () => {}
+    vi.spyOn(identityAttributes, "requestOpenId").mockImplementation(
+      () => new Promise((resolve) => (release = resolve)) as never
+    )
+
+    const { useIdentityAttributes } =
+      createIdentityAttributeHooks(identityAttributes)
+    const { result } = renderHook(() => useIdentityAttributes(), {
+      wrapper: wrapper(queryClient),
+    })
+
+    let pending!: Promise<unknown>
+    act(() => {
+      pending = result.current
+        .requestOpenIdAttributes({
+          openIdProvider: "https://issuer.example.com",
+          keys: ["email"],
+          nonce: new Uint8Array([1, 2, 3]),
+        })
+        .catch(() => undefined)
+    })
+
+    // Sign out while the request is still outstanding.
+    await act(async () => {
+      ;(authentication as any).updateState({
+        identity: null,
+        isAuthenticated: false,
+      })
+    })
+
+    await act(async () => {
+      release(seed)
+      await pending
+    })
+
+    expect(result.current.attributes).toBeNull()
+  })
+
   it("leaves them alone while the same session continues", async () => {
     const { useIdentityAttributes } =
       createIdentityAttributeHooks(identityAttributes)


### PR DESCRIPTION
Closes #250 — the last two items from that issue; the stranded `isAuthenticating` half shipped in 3.9.0.

## 1. Decoded identity attributes survived a sign-out

A name and an email are the signed-in user's personal data, held in hook state that nothing cleared:

```
after a successful request:  decodedAttributes = { name: "Ada Lovelace", email: "ada@example.com" }
after authentication.logout() (isAuthenticated false, agent anonymous):
                             decodedAttributes.name still "Ada Lovelace"
```

So after a logout — or a switch to another account — the next person to look at the screen saw the previous user's details.

The hook now subscribes to auth state and drops attributes and any error whenever the **principal behind them** changes. Keying on the principal rather than on "any auth event" matters: a loading flag flipping must not throw away attributes mid-session, and there is a test for that.

## 2. A stalled authenticate() could undo a logout

`authenticate()` applied its result unconditionally, so a logout completing while `getIdentity()`/`isAuthenticated()` were in flight was immediately overwritten:

```
after logout completed:               agent principal 2vxsx-fae, isAuthenticated false
after the stalled authenticate() resumed:
                                      agent principal o5q2b-…-oae   the signed-out session
```

It now captures the auth-state revision — the same guard `syncStateFromClient` already uses — and bails if anything moved while it was waiting.

## Verification

Three tests: attributes cleared on sign-out, attributes **kept** across an unrelated state change, and logout winning the race leaving the session anonymous. **The two covering the defects fail with the source changes reverted.**

One note on the first test: my initial version passed against the buggy code because the fixture never actually signed in, so the principal never changed. Fixed to establish an authenticated principal first, which is the only state in which attributes are ever obtained.

react 323 tests, core 244, typecheck, 21 examples and format:check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)