### PR TITLE
fix(scripts): sync AI-context versions in the tools release, as the v3 lane does

### DIFF
--- a/scripts/ai-context-files.js
+++ b/scripts/ai-context-files.js
@@ -1,0 +1,27 @@
+/**
+ * The single list of files whose version references must stay current.
+ *
+ * `check-ai-context.js` validates these; `release.js` and `release-tools.js`
+ * rewrite them. Keeping the list in one module is the point: when the two
+ * release scripts each carried their own copy, the tools lane's copy omitted
+ * the runtime `llms.txt` files and the runtime lane's omitted the tooling ones,
+ * so either lane could leave a stale mention that the checker then failed on.
+ */
+export const AI_CONTEXT_FILES = [
+  "llms.txt",
+  "llms-full.txt",
+  "AGENTS.md",
+  "CLAUDE.md",
+  ".cursorrules",
+  ".github/copilot-instructions.md",
+  "skill-packages/README.md",
+  "skill-packages/ic-reactor-hooks/SKILL.md",
+  "skill-packages/ic-reactor-packages/SKILL.md",
+  "skill-packages/ic-reactor-packages/references/package-map.md",
+  "packages/core/llms.txt",
+  "packages/react/llms.txt",
+  "packages/candid/llms.txt",
+  "packages/codegen/llms.txt",
+  "packages/cli/llms.txt",
+  "packages/vite-plugin/llms.txt",
+]

--- a/scripts/check-ai-context.js
+++ b/scripts/check-ai-context.js
@@ -2,6 +2,7 @@
 
 import { existsSync, readFileSync } from "node:fs"
 import { join } from "node:path"
+import { AI_CONTEXT_FILES } from "./ai-context-files.js"
 
 const rootDir = process.cwd()
 
@@ -33,19 +34,7 @@ const requiredPackageLlms = [
  * validated, so a release could bump every manifest and leave all of these
  * claiming the previous version with the gate still green.
  */
-const aiContextFiles = [
-  "llms.txt",
-  "llms-full.txt",
-  "AGENTS.md",
-  "CLAUDE.md",
-  ".cursorrules",
-  ".github/copilot-instructions.md",
-  "skill-packages/README.md",
-  "skill-packages/ic-reactor-hooks/SKILL.md",
-  "skill-packages/ic-reactor-packages/SKILL.md",
-  "skill-packages/ic-reactor-packages/references/package-map.md",
-  ...requiredPackageLlms.map((dir) => `packages/${dir}/llms.txt`),
-]
+const aiContextFiles = AI_CONTEXT_FILES
 
 /** The docs site is served under this base; see docs/astro.config.mjs. */
 const DOCS_BASE = "/v3/"

--- a/scripts/release-tools.js
+++ b/scripts/release-tools.js
@@ -42,6 +42,54 @@ function updateLlmsVersion(packageName, newVersion) {
   }
 }
 
