### PR TITLE
ci: bump github/codeql-action to 4.37.7 across all three paths at once

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,14 +28,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Supersedes #317, #318 and #319.

`codeql-action` requires `init`, `analyze` and `autobuild` to be the same version. Dependabot opens a separate PR per action path and has no way to group them, so each one on its own leaves a version mismatch and fails:

```
##[error]We were unable to automatically build your code.
Loaded a configuration file for version '4.37.7', but running version '4.37.6'
```

All three were red for exactly that reason — nothing wrong with the bump itself, just that it cannot land one path at a time. This does all three in one commit.

## Verification

Target `ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd` confirmed against the upstream repository as the genuine 4.37.7 release commit:

```
Merge pull request #4093 from github/update-v4.37.7-be7a3dbb8
```

All three paths now resolve to one SHA (checked: 1 distinct SHA across the three `uses:` lines).

## Note for next time

This will recur every CodeQL release. Worth either accepting the three-PR-merge-as-one workflow, or switching `codeql.yml` to a single reusable version input so Dependabot only has one place to update.