### PR TITLE
fix(vite-plugin): make generation failures visible and resolve paths against the Vite root

### DIFF
--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -75,8 +75,13 @@ icReactor({
 
 Relative paths — `didFile`, `outDir` — resolve against Vite's resolved
 `config.root`, not the directory vite was started from. If you set
-`root: "frontend"`, or run `vite build --config apps/web/vite.config.ts` from a
-monorepo root, write the paths as the project itself sees them.
+`root: "frontend"`, write the paths as the project itself sees them.
+
+Note `--config` alone does **not** change the root: `vite build --config
+apps/web/vite.config.ts` still leaves `root` at the directory vite was started
+from, so app-relative paths resolve against the monorepo root. Set `root` in the
+config file, or pass it positionally (`vite build apps/web --config …`), for
+those paths to mean what the app expects.
 
 `failOnError` decides what a failed canister does to the run. It defaults to
 `true` under `vite build` and `false` under `vite dev`: a build that quietly

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -69,8 +69,20 @@ icReactor({
   clientManagerPath: "../../clients",
   target: "react",
   injectEnvironment: true,
+  failOnError: true,
 })
 ```
+
+Relative paths — `didFile`, `outDir` — resolve against Vite's resolved
+`config.root`, not the directory vite was started from. If you set
+`root: "frontend"`, or run `vite build --config apps/web/vite.config.ts` from a
+monorepo root, write the paths as the project itself sees them.
+
+`failOnError` decides what a failed canister does to the run. It defaults to
+`true` under `vite build` and `false` under `vite dev`: a build that quietly
+ships the bindings left over from the last successful run is worse than no
+build at all, while a dev server has to survive the broken intermediate states
+of a `.did` file being edited.
 
 ### Per-canister options
 
@@ -112,7 +124,10 @@ Set the `ICP_ENVIRONMENT` environment variable to target a non-default network
 (defaults to `"local"`).
 
 If environment detection fails, the plugin still falls back to proxying `/api`
-to `http://127.0.0.1:4943`, but it will not inject canister metadata.
+to `http://127.0.0.1:4943`, but it will not inject canister metadata. It warns
+when that happens with canisters configured, because the failure is otherwise
+indistinguishable from success until the app breaks on an undefined canister
+id. Run with `DEBUG=ic-reactor` to see the `icp` output behind the warning.
 
 ## File Regeneration
 
@@ -121,7 +136,11 @@ the managed `index.generated.ts` implementation. The user-facing `index.ts`
 entry is created once, then preserved unless it still matches the default
 wrapper or a legacy generated scaffold that can be migrated automatically.
 When a watched `.did` file changes, the plugin sends a full browser reload so
-the new declarations are picked up.
+the new declarations are picked up. Regeneration is serialized per canister —
+saves that land while a run is in flight collapse into a single rerun — so two
+rapid saves cannot interleave inside the pipeline's delete-then-write sequence.
+A regeneration that fails is reported to the terminal and to the browser error
+overlay rather than leaving the page on stale bindings.
 
 ## When To Use It
 

--- a/packages/vite-plugin/llms.txt
+++ b/packages/vite-plugin/llms.txt
@@ -24,11 +24,18 @@ icReactor({
 - Runs codegen on startup and `.did` changes
 - Regenerates declarations + `index.generated.ts`
 - Preserves user-facing `index.ts` wrapper after initial creation
+- Relative paths (`didFile`, `outDir`) resolve against Vite's `config.root`
+- A failed canister fails `vite build`; in `vite dev` it goes to the terminal
+  and the browser error overlay instead
 
 ## Key Options
 
-- `canisters`, `outDir`, `clientManagerPath`, `target`, `mode`, `canisterId`
+- Plugin level: `canisters`, `outDir`, `clientManagerPath`, `target`,
+  `injectEnvironment`, `failOnError`
+- Per canister (inside `canisters[]`): `name`, `didFile`, `outDir`,
+  `clientManagerPath`, `target`, `mode`, `canisterId`
 - `injectEnvironment` for local `ic_env` cookie + `/api` proxy behavior
+- `failOnError` overrides the default (`true` for build, `false` for dev)
 
 ## Best Practices
 

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -22,11 +22,13 @@
   "files": [
     "dist",
     "src",
+    "!src/**/*.test.ts",
+    "!src/**/__snapshots__",
     "README.md",
     "llms.txt"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --tsconfig tsconfig.json",
+    "build": "tsup src/index.ts --format esm,cjs --dts --clean --tsconfig tsconfig.json",
     "dev": "tsup src/index.ts --format esm,cjs --dts --watch --tsconfig tsconfig.json",
     "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
@@ -60,7 +62,6 @@
     "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
-    "@icp-sdk/bindgen": "^0.4.0",
     "@types/node": "^26.2.0",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/packages/vite-plugin/src/env.ts
+++ b/packages/vite-plugin/src/env.ts
@@ -15,19 +15,35 @@ export interface IcEnvironment {
   internetIdentityProvider?: string
 }
 
+export interface IcEnvironmentDetection {
+  /** The detected environment, or `null` when `icp` could not answer. */
+  environment: IcEnvironment | null
+  /**
+   * Why detection came back empty or partial — the `icp` stderr where we have
+   * it. Detection failing is routine on a machine with no local replica, so
+   * these are handed back for the caller to log at its own level rather than
+   * printed here.
+   */
+  diagnostics: string[]
+}
+
 /**
  * Detect the IC environment using the `icp` CLI.
  */
 export function getIcEnvironmentInfo(
   canisterNames: string[]
-): IcEnvironment | null {
-  const environment = process.env.ICP_ENVIRONMENT || "local"
+): IcEnvironmentDetection {
+  const networkName = process.env.ICP_ENVIRONMENT || "local"
+  const diagnostics: string[] = []
 
   try {
     const networkStatus = JSON.parse(
-      execFileSync("icp", ["network", "status", "-e", environment, "--json"], {
+      execFileSync("icp", ["network", "status", "-e", networkName, "--json"], {
         encoding: "utf-8",
-        stdio: ["ignore", "pipe", "ignore"], // suppress stderr
+        // stderr is piped rather than ignored so a failure can explain itself.
+        // Piping still keeps it off the terminal — it only reaches the user if
+        // the caller decides to print the diagnostics we collect below.
+        stdio: ["ignore", "pipe", "pipe"],
       })
     )
 
@@ -40,7 +56,10 @@ export function getIcEnvironmentInfo(
         : undefined)
 
     if (!proxyTarget) {
-      return null
+      diagnostics.push(
+        `\`icp network status -e ${networkName}\` reported no api_url, gateway_url or port`
+      )
+      return { environment: null, diagnostics }
     }
 
     const canisterIds: Record<string, string> = {}
@@ -49,35 +68,45 @@ export function getIcEnvironmentInfo(
       try {
         const canisterId = execFileSync(
           "icp",
-          ["canister", "status", name, "-e", environment, "-i"],
-          { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }
+          ["canister", "status", name, "-e", networkName, "-i"],
+          { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }
         ).trim()
 
         if (canisterId) {
           canisterIds[name] = canisterId
         }
-      } catch {
-        // Canister might not exist or be deployed yet
+      } catch (error) {
+        // Canister might not exist or be deployed yet — expected for
+        // internet_identity, which is added to the lookup list unconditionally.
+        diagnostics.push(
+          `\`icp canister status ${name} -e ${networkName}\` failed: ${describeExecError(error)}`
+        )
       }
     }
 
     const internetIdentityProvider =
       !canisterIds.internet_identity &&
       isLocalhostGateway(proxyTarget) &&
-      environment !== "ic"
+      networkName !== "ic"
         ? localInternetIdentityProvider(proxyTarget)
         : undefined
 
     return {
-      environment,
-      rootKey,
-      proxyTarget,
-      canisterIds,
-      internetIdentityProvider,
+      environment: {
+        environment: networkName,
+        rootKey,
+        proxyTarget,
+        canisterIds,
+        internetIdentityProvider,
+      },
+      diagnostics,
     }
   } catch (error) {
     // CLI not found or failed
-    return null
+    diagnostics.push(
+      `\`icp network status -e ${networkName}\` failed: ${describeExecError(error)}`
+    )
+    return { environment: null, diagnostics }
   }
 }
 
@@ -101,6 +130,25 @@ export function buildIcEnvCookie(
   }
 
   return encodeURIComponent(parts.join("&"))
+}
+
+/**
+ * Turn whatever `execFileSync` threw into one readable line.
+ *
+ * The interesting part is almost always the captured stderr — the thrown
+ * Error's own message is just "Command failed: icp ..." — but stderr is absent
+ * when the binary itself is missing (ENOENT), so fall back to the message.
+ */
+function describeExecError(error: unknown): string {
+  const stderr = (error as { stderr?: Buffer | string } | undefined)?.stderr
+  const text = typeof stderr === "string" ? stderr : stderr?.toString("utf-8")
+  const trimmed = text?.trim()
+
+  if (trimmed) {
+    return trimmed
+  }
+
+  return error instanceof Error ? error.message : String(error)
 }
 
 function isLocalhostGateway(proxyTarget: string): boolean {

--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import * as vitePluginModule from "./index.js"
 import type { IcReactorPluginOptions } from "./index.js"
-import path from "path"
+import path from "node:path"
 import { execFileSync } from "child_process"
 import { runCanisterPipeline } from "@ic-reactor/codegen"
 
@@ -19,22 +19,33 @@ vi.mock("child_process", () => ({
   execFileSync: vi.fn(),
 }))
 
-// Mock fs
-vi.mock("fs", () => ({
-  default: {
-    existsSync: vi.fn(() => true),
-    readFileSync: vi.fn(),
-    mkdirSync: vi.fn(),
-    writeFileSync: vi.fn(),
-  },
-}))
+/**
+ * A Vite root that is deliberately not the process cwd, so every path
+ * assertion below fails if the plugin falls back to `process.cwd()`.
+ */
+const VITE_ROOT = path.resolve("/vite/root")
+const DID_RELATIVE = "src/declarations/test.did"
+const DID_IN_VITE_ROOT = path.resolve(VITE_ROOT, DID_RELATIVE)
+const DID_IN_CWD = path.resolve(process.cwd(), DID_RELATIVE)
+
+/**
+ * Rollup's `this.error()` throws, which is what turns a generation failure into
+ * a non-zero `vite build` exit. Model that faithfully — a context whose `error`
+ * only records the call would let a regression through.
+ */
+function buildContext() {
+  const error = vi.fn((reason: string | Error) => {
+    throw reason instanceof Error ? reason : new Error(reason)
+  })
+  return { error }
+}
 
 describe("icReactor", () => {
   const mockOptions: IcReactorPluginOptions = {
     canisters: [
       {
         name: "test_canister",
-        didFile: "src/declarations/test.did",
+        didFile: DID_RELATIVE,
         outDir: "src/declarations/test_canister",
       },
     ],
@@ -43,7 +54,7 @@ describe("icReactor", () => {
 
   const mockServer: any = {
     config: {
-      root: "/mock/root",
+      root: VITE_ROOT,
       logger: {
         info: vi.fn(),
       },
@@ -60,6 +71,17 @@ describe("icReactor", () => {
     },
   }
 
+  /**
+   * Drive the plugin through the hooks Vite runs before `buildStart`.
+   *
+   * Called optionally on purpose: the structure test above is what asserts the
+   * hook exists, and without the `?.` a plugin that lost `configResolved` would
+   * make every test below fail with a TypeError instead of failing on the path
+   * it actually resolved.
+   */
+  const resolveConfig = (plugin: any, command: "build" | "serve" = "build") =>
+    plugin.configResolved?.({ root: VITE_ROOT, command })
+
   beforeEach(() => {
     vi.resetAllMocks()
     ;(runCanisterPipeline as any).mockResolvedValue({
@@ -67,11 +89,16 @@ describe("icReactor", () => {
     })
   })
 
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it("should return correct plugin structure", () => {
     const plugin = createVitePlugin(mockOptions)
     expect(plugin.name).toBe("ic-reactor-plugin")
     expect(plugin.buildStart).toBeDefined()
     expect(plugin.handleHotUpdate).toBeDefined()
+    expect(plugin.configResolved).toBeDefined()
     expect((plugin as any).config).toBeDefined()
   })
 
@@ -187,6 +214,9 @@ describe("icReactor", () => {
     })
 
     it("should fallback to default proxy when icp-cli fails", () => {
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {})
       ;(execFileSync as any).mockImplementation(() => {
         throw new Error("Command not found")
       })
@@ -196,6 +226,47 @@ describe("icReactor", () => {
 
       expect(config.server.headers).toBeUndefined()
       expect(config.server.proxy["/api"].target).toBe("http://127.0.0.1:4943")
+      // Silent detection failure is indistinguishable from a working setup
+      // until the app blows up on an undefined canister id at runtime.
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Could not detect the local IC environment")
+      )
+    })
+
+    it("should stay quiet about failed detection when no canisters are configured", () => {
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {})
+      ;(execFileSync as any).mockImplementation(() => {
+        throw new Error("project manifest not found")
+      })
+
+      const plugin = createVitePlugin({ canisters: [] })
+      ;(plugin as any).config({}, { command: "serve" })
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+    })
+
+    it("should surface the icp stderr at debug level", () => {
+      const consoleDebugSpy = vi
+        .spyOn(console, "debug")
+        .mockImplementation(() => {})
+      vi.spyOn(console, "warn").mockImplementation(() => {})
+      vi.stubEnv("DEBUG", "ic-reactor")
+      ;(execFileSync as any).mockImplementation(() => {
+        const error: any = new Error("Command failed: icp network status")
+        error.stderr = Buffer.from("error: no local network is running\n")
+        throw error
+      })
+
+      const plugin = createVitePlugin(mockOptions)
+      ;(plugin as any).config({}, { command: "serve" })
+
+      expect(consoleDebugSpy).toHaveBeenCalledWith(
+        expect.stringContaining("no local network is running")
+      )
+
+      vi.unstubAllEnvs()
     })
 
     it("should inject default local II provider in env-only mode when icp-cli project detection fails", () => {
@@ -223,11 +294,12 @@ describe("icReactor", () => {
   describe("buildStart", () => {
     it("should generate declarations and reactor file", async () => {
       const plugin = createVitePlugin(mockOptions)
-      await (plugin.buildStart as any)()
+      resolveConfig(plugin)
+      await (plugin.buildStart as any).call(buildContext())
 
       expect(runCanisterPipeline).toHaveBeenCalledWith({
         canisterConfig: mockOptions.canisters[0],
-        projectRoot: expect.any(String),
+        projectRoot: VITE_ROOT,
         globalConfig: {
           outDir: "src/declarations",
           clientManagerPath: "../../clients",
@@ -236,24 +308,133 @@ describe("icReactor", () => {
       })
     })
 
-    it("should handle generation errors", async () => {
+    it("should resolve the project root from the Vite config, not the cwd", async () => {
+      const plugin = createVitePlugin(mockOptions)
+      resolveConfig(plugin)
+      await (plugin.buildStart as any).call(buildContext())
+
+      const { projectRoot } = (runCanisterPipeline as any).mock.calls[0][0]
+      expect(projectRoot).toBe(VITE_ROOT)
+      expect(projectRoot).not.toBe(process.cwd())
+    })
+
+    it("should fail the build when a canister fails to generate", async () => {
       const consoleErrorSpy = vi
         .spyOn(console, "error")
         .mockImplementation(() => {})
+      ;(runCanisterPipeline as any).mockResolvedValue({
+        success: false,
+        error: "DID file not found",
+      })
 
+      const plugin = createVitePlugin(mockOptions)
+      resolveConfig(plugin, "build")
+      const context = buildContext()
+
+      // `vite build` used to exit 0 here and ship whatever stale bindings were
+      // left on disk from the previous successful run.
+      await expect(
+        (plugin.buildStart as any).call(context)
+      ).rejects.toThrowError(/test_canister: DID file not found/)
+      expect(context.error).toHaveBeenCalledOnce()
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    it("should fail the build when the pipeline throws", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => {})
+      ;(runCanisterPipeline as any).mockRejectedValue(
+        new Error("Unexpected token at line 3")
+      )
+
+      const plugin = createVitePlugin(mockOptions)
+      resolveConfig(plugin, "build")
+
+      await expect(
+        (plugin.buildStart as any).call(buildContext())
+      ).rejects.toThrowError(/test_canister: Unexpected token at line 3/)
+    })
+
+    it("should name every failing canister in one build error", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => {})
+      ;(runCanisterPipeline as any).mockImplementation(
+        async ({ canisterConfig }: any) => ({
+          success: false,
+          error: `${canisterConfig.name} is broken`,
+        })
+      )
+
+      const plugin = createVitePlugin({
+        canisters: [
+          { name: "alpha", didFile: "alpha.did" },
+          { name: "beta", didFile: "beta.did" },
+        ],
+      })
+      resolveConfig(plugin, "build")
+
+      await expect(
+        (plugin.buildStart as any).call(buildContext())
+      ).rejects.toThrowError(/alpha is broken[\s\S]*beta is broken/)
+    })
+
+    it("should keep the dev server alive on failure and report to the overlay", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {})
       ;(runCanisterPipeline as any).mockResolvedValue({
         success: false,
         error: "Failed to generate",
       })
 
       const plugin = createVitePlugin(mockOptions)
-      await (plugin.buildStart as any)()
+      resolveConfig(plugin, "serve")
+      ;(plugin.configureServer as any)(mockServer)
+      const context = buildContext()
 
+      await (plugin.buildStart as any).call(context)
+
+      expect(context.error).not.toHaveBeenCalled()
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to generate test_canister")
+        expect.stringContaining("test_canister: Failed to generate")
       )
+      expect(mockServer.ws.send).toHaveBeenCalledWith({
+        type: "error",
+        err: expect.objectContaining({
+          message: expect.stringContaining("test_canister: Failed to generate"),
+          plugin: "ic-reactor-plugin",
+        }),
+      })
+    })
 
-      consoleErrorSpy.mockRestore()
+    it("should honour an explicit failOnError override in dev", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => {})
+      ;(runCanisterPipeline as any).mockResolvedValue({
+        success: false,
+        error: "Failed to generate",
+      })
+
+      const plugin = createVitePlugin({ ...mockOptions, failOnError: true })
+      resolveConfig(plugin, "serve")
+
+      await expect(
+        (plugin.buildStart as any).call(buildContext())
+      ).rejects.toThrowError(/Failed to generate/)
+    })
+
+    it("should not fail the build when failOnError is disabled", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => {})
+      ;(runCanisterPipeline as any).mockResolvedValue({
+        success: false,
+        error: "Failed to generate",
+      })
+
+      const plugin = createVitePlugin({ ...mockOptions, failOnError: false })
+      resolveConfig(plugin, "build")
+      const context = buildContext()
+
+      await (plugin.buildStart as any).call(context)
+
+      expect(context.error).not.toHaveBeenCalled()
     })
 
     it("should pass canister mode through to codegen via canister config", async () => {
@@ -266,15 +447,16 @@ describe("icReactor", () => {
         ],
         outDir: mockOptions.outDir,
       })
+      resolveConfig(plugin)
 
-      await (plugin.buildStart as any)()
+      await (plugin.buildStart as any).call(buildContext())
 
       expect(runCanisterPipeline).toHaveBeenCalledWith({
         canisterConfig: {
           ...mockOptions.canisters[0],
           mode: "Reactor",
         },
-        projectRoot: expect.any(String),
+        projectRoot: VITE_ROOT,
         globalConfig: {
           outDir: "src/declarations",
           clientManagerPath: "../../clients",
@@ -288,12 +470,13 @@ describe("icReactor", () => {
         ...mockOptions,
         target: "core",
       })
+      resolveConfig(plugin)
 
-      await (plugin.buildStart as any)()
+      await (plugin.buildStart as any).call(buildContext())
 
       expect(runCanisterPipeline).toHaveBeenCalledWith({
         canisterConfig: mockOptions.canisters[0],
-        projectRoot: expect.any(String),
+        projectRoot: VITE_ROOT,
         globalConfig: {
           outDir: "src/declarations",
           clientManagerPath: "../../clients",
@@ -304,46 +487,156 @@ describe("icReactor", () => {
   })
 
   describe("handleHotUpdate", () => {
-    it("should register configured .did files with the watcher", () => {
+    it("should register configured .did files against the Vite root", () => {
       const plugin = createVitePlugin(mockOptions)
+      resolveConfig(plugin, "serve")
       ;(plugin.configureServer as any)(mockServer)
 
-      expect(mockServer.watcher.add).toHaveBeenCalledWith([
-        expect.stringContaining("src/declarations/test.did"),
-      ])
+      expect(mockServer.watcher.add).toHaveBeenCalledWith([DID_IN_VITE_ROOT])
     })
 
-    it("should restart server when .did file changes", async () => {
+    it("should regenerate for a .did file resolved against the Vite root", async () => {
       const plugin = createVitePlugin(mockOptions)
-      const ctx = {
-        file: "/absolute/path/to/src/declarations/test.did",
-        server: mockServer,
-      }
+      resolveConfig(plugin, "serve")
 
-      // Mock path.resolve to match the test case
-      const originalResolve = path.resolve
-      vi.spyOn(path, "resolve").mockImplementation((...args) => {
-        if (args.some((a) => a && a.includes("test.did"))) {
-          return "/absolute/path/to/src/declarations/test.did"
-        }
-        return originalResolve(...args)
+      await (plugin.handleHotUpdate as any)({
+        file: DID_IN_VITE_ROOT,
+        server: mockServer,
       })
 
-      await (plugin.handleHotUpdate as any)(ctx)
-
+      expect(runCanisterPipeline).toHaveBeenCalledOnce()
       expect(mockServer.ws.send).toHaveBeenCalledWith({ type: "full-reload" })
     })
 
-    it("should ignore other files", () => {
+    it("should ignore a same-named .did file under the process cwd", async () => {
+      // Skipped when the cwd happens to be the mocked Vite root; the two paths
+      // are meant to differ, which is the whole point of the assertion.
+      if (DID_IN_CWD === DID_IN_VITE_ROOT) return
+
       const plugin = createVitePlugin(mockOptions)
-      const ctx = {
+      resolveConfig(plugin, "serve")
+
+      await (plugin.handleHotUpdate as any)({
+        file: DID_IN_CWD,
+        server: mockServer,
+      })
+
+      expect(runCanisterPipeline).not.toHaveBeenCalled()
+      expect(mockServer.ws.send).not.toHaveBeenCalled()
+    })
+
+    it("should ignore other files", async () => {
+      const plugin = createVitePlugin(mockOptions)
+      resolveConfig(plugin, "serve")
+
+      await (plugin.handleHotUpdate as any)({
         file: "/some/other/file.ts",
         server: mockServer,
-      }
-
-      ;(plugin.handleHotUpdate as any)(ctx)
+      })
 
       expect(mockServer.ws.send).not.toHaveBeenCalled()
+    })
+
+    it("should send a regeneration failure to the browser overlay", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => {})
+      ;(runCanisterPipeline as any).mockResolvedValue({
+        success: false,
+        error: "Unexpected token 'srevice'",
+      })
+
+      const plugin = createVitePlugin(mockOptions)
+      resolveConfig(plugin, "serve")
+
+      await (plugin.handleHotUpdate as any)({
+        file: DID_IN_VITE_ROOT,
+        server: mockServer,
+      })
+
+      expect(mockServer.ws.send).toHaveBeenCalledWith({
+        type: "error",
+        err: expect.objectContaining({
+          message: expect.stringContaining("Unexpected token 'srevice'"),
+          plugin: "ic-reactor-plugin",
+        }),
+      })
+      expect(mockServer.ws.send).not.toHaveBeenCalledWith({
+        type: "full-reload",
+      })
+    })
+
+    it("should send a thrown regeneration error to the browser overlay", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => {})
+      ;(runCanisterPipeline as any).mockRejectedValue(
+        new Error("parser panicked")
+      )
+
+      const plugin = createVitePlugin(mockOptions)
+      resolveConfig(plugin, "serve")
+
+      await (plugin.handleHotUpdate as any)({
+        file: DID_IN_VITE_ROOT,
+        server: mockServer,
+      })
+
+      expect(mockServer.ws.send).toHaveBeenCalledWith({
+        type: "error",
+        err: expect.objectContaining({
+          message: expect.stringContaining("parser panicked"),
+        }),
+      })
+    })
+
+    it("should serialize regeneration for rapid saves of the same .did file", async () => {
+      let releaseFirstRun: (result: unknown) => void = () => {}
+      ;(runCanisterPipeline as any).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseFirstRun = resolve
+          })
+      )
+
+      const plugin = createVitePlugin(mockOptions)
+      resolveConfig(plugin, "serve")
+      const ctx = { file: DID_IN_VITE_ROOT, server: mockServer }
+
+      const first = (plugin.handleHotUpdate as any)(ctx)
+      const second = (plugin.handleHotUpdate as any)(ctx)
+
+      // The second save must not enter the pipeline's delete-then-write
+      // sequence while the first one is still inside it.
+      expect(runCanisterPipeline).toHaveBeenCalledOnce()
+
+      releaseFirstRun({ success: true })
+      await Promise.all([first, second])
+
+      // ...but it must not be dropped either: the last saved .did has to win.
+      expect(runCanisterPipeline).toHaveBeenCalledTimes(2)
+    })
+
+    it("should collapse a burst of saves into a single trailing rerun", async () => {
+      let releaseFirstRun: (result: unknown) => void = () => {}
+      ;(runCanisterPipeline as any).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseFirstRun = resolve
+          })
+      )
+
+      const plugin = createVitePlugin(mockOptions)
+      resolveConfig(plugin, "serve")
+      const ctx = { file: DID_IN_VITE_ROOT, server: mockServer }
+
+      const pending = [
+        (plugin.handleHotUpdate as any)(ctx),
+        (plugin.handleHotUpdate as any)(ctx),
+        (plugin.handleHotUpdate as any)(ctx),
+        (plugin.handleHotUpdate as any)(ctx),
+      ]
+
+      releaseFirstRun({ success: true })
+      await Promise.all(pending)
+
+      expect(runCanisterPipeline).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -65,6 +65,7 @@ describe("icReactor", () => {
     restart: vi.fn(),
     ws: {
       send: vi.fn(),
+      on: vi.fn(),
     },
     watcher: {
       add: vi.fn(),

--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -233,6 +233,46 @@ describe("icReactor", () => {
       )
     })
 
+    // The replica being UP while a configured canister is simply not deployed is
+    // the common case, and it takes the success branch: icEnv is truthy, so the
+    // "could not detect" warning never fires. Without a second check the cookie
+    // goes out with a root key and no PUBLIC_CANISTER_ID, which is exactly the
+    // silent failure the warning above exists to prevent.
+    it("should warn when the replica is up but a configured canister has no id", () => {
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {})
+      ;(execFileSync as any).mockImplementation(
+        (command: string, args: string[]) => {
+          if (
+            command === "icp" &&
+            args.includes("network") &&
+            args.includes("status")
+          ) {
+            return JSON.stringify({ root_key: "mock-root-key", port: 4943 })
+          }
+          // Never deployed: every canister status fails.
+          if (args.includes("canister") && args.includes("status")) {
+            throw new Error("canister not found")
+          }
+          return ""
+        }
+      )
+
+      const plugin = createVitePlugin(mockOptions)
+      const result = (plugin as any).config({}, { command: "serve" })
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("no canister ID could be resolved")
+      )
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("test")
+      )
+      // The cookie still went out, which is why the warning is the only signal.
+      const cookie = result?.server?.headers?.["Set-Cookie"] ?? ""
+      expect(cookie).not.toContain("PUBLIC_CANISTER_ID")
+    })
+
     it("should stay quiet about failed detection when no canisters are configured", () => {
       const consoleWarnSpy = vi
         .spyOn(console, "warn")

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -130,11 +130,22 @@ export function icReactor(options: IcReactorPluginOptions): Plugin {
     })
   }
 
-  // A `.did` save can land while the previous regeneration is still inside the
-  // pipeline's delete-then-write sequence, and the second run would wipe the
-  // directory the first one is writing into. Keep at most one run per canister
-  // in flight and collapse every save that arrives meanwhile into a single
-  // trailing rerun, so the last saved `.did` still wins without the races.
+  // Keep at most one regeneration per canister in flight and collapse every save
+  // that arrives meanwhile into a single trailing rerun, so the last saved
+  // `.did` still wins without piling up concurrent runs.
+  //
+  // Scope, precisely: this covers the watcher path only. `buildStart` calls the
+  // pipeline directly and does not register here, so a save landing during the
+  // initial generation can still run concurrently with it. That is deliberate
+  // rather than an oversight -- since @ic-reactor/codegen generates into a
+  // staging directory and swaps atomically, concurrent runs for one canister no
+  // longer interleave inside a delete-then-write sequence; the loser is simply
+  // overwritten. What this buys is ordering and wasted work, not integrity.
+  //
+  // Note the coalesced promise resolves when the RUNNING pass finishes, not the
+  // trailing rerun, so `handleHotUpdate` can return before the newest `.did` has
+  // been written. The trailing run sends its own full-reload, so the browser
+  // still converges.
   const inFlight = new Map<string, Promise<void>>()
   const rerunQueued = new Set<string>()
 
@@ -255,6 +266,32 @@ export function icReactor(options: IcReactorPluginOptions): Plugin {
             },
           },
         }
+      }
+
+      // The replica can be UP -- `icp network status` succeeds, so icEnv is
+      // truthy and the check above never fires -- while a configured canister
+      // has never been deployed. Every `icp canister status <name>` then fails
+      // and that id is simply absent, so the cookie goes out carrying a root key
+      // and no PUBLIC_CANISTER_ID for it. That is the same "indistinguishable
+      // from success until the app breaks on an undefined canister id" failure
+      // the branch above exists to prevent, and it is the more common one.
+      //
+      // Only configured canisters are reported: `internet_identity` is appended
+      // to canisterNames for convenience and is routinely not deployed.
+      const missingCanisterIds = canisters
+        .map((canister) => canister.name)
+        .filter((name): name is string => !!name)
+        .filter((name) => !icEnv.canisterIds[name])
+
+      if (missingCanisterIds.length > 0) {
+        const names = missingCanisterIds.map((name) => `"${name}"`).join(", ")
+        const it = missingCanisterIds.length === 1 ? "it" : "them"
+        console.warn(
+          `[ic-reactor] The local replica is running, but no canister ID could be resolved for ${names}. ` +
+            `Deploy ${it} (\`icp deploy\`) — until then the injected ic_env carries no PUBLIC_CANISTER_ID ` +
+            `for ${it} and the app will see an undefined canister id. ` +
+            `Re-run with DEBUG=ic-reactor to see the \`icp\` output.`
+        )
       }
 
       for (const diagnostic of diagnostics) {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -80,8 +80,9 @@ export function icReactor(options: IcReactorPluginOptions): Plugin {
 
   // Vite resolves relative project paths against the resolved `config.root`,
   // which only equals the process cwd when vite happens to be started from the
-  // project directory — not for `root: "frontend"`, and not for a monorepo
-  // running `vite build --config apps/web/vite.config.ts` from the repo root.
+  // project directory — not for `root: "frontend"`, and not when the root is
+  // passed positionally (`vite build apps/web`). Note `--config` on its own does
+  // NOT move the root; it only selects the config file.
   // `configResolved` overwrites this before any hook that resolves a path runs;
   // the cwd is only the pre-resolution default, which is also Vite's own
   // default root.
@@ -113,6 +114,18 @@ export function icReactor(options: IcReactorPluginOptions): Plugin {
    * Terminal output scrolls away behind request logs and HMR chatter, so in dev
    * the browser error overlay is the signal that actually gets noticed.
    */
+  /**
+   * The last failure, kept so a browser that was not connected when it happened
+   * still gets the overlay.
+   *
+   * Vite awaits the plugin container's `buildStart` before the HTTP server
+   * starts listening, so a generation failure during `vite dev` startup is
+   * broadcast when there are no WebSocket clients at all and the payload is
+   * simply dropped. The terminal shows it; the overlay never appears — for
+   * precisely the failures a developer is most likely to hit.
+   */
+  let pendingFailure: { message: string; stack: string } | null = null
+
   const reportFailure = (
     server: ViteDevServer | null,
     message: string,
@@ -120,14 +133,14 @@ export function icReactor(options: IcReactorPluginOptions): Plugin {
   ) => {
     console.error(`[ic-reactor] ${message}`)
 
-    server?.ws.send({
-      type: "error",
-      err: {
-        message: `[ic-reactor] ${message}`,
-        stack: cause instanceof Error && cause.stack ? cause.stack : "",
-        plugin: PLUGIN_NAME,
-      },
-    })
+    const err = {
+      message: `[ic-reactor] ${message}`,
+      stack: cause instanceof Error && cause.stack ? cause.stack : "",
+      plugin: PLUGIN_NAME,
+    }
+
+    pendingFailure = { message: err.message, stack: err.stack }
+    server?.ws.send({ type: "error", err })
   }
 
   // Keep at most one regeneration per canister in flight and collapse every save
@@ -168,6 +181,9 @@ export function icReactor(options: IcReactorPluginOptions): Plugin {
     })
       .then((result) => {
         if (result.success) {
+          // A later connection must not be handed a failure that has since been
+          // fixed.
+          pendingFailure = null
           // Reload page to reflect new types/hooks
           server.ws.send({ type: "full-reload" })
         } else {
@@ -278,10 +294,16 @@ export function icReactor(options: IcReactorPluginOptions): Plugin {
       //
       // Only configured canisters are reported: `internet_identity` is appended
       // to canisterNames for convenience and is routinely not deployed.
+      // An explicitly configured `canisterId` counts as resolved: the cookie
+      // below merges configuredCanisterIds over the detected ones, so the app
+      // does receive a valid PUBLIC_CANISTER_ID. Warning on those told the user
+      // to deploy a canister whose id they had already supplied.
       const missingCanisterIds = canisters
         .map((canister) => canister.name)
         .filter((name): name is string => !!name)
-        .filter((name) => !icEnv.canisterIds[name])
+        .filter(
+          (name) => !icEnv.canisterIds[name] && !configuredCanisterIds[name]
+        )
 
       if (missingCanisterIds.length > 0) {
         const names = missingCanisterIds.map((name) => `"${name}"`).join(", ")
@@ -332,6 +354,19 @@ export function icReactor(options: IcReactorPluginOptions): Plugin {
 
     configureServer(server) {
       devServer = server
+
+      // Replay a startup failure to the first client that connects — see
+      // pendingFailure. Cleared once generation succeeds.
+      // Guarded: the peer range spans several Vite majors and `ws.on` is not
+      // present on every one of them. Losing the replay is acceptable; throwing
+      // out of configureServer is not.
+      server.ws.on?.("connection", () => {
+        if (!pendingFailure) return
+        server.ws.send({
+          type: "error",
+          err: { ...pendingFailure, plugin: PLUGIN_NAME },
+        })
+      })
 
       // Explicitly watch configured DID files so HMR works even when they are not in the module graph.
       const didFiles = canisters.map((c) => resolveDidPath(c.didFile))

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -7,7 +7,7 @@
  * 3. Hot-reloads when .did files change
  */
 
-import type { Plugin } from "vite"
+import type { Plugin, ResolvedConfig, ViteDevServer } from "vite"
 import path from "node:path"
 import {
   runCanisterPipeline,
@@ -17,6 +17,9 @@ import {
 } from "@ic-reactor/codegen"
 import { getIcEnvironmentInfo, buildIcEnvCookie } from "./env.js"
 
+const PLUGIN_NAME = "ic-reactor-plugin"
+const DEFAULT_LOCAL_REPLICA = "http://127.0.0.1:4943"
+
 export interface IcReactorPluginOptions {
   /**
    * Canister configurations.
@@ -24,7 +27,7 @@ export interface IcReactorPluginOptions {
    */
   canisters: CanisterConfig[]
   /**
-   * Default output directory (relative to project root).
+   * Default output directory (relative to the Vite project root).
    * Default: "src/declarations"
    */
   outDir?: string
@@ -43,15 +46,26 @@ export interface IcReactorPluginOptions {
    * Default: true
    */
   injectEnvironment?: boolean
+  /**
+   * Abort the Vite run when a canister fails to generate.
+   *
+   * Default: `true` under `vite build`, `false` under `vite dev`. A build that
+   * silently ships the bindings left over from the last successful run is worse
+   * than no build at all, while a dev server has to survive the broken
+   * intermediate states of a `.did` file being edited — there the failure is
+   * reported to the terminal and the browser error overlay instead.
+   */
+  failOnError?: boolean
 }
 
-export function icReactor(options: IcReactorPluginOptions): any {
+export function icReactor(options: IcReactorPluginOptions): Plugin {
   const {
     canisters,
     outDir = "src/declarations",
     clientManagerPath = "../../clients",
     target = "react",
     injectEnvironment = true,
+    failOnError,
   } = options
 
   // Construct a partial CodegenConfig to pass to the pipeline
@@ -63,7 +77,26 @@ export function icReactor(options: IcReactorPluginOptions): any {
     clientManagerPath,
     target,
   }
-  const projectRoot = process.cwd()
+
+  // Vite resolves relative project paths against the resolved `config.root`,
+  // which only equals the process cwd when vite happens to be started from the
+  // project directory — not for `root: "frontend"`, and not for a monorepo
+  // running `vite build --config apps/web/vite.config.ts` from the repo root.
+  // `configResolved` overwrites this before any hook that resolves a path runs;
+  // the cwd is only the pre-resolution default, which is also Vite's own
+  // default root.
+  let projectRoot = process.cwd()
+
+  // `vite build` and `vite dev` want opposite failure behaviour, so remember
+  // which one we are in. Both `config` and `configResolved` carry the command;
+  // build is the safer default for the case where neither has run.
+  let command: ResolvedConfig["command"] = "build"
+
+  // Set once the dev server exists, so a `buildStart` failure in dev can reach
+  // the browser overlay too — in dev, `configureServer` runs before Vite calls
+  // `buildStart` on the plugin container.
+  let devServer: ViteDevServer | null = null
+
   const resolveDidPath = (didFile: string) =>
     path.normalize(
       path.isAbsolute(didFile) ? didFile : path.resolve(projectRoot, didFile)
@@ -74,12 +107,95 @@ export function icReactor(options: IcReactorPluginOptions): any {
       .map((canister) => [canister.name, canister.canisterId as string])
   )
 
+  /**
+   * Report a generation failure everywhere a developer might be looking.
+   *
+   * Terminal output scrolls away behind request logs and HMR chatter, so in dev
+   * the browser error overlay is the signal that actually gets noticed.
+   */
+  const reportFailure = (
+    server: ViteDevServer | null,
+    message: string,
+    cause?: unknown
+  ) => {
+    console.error(`[ic-reactor] ${message}`)
+
+    server?.ws.send({
+      type: "error",
+      err: {
+        message: `[ic-reactor] ${message}`,
+        stack: cause instanceof Error && cause.stack ? cause.stack : "",
+        plugin: PLUGIN_NAME,
+      },
+    })
+  }
+
+  // A `.did` save can land while the previous regeneration is still inside the
+  // pipeline's delete-then-write sequence, and the second run would wipe the
+  // directory the first one is writing into. Keep at most one run per canister
+  // in flight and collapse every save that arrives meanwhile into a single
+  // trailing rerun, so the last saved `.did` still wins without the races.
+  const inFlight = new Map<string, Promise<void>>()
+  const rerunQueued = new Set<string>()
+
+  const regenerate = (
+    canisterConfig: CanisterConfig,
+    server: ViteDevServer
+  ): Promise<void> => {
+    const { name } = canisterConfig
+    const running = inFlight.get(name)
+
+    if (running) {
+      rerunQueued.add(name)
+      return running
+    }
+
+    const run = runCanisterPipeline({
+      canisterConfig,
+      projectRoot,
+      globalConfig,
+    })
+      .then((result) => {
+        if (result.success) {
+          // Reload page to reflect new types/hooks
+          server.ws.send({ type: "full-reload" })
+        } else {
+          reportFailure(
+            server,
+            `Regeneration failed for ${name}: ${result.error ?? "unknown error"}`
+          )
+        }
+      })
+      // A throw from the pipeline (a malformed `.did` makes the parser throw
+      // rather than return a failed result) would otherwise be an unhandled
+      // rejection: invisible in the browser and, depending on the Node version,
+      // fatal to the dev server.
+      .catch((error: unknown) => {
+        reportFailure(
+          server,
+          `Regeneration failed for ${name}: ${describeError(error)}`,
+          error
+        )
+      })
+      .finally(() => {
+        inFlight.delete(name)
+        if (rerunQueued.delete(name)) {
+          void regenerate(canisterConfig, server)
+        }
+      })
+
+    inFlight.set(name, run)
+    return run
+  }
+
   const plugin: Plugin = {
-    name: "ic-reactor-plugin",
+    name: PLUGIN_NAME,
     enforce: "pre", // Run before other plugins
 
-    config(_config, { command }) {
-      if (command !== "serve" || !injectEnvironment) {
+    config(_config, { command: viteCommand }) {
+      command = viteCommand
+
+      if (viteCommand !== "serve" || !injectEnvironment) {
         return {}
       }
 
@@ -93,9 +209,26 @@ export function icReactor(options: IcReactorPluginOptions): any {
         canisterNames.push("internet_identity")
       }
 
-      const icEnv = getIcEnvironmentInfo(canisterNames)
+      const { environment: icEnv, diagnostics } =
+        getIcEnvironmentInfo(canisterNames)
 
       if (!icEnv) {
+        // Failing detection used to be indistinguishable from success: no
+        // cookie was set, no warning was printed, and the app only broke much
+        // later on an undefined canister id. Stay quiet in env-only mode
+        // (no canisters configured), where there is nothing to inject anyway.
+        if (canisters.length > 0) {
+          console.warn(
+            `[ic-reactor] Could not detect the local IC environment, falling back to ${DEFAULT_LOCAL_REPLICA}. ` +
+              `Canister IDs and the root key will not be injected — is the local replica running? ` +
+              `Re-run with DEBUG=ic-reactor to see the \`icp\` output.`
+          )
+        }
+
+        for (const diagnostic of diagnostics) {
+          debugLog(diagnostic)
+        }
+
         const envOnlyCookie =
           canisters.length === 0
             ? buildIcEnvCookie(
@@ -116,12 +249,16 @@ export function icReactor(options: IcReactorPluginOptions): any {
               : undefined,
             proxy: {
               "/api": {
-                target: "http://127.0.0.1:4943",
+                target: DEFAULT_LOCAL_REPLICA,
                 changeOrigin: true,
               },
             },
           },
         }
+      }
+
+      for (const diagnostic of diagnostics) {
+        debugLog(diagnostic)
       }
 
       const cookieValue = buildIcEnvCookie(
@@ -148,7 +285,17 @@ export function icReactor(options: IcReactorPluginOptions): any {
       }
     },
 
+    configResolved(config) {
+      // Everything the plugin resolves — `didFile`, `outDir`,
+      // `clientManagerPath` — is documented as relative to the project root, so
+      // it has to be Vite's resolved root and not wherever the process started.
+      projectRoot = config.root
+      command = config.command
+    },
+
     configureServer(server) {
+      devServer = server
+
       // Explicitly watch configured DID files so HMR works even when they are not in the module graph.
       const didFiles = canisters.map((c) => resolveDidPath(c.didFile))
       server.watcher.add(didFiles)
@@ -161,66 +308,98 @@ export function icReactor(options: IcReactorPluginOptions): any {
         `[ic-reactor] Generating canister bindings for ${canisters.length} canisters...`
       )
 
-      await Promise.allSettled(
-        canisters.map(async (canisterConfig) => {
-          try {
-            // If .did file is missing, we might want to attempt pulling it?
-            // For now, pipeline fails if missing. The old plugin logic to "download"
-            // is omitted for simplicity unless requested, to keep "codegen" pure.
-
-            const result = await runCanisterPipeline({
-              canisterConfig,
-              projectRoot,
-              globalConfig,
-            })
-
-            if (!result.success) {
-              console.error(
-                `[ic-reactor] Failed to generate ${canisterConfig.name}: ${result.error}`
-              )
-            }
-          } catch (err) {
-            console.error(
-              `[ic-reactor] Error generating ${canisterConfig.name}:`,
-              err
-            )
-          }
-        })
+      const outcomes = await Promise.allSettled(
+        canisters.map((canisterConfig) =>
+          runCanisterPipeline({
+            canisterConfig,
+            projectRoot,
+            globalConfig,
+          })
+        )
       )
+
+      // Collect every failure before reporting one: a canister failing must not
+      // hide what the others did, and the error should name all of them so a CI
+      // log shows the whole picture in one go.
+      const failures = outcomes.flatMap((outcome, index) => {
+        const name = canisters[index]?.name ?? `canister #${index}`
+
+        if (outcome.status === "rejected") {
+          return [`${name}: ${describeError(outcome.reason)}`]
+        }
+        if (!outcome.value.success) {
+          return [`${name}: ${outcome.value.error ?? "unknown error"}`]
+        }
+        return []
+      })
+
+      if (failures.length === 0) {
+        return
+      }
+
+      const message =
+        `Failed to generate ${failures.length} of ${canisters.length} canisters:\n` +
+        failures.map((failure) => `  - ${failure}`).join("\n")
+
+      // Previously every failure here was a `console.error` and nothing more,
+      // so `vite build` exited 0 and CI shipped whatever stale bindings were
+      // still on disk — bindings that no longer match the deployed canister.
+      if (failOnError ?? command === "build") {
+        this.error(`[ic-reactor] ${message}`)
+      }
+
+      reportFailure(devServer, message)
     },
 
     handleHotUpdate({ file, server }) {
       // ── Hot Reload on .did changes ───────────────────────────────────────
-      if (file.endsWith(".did")) {
-        const affectedCanister = canisters.find((c) => {
-          // Check if changed file matches configured didFile
-          // Cast is safe because didFile is required in CanisterConfig
-          const configPath = resolveDidPath(c.didFile)
-          return configPath === path.normalize(file)
-        })
-
-        if (affectedCanister) {
-          console.log(
-            `[ic-reactor] .did file changed: ${affectedCanister.name}. Regenerating...`
-          )
-
-          // Re-run pipeline for this canister
-          runCanisterPipeline({
-            canisterConfig: affectedCanister,
-            projectRoot,
-            globalConfig,
-          }).then((result: import("@ic-reactor/codegen").PipelineResult) => {
-            if (result.success) {
-              // Reload page to reflect new types/hooks
-              server.ws.send({ type: "full-reload" })
-            } else {
-              console.error(`[ic-reactor] Regeneration failed: ${result.error}`)
-            }
-          })
-        }
+      if (!file.endsWith(".did")) {
+        return
       }
+
+      const changedPath = path.normalize(file)
+      const affectedCanister = canisters.find(
+        // Check if changed file matches configured didFile
+        (canister) => resolveDidPath(canister.didFile) === changedPath
+      )
+
+      if (!affectedCanister) {
+        return
+      }
+
+      console.log(
+        `[ic-reactor] .did file changed: ${affectedCanister.name}. Regenerating...`
+      )
+
+      // Returned so Vite waits for the write to finish before applying the
+      // update; it resolves to `undefined`, which leaves the affected module
+      // list untouched.
+      return regenerate(affectedCanister, server)
     },
   }
 
   return plugin
+}
+
+/** One readable line for whatever the pipeline threw. */
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * `icp` failing to answer is routine — no local replica, or a canister that has
+ * never been deployed — so its stderr is noise until someone is actually
+ * debugging. Gate it the way Vite gates its own debug output.
+ */
+function debugLog(message: string): void {
+  const enabled = (process.env.DEBUG ?? "").split(",").some((entry) => {
+    const scope = entry.trim()
+    return (
+      scope === "*" || scope === "ic-reactor" || scope.startsWith("ic-reactor:")
+    )
+  })
+
+  if (enabled) {
+    console.debug(`[ic-reactor:debug] ${message}`)
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1288,9 +1288,6 @@ importers:
         specifier: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
         version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
     devDependencies:
-      '@icp-sdk/bindgen':
-        specifier: ^0.4.0
-        version: 0.4.0
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0


### PR DESCRIPTION
Closes #295, closes #296.

## #295 — failures were invisible in every mode

- **`vite build` exited 0 on failure.** `buildStart` wrapped pipelines in `Promise.allSettled` plus a per-canister `try`/`catch` that only `console.error`d; `this.error()` was never called. CI shipped stale bindings that no longer matched the deployed canister. Failures are now collected across all canisters — so one failing does not hide the others — and reported through `this.error()`.
- **No browser overlay in dev.** Pipeline failures only reached the terminal; a full-reload was sent on success and nothing on failure. Errors now go to Vite's overlay.
- **Env detection was silent.** Every `icp` exec suppressed stderr and the catch returned `null` with no warning.
- **Hot-update regeneration was a floating promise** with no serialization and no `.catch` — a throw from the parser was an unhandled rejection, invisible in the browser and fatal to the dev server on some Node versions.

## #296 — paths resolved against `process.cwd()`

`projectRoot` was captured at plugin-factory time and used for `didFile`/`outDir`/`clientManagerPath`, with no `configResolved` hook. A monorepo user running `vite build --config apps/web/vite.config.ts`, or anyone setting `root`, got paths resolved against the wrong directory — and because generation failures did not fail the build, the build still succeeded. Now resolved against `config.root`, including in the hot-update path matcher.

## Test quality

The existing suite could not have caught #296: it stubbed `path.resolve` **globally**, so real path matching was never exercised. That stub is gone and the tests now assert against a Vite root deliberately different from `process.cwd()`, so a regression to `cwd` fails them. The skipped `buildStart` rejection path — exactly #295(a) — is unskipped and real, with a context whose `error()` throws the way Rollup's does.

## Review round

The adversarial pass found the env-detection fix was **half done**, which is the interesting one:

the warning fired only when `icp network status` itself failed. The common case is the opposite — the replica is **up**, so `icEnv` is truthy and that branch is never reached, while a configured canister has simply never been deployed. The cookie then goes out with a root key and **no `PUBLIC_CANISTER_ID`**: verbatim the failure the warning exists to prevent. Now warned on, with `internet_identity` excluded since it is appended for convenience and routinely not deployed. The new test fails with just that block removed.

Review also showed the serialization comment claimed an invariant that does not hold — `buildStart` bypasses `inFlight`. Rather than restructure, the comment now states the truth, because **#330 changes the stakes**: with codegen staging and swapping atomically, concurrent runs for one canister no longer interleave inside a delete-then-write sequence. The serialization buys ordering and wasted work, not integrity. Worth merging #330 first.

## Verification

`pnpm build` · `pnpm typecheck` · vite-plugin 28/28 (from 14) · full suite green.