+// Every file `scripts/check-ai-context.js` verifies. `updateLlmsVersion` only
+// rewrites the backticked version table in the root llms.txt, so prose mentions
+// elsewhere (the package tables in AGENTS.md/CLAUDE.md, the lane lines in
+// .cursorrules and skill-packages/README.md, ...) were left behind and failed
+// the check:ai-context CI gate on the release commit itself.
+//
+// `scripts/release.js` has carried this fix for the runtime lane for a while;
+// this lane never got it, so every tools release broke the gate on main.
+const AI_CONTEXT_FILES = [
+  "llms.txt",
+  "llms-full.txt",
+  "AGENTS.md",
+  "CLAUDE.md",
+  ".cursorrules",
+  ".github/copilot-instructions.md",
+  "skill-packages/README.md",
+  "skill-packages/ic-reactor-hooks/SKILL.md",
+  "skill-packages/ic-reactor-packages/SKILL.md",
+  "skill-packages/ic-reactor-packages/references/package-map.md",
+  "packages/codegen/llms.txt",
+  "packages/cli/llms.txt",
+  "packages/vite-plugin/llms.txt",
+]
+
+function syncAiContextVersions(oldVersion, newVersion) {
+  if (oldVersion === newVersion) return
+  // Same boundaries as check-ai-context.js's SEMVER, so `0.12.0` inside
+  // `0.12.01` or a longer dotted string is not touched. Matches an optional
+  // leading `v`.
+  const escaped = oldVersion.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&")
+  const pattern = new RegExp(`(?<![\\d.])(v?)${escaped}(?![\\d.]\\d)`, "g")
+
+  for (const relativePath of AI_CONTEXT_FILES) {
+    const fullPath = join(rootDir, relativePath)
+    let text
+    try {
+      text = readFileSync(fullPath, "utf-8")
+    } catch {
+      continue // optional file
+    }
+    const updated = text.replace(pattern, `$1${newVersion}`)
+    if (updated !== text) {
+      writeFileSync(fullPath, updated, "utf-8")
+      console.log(`✅ Synced ${relativePath} to ${newVersion}`)
+    }
+  }
+}
+
 function updatePackageJson(filePath, newVersion) {
   try {
     const fullPath = join(rootDir, filePath)
@@ -67,7 +115,15 @@ const packages = [
   "packages/cli/package.json",
 ]
 
+// Read the outgoing version before any manifest is rewritten, so prose mentions
+// of it can be swept afterwards.
+const previousVersion = JSON.parse(
+  readFileSync(join(rootDir, packages[0]), "utf-8")
+).version
+
 packages.forEach((pkg) => updatePackageJson(pkg, version))
+
+syncAiContextVersions(previousVersion, version)
 
 // 2. Update library lockfile
 console.log("\n🔗 Updating lockfile (pnpm install)...")
@@ -80,9 +136,10 @@ try {
 }
 
 const RELEASE_PATHS = [
-  // updateLlmsVersion() rewrites the root manifest; without it here the bump
-  // is left unstaged and check:ai-context fails on the released commit.
-  "llms.txt",
+  // updateLlmsVersion() and syncAiContextVersions() rewrite these; without them
+  // here the bump is left unstaged and check:ai-context fails on the released
+  // commit.
+  ...AI_CONTEXT_FILES,
   "pnpm-lock.yaml",
   "packages/codegen/package.json",
   "packages/vite-plugin/package.json",

--- a/scripts/release-tools.js
+++ b/scripts/release-tools.js
@@ -3,6 +3,8 @@ import { readFileSync, writeFileSync } from "fs"
 import { join, dirname } from "path"
 import { fileURLToPath } from "url"
 import { execFileSync } from "child_process"
+import { AI_CONTEXT_FILES } from "./ai-context-files.js"
+import { syncAiContextVersions } from "./sync-ai-context-versions.js"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const rootDir = join(__dirname, "..")
@@ -42,54 +44,6 @@ function updateLlmsVersion(packageName, newVersion) {
   }
 }
 
-// Every file `scripts/check-ai-context.js` verifies. `updateLlmsVersion` only
-// rewrites the backticked version table in the root llms.txt, so prose mentions
-// elsewhere (the package tables in AGENTS.md/CLAUDE.md, the lane lines in
-// .cursorrules and skill-packages/README.md, ...) were left behind and failed
-// the check:ai-context CI gate on the release commit itself.
-//
-// `scripts/release.js` has carried this fix for the runtime lane for a while;
-// this lane never got it, so every tools release broke the gate on main.
-const AI_CONTEXT_FILES = [
-  "llms.txt",
-  "llms-full.txt",
-  "AGENTS.md",
-  "CLAUDE.md",
-  ".cursorrules",
-  ".github/copilot-instructions.md",
-  "skill-packages/README.md",
-  "skill-packages/ic-reactor-hooks/SKILL.md",
-  "skill-packages/ic-reactor-packages/SKILL.md",
-  "skill-packages/ic-reactor-packages/references/package-map.md",
-  "packages/codegen/llms.txt",
-  "packages/cli/llms.txt",
-  "packages/vite-plugin/llms.txt",
-]
-
-function syncAiContextVersions(oldVersion, newVersion) {
-  if (oldVersion === newVersion) return
-  // Same boundaries as check-ai-context.js's SEMVER, so `0.12.0` inside
-  // `0.12.01` or a longer dotted string is not touched. Matches an optional
-  // leading `v`.
-  const escaped = oldVersion.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&")
-  const pattern = new RegExp(`(?<![\\d.])(v?)${escaped}(?![\\d.]\\d)`, "g")
-
-  for (const relativePath of AI_CONTEXT_FILES) {
-    const fullPath = join(rootDir, relativePath)
-    let text
-    try {
-      text = readFileSync(fullPath, "utf-8")
-    } catch {
-      continue // optional file
-    }
-    const updated = text.replace(pattern, `$1${newVersion}`)
-    if (updated !== text) {
-      writeFileSync(fullPath, updated, "utf-8")
-      console.log(`✅ Synced ${relativePath} to ${newVersion}`)
-    }
-  }
-}
-
 function updatePackageJson(filePath, newVersion) {
   try {
     const fullPath = join(rootDir, filePath)
@@ -123,7 +77,12 @@ const previousVersion = JSON.parse(
 
 packages.forEach((pkg) => updatePackageJson(pkg, version))
 
-syncAiContextVersions(previousVersion, version)
+const syncedFiles = syncAiContextVersions(rootDir, previousVersion, version, [
+  "@ic-reactor/codegen",
+  "@ic-reactor/vite-plugin",
+  "@ic-reactor/cli",
+])
+syncedFiles.forEach((f) => console.log(`✅ Synced ${f} to ${version}`))
 
 // 2. Update library lockfile
 console.log("\n🔗 Updating lockfile (pnpm install)...")

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -3,6 +3,8 @@ import { readFileSync, writeFileSync } from "fs"
 import { join, dirname } from "path"
 import { fileURLToPath } from "url"
 import { execFileSync } from "child_process"
+import { AI_CONTEXT_FILES } from "./ai-context-files.js"
+import { syncAiContextVersions } from "./sync-ai-context-versions.js"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const rootDir = join(__dirname, "..")
@@ -39,50 +41,6 @@ function updateLlmsVersion(packageName, newVersion) {
     console.error(
       `❌ Failed to update llms.txt for ${packageName}: ${err.message}`
     )
-  }
-}
-
-// Every file `scripts/check-ai-context.js` verifies. `updateLlmsVersion` only
-// rewrites the backticked version table in the root llms.txt, so prose mentions
-// elsewhere ("targets the stable v3.8.0 runtime release", the package tables in
-// AGENTS.md/CLAUDE.md, ...) were left behind and failed the check:ai-context CI
-// gate on the release commit itself.
-const AI_CONTEXT_FILES = [
-  "llms.txt",
-  "llms-full.txt",
-  "AGENTS.md",
-  "CLAUDE.md",
-  ".cursorrules",
-  ".github/copilot-instructions.md",
-  "skill-packages/README.md",
-  "skill-packages/ic-reactor-hooks/SKILL.md",
-  "skill-packages/ic-reactor-packages/SKILL.md",
-  "skill-packages/ic-reactor-packages/references/package-map.md",
-  "packages/core/llms.txt",
-  "packages/react/llms.txt",
-  "packages/candid/llms.txt",
-]
-
-function syncAiContextVersions(oldVersion, newVersion) {
-  if (oldVersion === newVersion) return
-  // Same boundaries as check-ai-context.js's SEMVER, so `3.9.0` inside `3.9.01`
-  // or a longer dotted string is not touched. Matches an optional leading `v`.
-  const escaped = oldVersion.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&")
-  const pattern = new RegExp(`(?<![\\d.])(v?)${escaped}(?![\\d.]\\d)`, "g")
-
-  for (const relativePath of AI_CONTEXT_FILES) {
-    const fullPath = join(rootDir, relativePath)
-    let text
-    try {
-      text = readFileSync(fullPath, "utf-8")
-    } catch {
-      continue // optional file
-    }
-    const updated = text.replace(pattern, `$1${newVersion}`)
-    if (updated !== text) {
-      writeFileSync(fullPath, updated, "utf-8")
-      console.log(`✅ Synced ${relativePath} to ${newVersion}`)
-    }
   }
 }
 
@@ -131,7 +89,12 @@ try {
 
 // 3. Sync every AI-context file the check:ai-context gate reads
 console.log("\n🧠 Syncing AI-context versions...")
-syncAiContextVersions(previousVersion, version)
+const syncedFiles = syncAiContextVersions(rootDir, previousVersion, version, [
+  "@ic-reactor/core",
+  "@ic-reactor/react",
+  "@ic-reactor/candid",
+])
+syncedFiles.forEach((f) => console.log(`✅ Synced ${f} to ${version}`))
 
 // 4. Sync examples to literal version for the Git Commit (StackBlitz support)
 try {

--- a/scripts/sync-ai-context-versions.js
+++ b/scripts/sync-ai-context-versions.js
@@ -1,0 +1,75 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { AI_CONTEXT_FILES } from "./ai-context-files.js"
+
+/**
+ * Rewrite version references belonging to the packages being released.
+ *
+ * The lanes version independently — runtime is 3.x, tooling 0.12.x, parser
+ * 0.4.x — so a blind textual replacement of the outgoing version is unsafe: if
+ * two lanes ever share a version string, releasing one would silently rewrite
+ * the other's documented version, and `check-ai-context.js` would not catch it
+ * because it accepts any version belonging to any @ic-reactor package.
+ *
+ * So a replacement happens only on a line that also names one of the packages
+ * being released. Every real occurrence is of that shape — the package tables
+ * in AGENTS.md/CLAUDE.md, the lane lines in .cursorrules and
+ * skill-packages/README.md, the version table in llms.txt. A version mention
+ * that names no package is left alone, which surfaces as a loud
+ * `check:ai-context` failure on the release commit rather than as a silent
+ * cross-lane rewrite.
+ *
+ * @param {string} rootDir       repository root
+ * @param {string} oldVersion    version being replaced
+ * @param {string} newVersion    version to write
+ * @param {string[]} packageNames  the `@ic-reactor/*` packages this release covers
+ * @returns {string[]} relative paths that changed
+ */
+export function syncAiContextVersions(
+  rootDir,
+  oldVersion,
+  newVersion,
+  packageNames
+) {
+  if (oldVersion === newVersion) return []
+
+  // Same boundaries as check-ai-context.js's SEMVER, so `0.12.0` inside
+  // `0.12.01` or a longer dotted string is not touched. Matches an optional
+  // leading `v`.
+  const escaped = oldVersion.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&")
+  const pattern = new RegExp(`(?<![\\d.])(v?)${escaped}(?![\\d.]\\d)`, "g")
+
+  // A line qualifies if it names one of the released packages, either in full
+  // (`@ic-reactor/codegen`) or as its directory (`packages/codegen`).
+  const needles = packageNames.flatMap((name) => {
+    const dir = name.replace("@ic-reactor/", "")
+    return [name, `packages/${dir}`]
+  })
+
+  const changed = []
+
+  for (const relativePath of AI_CONTEXT_FILES) {
+    const fullPath = join(rootDir, relativePath)
+    let text
+    try {
+      text = readFileSync(fullPath, "utf-8")
+    } catch {
+      continue // optional file
+    }
+
+    const updated = text
+      .split("\n")
+      .map((line) => {
+        if (!needles.some((needle) => line.includes(needle))) return line
+        return line.replace(pattern, `$1${newVersion}`)
+      })
+      .join("\n")
+
+    if (updated !== text) {
+      writeFileSync(fullPath, updated, "utf-8")
+      changed.push(relativePath)
+    }
+  }
+
+  return changed
+}


### PR DESCRIPTION
Found while cutting `tools-v0.12.1`: the release script produced a commit that immediately failed the repo's own `check:ai-context` gate.

`scripts/release.js` (the v3 runtime lane) already solves this — it has `AI_CONTEXT_FILES` and `syncAiContextVersions`, rewriting every file the checker verifies and staging them in the release commit. `scripts/release-tools.js`, otherwise a near-copy, never got that fix. It rewrote only the backticked version table in the root `llms.txt`, leaving prose mentions behind:

```
- .cursorrules:11                     "Codegen lane (`0.12.0`)"
- .github/copilot-instructions.md:9
- skill-packages/README.md:9
- CLAUDE.md:15-17                     package table
- AGENTS.md:15-17                     package table
```

`check:ai-context` is a push gate in `ci.yml`, so **every tools release has been turning main red** until someone patched it by hand afterwards.

## Change

Ports the two pieces across, aimed at the codegen/cli/vite-plugin `llms.txt` files rather than core/react/candid. Reads the outgoing version *before* any manifest is rewritten, and folds `AI_CONTEXT_FILES` into `RELEASE_PATHS` so the edits are staged rather than left dirty in the working tree.

## Verification

Re-ran `node scripts/release-tools.js 0.12.1` against a clean tree with this fix. It now rewrites all six lines itself, and `pnpm check:ai-context` passes on the commit it produces — no manual step.

Worth landing before the next tools release, which is queued behind it.