### PR TITLE
docs(site): add SSR, optional-peer, and engines coverage

### DIFF
--- a/docs/src/content/docs/examples/nextjs.mdx
+++ b/docs/src/content/docs/examples/nextjs.mdx
@@ -93,9 +93,9 @@ export const { useActorQuery: useQueryTodo, useActorMutation: useMutateTodo } =
 <Aside type="caution">
   These module-scope reactors are for the client bundle. On the server —
   `getServerSideProps` or the App Router — do not call canisters through a
-  module-scope reactor: it is created once per process, and query keys carry no
-  caller principal, so one user's caller-scoped data can be served to another
-  request. Build the reactor (with its own `QueryClient`) inside the request
-  instead — see
+  module-scope reactor: it is reused by every request served by the same server
+  module graph, and query keys carry no caller principal, so one user's
+  caller-scoped data can be served to another request. Build the reactor (with
+  its own `QueryClient`) inside the request instead — see
   [Server-Side Rendering](/v3/framework/react-setup#server-side-rendering).
 </Aside>

--- a/docs/src/content/docs/examples/nextjs.mdx
+++ b/docs/src/content/docs/examples/nextjs.mdx
@@ -89,3 +89,13 @@ export const { useActorQuery: useQueryTodo, useActorMutation: useMutateTodo } =
   automatic regeneration on `.did` changes, use the Vite plugin examples
   instead.
 </Aside>
+
+<Aside type="caution">
+  These module-scope reactors are for the client bundle. On the server —
+  `getServerSideProps` or the App Router — do not call canisters through a
+  module-scope reactor: it is created once per process, and query keys carry no
+  caller principal, so one user's caller-scoped data can be served to another
+  request. Build the reactor (with its own `QueryClient`) inside the request
+  instead — see
+  [Server-Side Rendering](/v3/framework/react-setup#server-side-rendering).
+</Aside>

--- a/docs/src/content/docs/framework/react-setup.mdx
+++ b/docs/src/content/docs/framework/react-setup.mdx
@@ -379,11 +379,11 @@ function App() {
 
 Every setup on this page defines the reactor at module scope, which is exactly
 right for a client-only SPA — but on a server it is a data leak. A reactor owns
-its `QueryClient`, so a module-scope reactor is created once per process and
-shared by every request, and query keys are `[canisterId, functionName, args]`
-— they do not include the caller. A cached result for a caller-scoped method
-(`get_my_balance`, a deposit address, `my_profile`) is handed to whichever
-request asks next:
+its `QueryClient`, and module scope outlives the request: every request served
+by the same server module graph shares one reactor and one cache. No segment
+of a reactor query key identifies the caller, so a cached result for a
+caller-scoped method (`get_my_balance`, a deposit address, `my_profile`) is
+handed to whichever request asks next:
 
 ```tsx
 import { defineReactor } from "@ic-reactor/react"
@@ -412,6 +412,12 @@ export default async function Page() {
   return <Profile data={data} />
 }
 ```
+
+The fresh reactor's agent is **anonymous**. A per-request `QueryClient`
+isolates the cache; it does not carry the caller's identity. For a
+caller-scoped method like `get_my_profile` to answer as the request's user,
+thread that request's identity into the reactor — `agentOptions: { identity }`
+on the `defineReactor` call — however your server derives it.
 
 Two further constraints on the Next.js App Router specifically:
 

--- a/docs/src/content/docs/framework/react-setup.mdx
+++ b/docs/src/content/docs/framework/react-setup.mdx
@@ -373,6 +373,60 @@ function App() {
 }
 ```
 
+## Server-Side Rendering
+
+**Build the reactor inside the request, not at module scope.**
+
+Every setup on this page defines the reactor at module scope, which is exactly
+right for a client-only SPA — but on a server it is a data leak. A reactor owns
+its `QueryClient`, so a module-scope reactor is created once per process and
+shared by every request, and query keys are `[canisterId, functionName, args]`
+— they do not include the caller. A cached result for a caller-scoped method
+(`get_my_balance`, a deposit address, `my_profile`) is handed to whichever
+request asks next:
+
+```tsx
+import { defineReactor } from "@ic-reactor/react"
+import { QueryClient } from "@tanstack/react-query"
+import { canisterId, idlFactory, type _SERVICE } from "../declarations/backend"
+
+// ❌ Shared by every request on the server
+export const app = defineReactor<_SERVICE>({
+  name: "backend",
+  idlFactory,
+  canisterId,
+})
+```
+
+```tsx
+// ✅ Per request: nothing is shared between users
+export default async function Page() {
+  const app = defineReactor<_SERVICE>({
+    name: "backend",
+    idlFactory,
+    canisterId,
+    queryClient: new QueryClient(),
+  })
+
+  const data = await app.reactor.fetchQuery({ functionName: "get_my_profile" })
+  return <Profile data={data} />
+}
+```
+
+Two further constraints on the Next.js App Router specifically:
+
+- Hooks are client-only, like every React hook — call them from a
+  `"use client"` module. A server component may import `Reactor` /
+  `ClientManager` and make imperative calls; that path works.
+- Hooks bind to their reactor's own `QueryClient` rather than to a
+  `QueryClientProvider`, so `HydrationBoundary` prefetch does not feed them
+  unless the provider's client _is_ that reactor's client. Next.js also
+  evaluates a shared module twice on the server (the RSC and SSR graphs), so a
+  module-scope reactor is two different instances there.
+
+If none of that applies — a client-only SPA — module-scope reactors are exactly
+right and none of this is a concern.
+
 ## Best Practices
 
 1. **Centralize configuration** — Keep reactor setup in a dedicated `reactor/` folder

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -10,7 +10,10 @@ IC Reactor is compatible with React 18+, and works with TypeScript 5+.
 
 ## Prerequisites
 
-- **Node.js** 18 or later
+- **Node.js** 18 or later for `@ic-reactor/core` and `@ic-reactor/react`;
+  `@ic-reactor/candid` requires Node 20.19.0 or later (the floor of its
+  `@noble/hashes` dependency). Each package declares this in its `engines`
+  field.
 - **A package manager**: npm, yarn, pnpm, or bun
 
 ## Install Packages
@@ -44,6 +47,12 @@ Most users will want the React package, which includes everything you need:
 <Aside type="tip">
   `@ic-reactor/react` re-exports everything from `@ic-reactor/core`, so you only
   need one import for everything!
+</Aside>
+
+<Aside type="note">
+  `react` is the only required React peer. `react-dom` is declared as an
+  **optional** peer — the package never imports it — so renderers without a
+  DOM (React Native, custom hosts) work without installing it.
 </Aside>
 
 ### Non-React Projects (Node.js, Svelte, Vue, etc.)
@@ -116,6 +125,27 @@ not work until you install it:
 ```bash
 pnpm add @icp-sdk/auth
 ```
+
+Bundlers still **resolve** that specifier while building the module graph,
+which happens before any tree-shaking — so a missing peer cannot simply be
+optimized away. The import sits inside a `try` block, which webpack-family
+bundlers treat as declaring an optional dependency: with the peer absent the
+build succeeds and prints one warning,
+`Module not found: Can't resolve '@icp-sdk/auth/client'`. Only the login paths
+are affected, and they throw an actionable error if they are ever called.
+
+Install the peer to remove the warning, or silence it with
+[`ignoreWarnings`](https://webpack.js.org/configuration/other-options/#ignorewarnings):
+
+```js
+// webpack.config.js / next.config.js (webpack)
+ignoreWarnings: [{ module: /@ic-reactor\/react/, message: /@icp-sdk\/auth/ }]
+```
+
+Vite, Rollup, and webpack all code-split the auth module into its own async
+chunk. That chunk is never fetched unless something touches authentication,
+and its bytes are dropped from the output entirely in apps that never
+reference `AuthenticationManager`.
 
 [Read more about Authentication](/v3/guides/authentication)
 

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -128,8 +128,8 @@ pnpm add @icp-sdk/auth
 
 Bundlers still **resolve** that specifier while building the module graph,
 which happens before any tree-shaking — so a missing peer cannot simply be
-optimized away. The import sits inside a `try` block, which webpack-family
-bundlers treat as declaring an optional dependency: with the peer absent the
+optimized away. The import sits inside a `try` block, which **webpack-family
+bundlers** treat as declaring an optional dependency: with the peer absent the
 build succeeds and prints one warning,
 `Module not found: Can't resolve '@icp-sdk/auth/client'`. Only the login paths
 are affected, and they throw an actionable error if they are ever called.
@@ -138,11 +138,31 @@ Install the peer to remove the warning, or silence it with
 [`ignoreWarnings`](https://webpack.js.org/configuration/other-options/#ignorewarnings):
 
 ```js
-// webpack.config.js / next.config.js (webpack)
-ignoreWarnings: [{ module: /@ic-reactor\/react/, message: /@icp-sdk\/auth/ }]
+// webpack.config.js
+module.exports = {
+  ignoreWarnings: [{ module: /@ic-reactor\/react/, message: /@icp-sdk\/auth/ }],
+}
 ```
 
-Vite, Rollup, and webpack all code-split the auth module into its own async
+```js
+// next.config.js — ignoreWarnings only takes effect inside webpack()
+module.exports = {
+  webpack: (config) => {
+    config.ignoreWarnings = [
+      { module: /@ic-reactor\/react/, message: /@icp-sdk\/auth/ },
+    ]
+    return config
+  },
+}
+```
+
+The optional-`try` treatment is webpack-specific — other bundlers may refuse
+to resolve the missing specifier at build time. If yours does, install the
+peer, or construct the `AuthClient` yourself and pass it as `authClient` to
+`AuthenticationManager`, in which case IC Reactor never imports
+`@icp-sdk/auth` at all.
+
+With the peer installed, the auth module is code-split into its own async
 chunk. That chunk is never fetched unless something touches authentication,
 and its bytes are dropped from the output entirely in apps that never
 reference `AuthenticationManager`.

--- a/docs/src/content/docs/getting-started/why-ic-reactor.mdx
+++ b/docs/src/content/docs/getting-started/why-ic-reactor.mdx
@@ -128,7 +128,7 @@ IC Reactor's architecture was built with **modern software engineering principle
 | **Suspense Support**        | ✅ Built-in                      | ❌ Complex setup           |
 | **Infinite Queries**        | ✅ Built-in                      | ❌ Complex setup           |
 | **DevTools**                | ✅ TanStack Query DevTools       | ❌ None                    |
-| **SSR Support**             | ✅ With prefetching              | ⚠️ Tricky                  |
+| **SSR**                     | ⚠️ Per-request reactor required  | ⚠️ Tricky                  |
 | **Multi-Actor**             | ✅ Shared ClientManager          | ⚠️ Manual coordination     |
 
 <Aside>

--- a/docs/src/content/docs/packages/candid/index.mdx
+++ b/docs/src/content/docs/packages/candid/index.mdx
@@ -58,6 +58,10 @@ For local parsing (recommended for production):
 npm install @ic-reactor/parser
 ```
 
+Unlike `@ic-reactor/core` and `@ic-reactor/react` (Node.js 18+), this package
+requires **Node.js 20.19.0 or later** — the floor of its `@noble/hashes`
+dependency, declared in the package's `engines` field.
+
 ## Quick Start
 
 ### Using CandidReactor

--- a/docs/src/content/docs/packages/react.mdx
+++ b/docs/src/content/docs/packages/react.mdx
@@ -29,15 +29,23 @@ pnpm add @icp-sdk/auth
 `react` is the only required React peer — `react-dom` is declared as an
 **optional** peer and never imported. `@icp-sdk/auth` is optional too: it is
 loaded through a literal `import("@icp-sdk/auth/client")` inside a `try`
-block, so the build succeeds without it, but webpack-family bundlers print one
-`Module not found: Can't resolve '@icp-sdk/auth/client'` warning while
-resolving the module graph. Install the peer to remove the warning, or
-silence it:
+block, which **webpack-family bundlers** treat as declaring an optional
+dependency — with the peer absent the build succeeds and prints one
+`Module not found: Can't resolve '@icp-sdk/auth/client'` warning. Install the
+peer to remove the warning, or silence it with
+[`ignoreWarnings`](https://webpack.js.org/configuration/other-options/#ignorewarnings)
+(in Next.js, assign it inside the `webpack(config)` callback):
 
 ```js
-// webpack.config.js / next.config.js (webpack)
+// webpack.config.js
 ignoreWarnings: [{ module: /@ic-reactor\/react/, message: /@icp-sdk\/auth/ }]
 ```
+
+That optional-`try` treatment is webpack-specific — other bundlers may fail to
+resolve the missing specifier at build time. If yours does, install the peer,
+or construct the `AuthClient` yourself and pass it as `authClient` to
+`AuthenticationManager`, in which case IC Reactor never imports
+`@icp-sdk/auth` at all.
 
 The package requires Node.js 18+ (declared in `engines`).
 

--- a/docs/src/content/docs/packages/react.mdx
+++ b/docs/src/content/docs/packages/react.mdx
@@ -26,6 +26,21 @@ pnpm add @ic-reactor/react @tanstack/react-query @icp-sdk/core
 pnpm add @icp-sdk/auth
 ```
 
+`react` is the only required React peer — `react-dom` is declared as an
+**optional** peer and never imported. `@icp-sdk/auth` is optional too: it is
+loaded through a literal `import("@icp-sdk/auth/client")` inside a `try`
+block, so the build succeeds without it, but webpack-family bundlers print one
+`Module not found: Can't resolve '@icp-sdk/auth/client'` warning while
+resolving the module graph. Install the peer to remove the warning, or
+silence it:
+
+```js
+// webpack.config.js / next.config.js (webpack)
+ignoreWarnings: [{ module: /@ic-reactor\/react/, message: /@icp-sdk\/auth/ }]
+```
+
+The package requires Node.js 18+ (declared in `engines`).
+
 ## What's Included
 
 <CardGrid>


### PR DESCRIPTION
Adds the v3.10.0 topics the site was missing, adapted from the package READMEs (which are current) rather than invented.

## Changes

- **Server-Side Rendering** (new section in React Setup): module-scope reactors are client-only. A reactor owns its `QueryClient` and query keys carry no caller principal, so on a server a module-scope reactor serves one user's caller-scoped data to the next request — build the reactor (with a fresh `QueryClient`) inside the request. Includes the App Router constraints: hooks are client-only, hooks bind to the reactor's own `QueryClient` (so `HydrationBoundary` prefetch doesn't reach them unless the provider's client is that instance), and Next.js evaluates a shared module twice on the server. The Next.js example links here with a caution aside, and the Why IC Reactor comparison table's "SSR ✅ With prefetching" row is replaced with the honest "per-request reactor required".
- **`@icp-sdk/auth` optional peer** (Installation + `@ic-reactor/react` page): bundlers resolve the specifier before tree-shaking, so with the peer absent webpack-family bundlers print one `Module not found: Can't resolve '@icp-sdk/auth/client'` warning; silence it with `ignoreWarnings` or install the peer. Only login paths are affected.
- **engines**: core/react need Node 18+; `@ic-reactor/candid` needs Node 20.19.0+ (the floor of its `@noble/hashes` dependency). Noted in Installation prerequisites and on the candid package page.
- **`react-dom` is an optional peer** and never imported — noted in Installation and the react package page.

## Verification

- The SSR snippet (`defineReactor` with a per-request `QueryClient`, `app.reactor.fetchQuery`) typechecks against the published `@ic-reactor/react@3.10.0`
- engines/peer claims checked against the published packages' `package.json` (`engines`, `peerDependenciesMeta`)
- `pnpm docs:build`, `pnpm check:ai-context`, `pnpm format:check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXKDGRGzXWgCxTTf6rvfeW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXKDGRGzXWgCxTTf6rvfeW)_