### PR TITLE
docs(site): document reactorRetry and isRetryableReactorError

### DIFF
--- a/docs/src/content/docs/framework/query-caching.mdx
+++ b/docs/src/content/docs/framework/query-caching.mdx
@@ -369,26 +369,29 @@ const queryClient = new QueryClient({
 
 ### Smart Retry Logic
 
-Don't retry business logic errors:
+Retrying helps only when the failure could change next time — a transport
+fault, a transient replica rejection. A canister `Err` variant, a validation
+failure, or a Candid encode error is deterministic, and retrying it spends
+several attempts and seconds of backoff to reach the same failure. IC Reactor
+ships this classification as `reactorRetry`, which is already the query default
+in the `QueryClient` that `defineReactor` creates. Opt in on a `QueryClient`
+you construct yourself:
 
 ```typescript
-import { CanisterError } from "@ic-reactor/react"
+import { reactorRetry } from "@ic-reactor/react"
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: (failureCount, error) => {
-        // Don't retry canister business logic errors
-        if (error instanceof CanisterError) {
-          return false
-        }
-        // Retry network errors up to 3 times
-        return failureCount < 3
-      },
+      retry: reactorRetry,
     },
   },
 })
 ```
+
+For custom attempt counts, build your own predicate on
+`isRetryableReactorError` — see
+[Error Handling — Retry Configuration](/v3/guides/error-handling#retry-configuration).
 
 ## Prefetching
 

--- a/docs/src/content/docs/guides/error-handling.mdx
+++ b/docs/src/content/docs/guides/error-handling.mdx
@@ -307,7 +307,9 @@ IC Reactor ships this classification as two functions, exported from
 - **`isRetryableReactorError(error)`** — returns `true` only when a retry could
   help. `CanisterError`, `ValidationError`, and a `CallError` without an
   agent error underneath (encode/decode/transform failures) are never
-  retryable.
+  retryable. Within agent errors the bias runs the other way: an unrecognized
+  `kind`, or a rejection whose code cannot be read, still retries, so an
+  unfamiliar transport-level fault is never silently made fatal.
 - **`reactorRetry(failureCount, error)`** — a TanStack Query `retry` predicate
   built on it: up to 3 retries (4 attempts in total) for retryable errors, none
   otherwise. It always returns `false` on the server

--- a/docs/src/content/docs/guides/error-handling.mdx
+++ b/docs/src/content/docs/guides/error-handling.mdx
@@ -288,26 +288,60 @@ if (error instanceof CanisterError) {
 
 ## Retry Configuration
 
-### Don't Retry Business Errors
+### Built-in Retry Classification
 
-Configure your QueryClient to retry network errors but not business logic errors:
+Most canister-call failures cannot change on retry: a canister `Err` variant, a
+`ValidationError`, a Candid encode or decode failure that never reached the
+network, a replica rejection the replica will simply repeat for an identical
+call. Retrying those costs several attempts and seconds of backoff to arrive at
+the same failure. Only a `CallError` caused by an agent-level fault — a
+transport, protocol, or certificate failure, or a `SysTransient`/`SysUnknown`
+rejection — can plausibly produce a different result next time.
+
+IC Reactor ships this classification as two functions, exported from
+`@ic-reactor/core` and re-exported by `@ic-reactor/react`:
+
+- **`isRetryableReactorError(error)`** — returns `true` only when a retry could
+  help. `CanisterError`, `ValidationError`, and a `CallError` without an
+  agent error underneath (encode/decode/transform failures) are never
+  retryable.
+- **`reactorRetry(failureCount, error)`** — a TanStack Query `retry` predicate
+  built on it: up to 3 attempts for retryable errors, none otherwise. It always
+  returns `false` on the server (`typeof window === "undefined"`), preserving
+  TanStack Query's no-retries-on-server default so a failed prefetch or render
+  keeps failing fast.
+
+The `QueryClient` that `defineReactor` creates already uses `reactorRetry` as
+its default for queries. A `QueryClient` you construct yourself opts in
+explicitly:
 
 ```typescript
 import { QueryClient } from "@tanstack/react-query"
-import { CanisterError } from "@ic-reactor/react"
+import { reactorRetry } from "@ic-reactor/react"
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: (failureCount, error) => {
-        // Never retry canister business logic errors
-        if (error instanceof CanisterError) {
-          return false
-        }
+      retry: reactorRetry,
+    },
+  },
+})
+```
 
-        // Retry network errors up to 3 times
-        return failureCount < 3
-      },
+### Custom Retry Logic
+
+Combine `isRetryableReactorError` with your own policy when you need different
+attempt counts or delays:
+
+```typescript
+import { QueryClient } from "@tanstack/react-query"
+import { isRetryableReactorError } from "@ic-reactor/react"
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: (failureCount, error) =>
+        failureCount < 5 && isRetryableReactorError(error),
       retryDelay: (attemptIndex) => {
         // Exponential backoff: 1s, 2s, 4s...
         return Math.min(1000 * 2 ** attemptIndex, 30000)
@@ -320,7 +354,7 @@ const queryClient = new QueryClient({
 })
 ```
 
-### Custom Retry Logic
+Per-query overrides still work as in plain TanStack Query:
 
 ```typescript
 const { data } = useActorQuery({
@@ -402,6 +436,8 @@ const { data } = useActorQuery({
 ### Log Errors for Debugging
 
 ```typescript
+import { isRetryableReactorError, reactorRetry } from "@ic-reactor/react"
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -410,10 +446,10 @@ const queryClient = new QueryClient({
         console.error("Query failed:", {
           failureCount,
           error,
-          isCanisterError: error instanceof CanisterError,
+          isRetryable: isRetryableReactorError(error),
         })
 
-        return failureCount < 3 && !(error instanceof CanisterError)
+        return reactorRetry(failureCount, error)
       },
     },
   },
@@ -442,7 +478,7 @@ const { mutate } = useActorMutation({
 
 1. **Use `onCanisterError` for mutations** — Separates canister `Result { Err }` variants from network/agent errors without manual `instanceof` checks
 2. **Distinguish error types** — Handle `CanisterError`, `CallError`, and `ValidationError` differently
-3. **Don't retry business errors** — If the canister says "insufficient funds", retrying won't help
+3. **Don't retry deterministic failures** — If the canister says "insufficient funds", retrying won't help. `reactorRetry` (the default when `defineReactor` creates the `QueryClient`) classifies this for you
 4. **Show actionable messages** — Tell users how to fix the issue
 5. **Provide recovery options** — Retry buttons, form reset, etc.
 6. **Log appropriately** — Send business errors to analytics, network errors to monitoring

--- a/docs/src/content/docs/guides/error-handling.mdx
+++ b/docs/src/content/docs/guides/error-handling.mdx
@@ -291,12 +291,15 @@ if (error instanceof CanisterError) {
 ### Built-in Retry Classification
 
 Most canister-call failures cannot change on retry: a canister `Err` variant, a
-`ValidationError`, a Candid encode or decode failure that never reached the
-network, a replica rejection the replica will simply repeat for an identical
-call. Retrying those costs several attempts and seconds of backoff to arrive at
-the same failure. Only a `CallError` caused by an agent-level fault — a
-transport, protocol, or certificate failure, or a `SysTransient`/`SysUnknown`
-rejection — can plausibly produce a different result next time.
+`ValidationError`, a Candid encode failure that never produced a request, a
+decode failure on the reply (the same reply decodes to the same error — and for
+an update, the canister may already have committed the change, so a retry would
+submit it again), a replica rejection the replica will simply repeat for an
+identical call. Retrying those costs several attempts and seconds of backoff to
+arrive at the same failure. Only a `CallError` caused by an agent-level fault —
+a transport, protocol, or certificate failure, or a
+`SysTransient`/`SysUnknown` rejection — can plausibly produce a different
+result next time.
 
 IC Reactor ships this classification as two functions, exported from
 `@ic-reactor/core` and re-exported by `@ic-reactor/react`:
@@ -306,10 +309,11 @@ IC Reactor ships this classification as two functions, exported from
   agent error underneath (encode/decode/transform failures) are never
   retryable.
 - **`reactorRetry(failureCount, error)`** — a TanStack Query `retry` predicate
-  built on it: up to 3 attempts for retryable errors, none otherwise. It always
-  returns `false` on the server (`typeof window === "undefined"`), preserving
-  TanStack Query's no-retries-on-server default so a failed prefetch or render
-  keeps failing fast.
+  built on it: up to 3 retries (4 attempts in total) for retryable errors, none
+  otherwise. It always returns `false` on the server
+  (`typeof window === "undefined"`), preserving TanStack Query's
+  no-retries-on-server default so a failed prefetch or render keeps failing
+  fast.
 
 The `QueryClient` that `defineReactor` creates already uses `reactorRetry` as
 its default for queries. A `QueryClient` you construct yourself opts in

--- a/docs/src/content/docs/packages/core.mdx
+++ b/docs/src/content/docs/packages/core.mdx
@@ -108,6 +108,9 @@ or a `SysTransient`/`SysUnknown` replica rejection. A canister `Err` variant
 (`CanisterError`), a `ValidationError`, a Candid encode failure (no request
 was ever made), and a decode failure on the reply are never retryable:
 identical input — or the identical reply — produces the identical failure.
+Within agent errors the bias is toward retrying — an unrecognized `kind`, or a
+rejection whose code cannot be read, still retries, so an unfamiliar
+transport-level fault is never silently made fatal.
 
 `reactorRetry(failureCount, error)` is a ready-made TanStack Query `retry`
 predicate on top of it — up to 3 retries (4 attempts in total) for retryable

--- a/docs/src/content/docs/packages/core.mdx
+++ b/docs/src/content/docs/packages/core.mdx
@@ -87,6 +87,35 @@ const greeting = await backend.fetchQuery({
 })
 ```
 
+## Retry Classification
+
+Whether a failed call is worth retrying is decided by what failed, and most
+failures are deterministic. `@ic-reactor/core` exports the classification
+(`@ic-reactor/react` re-exports both functions):
+
+```typescript
+import { reactorRetry, isRetryableReactorError } from "@ic-reactor/core"
+import { QueryClient } from "@tanstack/query-core"
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: reactorRetry } },
+})
+```
+
+`isRetryableReactorError(error)` returns `true` only for a `CallError` whose
+cause is an agent-level fault — a transport, protocol, or certificate failure,
+or a `SysTransient`/`SysUnknown` replica rejection. A canister `Err` variant
+(`CanisterError`), a `ValidationError`, and a Candid encode/decode failure
+that never produced a request are never retryable: identical input produces
+the identical failure.
+
+`reactorRetry(failureCount, error)` is a ready-made TanStack Query `retry`
+predicate on top of it — up to 3 attempts for retryable errors, none
+otherwise, and always `false` on the server so a failed prefetch keeps failing
+fast. `defineReactor` in `@ic-reactor/react` already installs it as the query
+default on the `QueryClient` it creates; a `QueryClient` you construct
+yourself opts in as shown above.
+
 ## Identity Attributes
 
 Identity attributes are **not** part of `@ic-reactor/core`.

--- a/docs/src/content/docs/packages/core.mdx
+++ b/docs/src/content/docs/packages/core.mdx
@@ -105,16 +105,16 @@ const queryClient = new QueryClient({
 `isRetryableReactorError(error)` returns `true` only for a `CallError` whose
 cause is an agent-level fault — a transport, protocol, or certificate failure,
 or a `SysTransient`/`SysUnknown` replica rejection. A canister `Err` variant
-(`CanisterError`), a `ValidationError`, and a Candid encode/decode failure
-that never produced a request are never retryable: identical input produces
-the identical failure.
+(`CanisterError`), a `ValidationError`, a Candid encode failure (no request
+was ever made), and a decode failure on the reply are never retryable:
+identical input — or the identical reply — produces the identical failure.
 
 `reactorRetry(failureCount, error)` is a ready-made TanStack Query `retry`
-predicate on top of it — up to 3 attempts for retryable errors, none
-otherwise, and always `false` on the server so a failed prefetch keeps failing
-fast. `defineReactor` in `@ic-reactor/react` already installs it as the query
-default on the `QueryClient` it creates; a `QueryClient` you construct
-yourself opts in as shown above.
+predicate on top of it — up to 3 retries (4 attempts in total) for retryable
+errors, none otherwise, and always `false` on the server so a failed prefetch
+keeps failing fast. `defineReactor` in `@ic-reactor/react` already installs it
+as the query default on the `QueryClient` it creates; a `QueryClient` you
+construct yourself opts in as shown above.
 
 ## Identity Attributes
 


### PR DESCRIPTION
v3.10.0 stopped retrying failures that cannot change and exported the classification from `@ic-reactor/core` (re-exported by `@ic-reactor/react`). The docs site did not mention either function; worse, its recommended retry predicate — `!(error instanceof CanisterError)` — still retried validation failures and Candid encode/decode errors, exactly the cases the release fixed.

## Changes

- **Error Handling guide**: the Retry Configuration section now introduces `isRetryableReactorError` (true only for a `CallError` whose cause is an agent-level fault — transport/protocol/certificate, or a `SysTransient`/`SysUnknown` rejection) and `reactorRetry` (3 attempts for retryable errors, none otherwise, always `false` server-side so prefetches keep failing fast). Notes that the `QueryClient` `defineReactor` creates already defaults to `reactorRetry`, while a self-built `QueryClient` opts in. The logging example and best-practices list use the new helpers.
- **Query Caching**: Smart Retry Logic now points at `reactorRetry` instead of the hand-rolled `instanceof` predicate.
- **`@ic-reactor/core` package page**: new Retry Classification section documenting both exports.

## Verification

- All snippets typecheck against the published `@ic-reactor/react@3.10.0` / `@ic-reactor/core@3.10.0`
- Runtime behavior confirmed against the published package: canister `Err`, `ValidationError`, and encode-failure `CallError`s are non-retryable; transport faults and reject code 2 retry; reject code 5 does not; `reactorRetry` returns `false` without `window`
- `pnpm docs:build`, `pnpm check:ai-context`, `pnpm format:check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXKDGRGzXWgCxTTf6rvfeW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXKDGRGzXWgCxTTf6rvfeW)_