### PR TITLE
docs: make the Quick Start run and drop a Reactor API that never existed

### DIFF
--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -170,14 +170,19 @@ function RegisterWithOpenIdProvider() {
   async function handleRegister() {
     const result = await requestOpenIdAttributes({
       // Pass the nonce as a callback — see the caution below
-      nonce: () => backend.registerBegin(),
+      nonce: () => backend.callMethod({ functionName: "register_begin" }),
       openIdProvider: "microsoft",
       keys: ["email", "name"],
     })
 
-    await backend.registerFinish({
-      data: result.signedAttributes.data,
-      signature: result.signedAttributes.signature,
+    await backend.callMethod({
+      functionName: "register_finish",
+      args: [
+        {
+          data: result.signedAttributes.data,
+          signature: result.signedAttributes.signature,
+        },
+      ],
     })
   }
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -225,7 +225,8 @@ export const { useIdentityAttributes } =
 returns exactly `useAuth`, `useAgentState`, and `useUserPrincipal`.
 `useIdentityAttributes` comes only from `createIdentityAttributeHooks`.
 
-Pass identity-attribute nonces as a callback (`nonce: () => backend.registerBegin()`).
+Pass identity-attribute nonces as a callback
+(`nonce: () => backend.callMethod({ functionName: "register_begin" })`).
 Awaiting the nonce before the call ends the user gesture and the browser blocks
 the Internet Identity window.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -41,7 +41,7 @@ ignoreWarnings: [{ module: /@ic-reactor\/react/, message: /@icp-sdk\/auth/ }]
 // src/reactor.ts
 import { ClientManager, Reactor, createActorHooks } from "@ic-reactor/react"
 import { QueryClient } from "@tanstack/react-query"
-import { idlFactory, type _SERVICE } from "./declarations/backend"
+import { canisterId, idlFactory, type _SERVICE } from "./declarations/backend"
 
 export const queryClient = new QueryClient()
 
@@ -53,9 +53,10 @@ export const backend = new Reactor<_SERVICE>({
   clientManager,
   idlFactory,
   name: "backend",
-  // Required. Omit it only when the vite-plugin injects an `ic_env` cookie for
-  // this canister; outside that flow the constructor throws.
-  canisterId: "rrkah-fqaaa-aaaaa-aaaaq-cai",
+  // `dfx` writes this alongside the idlFactory. Required — omit it only when
+  // the vite-plugin injects an `ic_env` cookie for this canister; outside that
+  // flow the constructor throws.
+  canisterId,
 })
 
 export const {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -53,6 +53,9 @@ export const backend = new Reactor<_SERVICE>({
   clientManager,
   idlFactory,
   name: "backend",
+  // Required. Omit it only when the vite-plugin injects an `ic_env` cookie for
+  // this canister; outside that flow the constructor throws.
+  canisterId: "rrkah-fqaaa-aaaaa-aaaaq-cai",
 })
 
 export const {
@@ -255,13 +258,13 @@ the Internet Identity window:
 ```tsx
 // ✅ window opens immediately, nonce resolves while the user is in II
 await requestOpenIdAttributes({
-  nonce: () => backend.registerBegin(),
+  nonce: () => backend.callMethod({ functionName: "register_begin" }),
   openIdProvider: "google",
   keys: ["email", "name"],
 })
 
 // ❌ gesture is gone by the time the window would open
-const nonce = await backend.registerBegin()
+const nonce = await backend.callMethod({ functionName: "register_begin" })
 await requestOpenIdAttributes({ nonce, openIdProvider: "google", keys })
 ```
 
@@ -280,7 +283,7 @@ function RegisterWithOpenIdProvider() {
 
   async function handleProviderLogin() {
     const result = await requestOpenIdAttributes({
-      nonce: () => backend.registerBegin(),
+      nonce: () => backend.callMethod({ functionName: "register_begin" }),
       openIdProvider: "microsoft",
       keys: ["email", "name"],
       windowOpenerFeatures: popupCenter(),
@@ -289,9 +292,14 @@ function RegisterWithOpenIdProvider() {
     console.log(result.decodedAttributes.email)
     console.log(result.decodedAttributes.name)
 
-    await backend.registerFinish({
-      data: result.signedAttributes.data,
-      signature: result.signedAttributes.signature,
+    await backend.callMethod({
+      functionName: "register_finish",
+      args: [
+        {
+          data: result.signedAttributes.data,
+          signature: result.signedAttributes.signature,
+        },
+      ],
     })
   }
 


### PR DESCRIPTION
Fixes #259.

Both defects verified by running them against the **published 3.9.0 package**, not by reading.

## 1. The Quick Start threw

It constructed a `Reactor` with no `canisterId`. Outside the vite-plugin's `ic_env` flow that throws at module load — so the first thing a new reader copies fails immediately:

```
Error: [ic-reactor] canisterId is required for "backend" but was not provided
and could not be resolved from the ic_env cookie (key: "PUBLIC_CANISTER_ID:backend").
```

With `canisterId` added (and a comment on when it may be omitted), the same snippet runs:

```
Quick Start constructed OK → rrkah-fqaaa-aaaaa-aaaaq-cai
```

## 2. The identity-attribute examples used an API that does not exist

They called `backend.registerBegin()` and `backend.registerFinish(...)`. `Reactor` has no dynamic method proxies. Against the published prototype:

```
  EXISTS  callMethod
  EXISTS  fetchQuery
  MISSING registerBegin
  MISSING registerFinish
```

Rewritten against `callMethod` in all three places the example appears — `packages/react/README.md`, `llms-full.txt`, and `docs/src/content/docs/guides/authentication.mdx`.

format:check and check:ai-context pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)