### PR TITLE
feat(core): infer plain function-typed services, and document two sharp edges

### DIFF
--- a/docs/src/content/docs/framework/queries.mdx
+++ b/docs/src/content/docs/framework/queries.mdx
@@ -124,7 +124,7 @@ value that is not a result variant passes through untouched.
 const { data, error } = useActorQuery({ functionName: "claim", args: [id] })
 
 // data  -> bigint | undefined      (the Ok payload, already unwrapped)
-// error -> CanisterError | null    (.detail is the Err payload)
+// error -> CanisterError | null    (.err is the Err payload)
 ```
 
 This happens at the **candid-decoded layer**, after the call has succeeded at
@@ -138,8 +138,9 @@ actually gives you. You do not need an `unwrap()` helper of your own.
 
 <Aside type="tip">
   If you want the raw variant — to branch on `Err` without a `try`/`catch` —
-  override `transformResult` on your Reactor subclass, or read the untransformed
-  value through `reactor.callMethod()`.
+  override `transformResult` on a Reactor subclass. That is the only way:
+  `callMethod()` runs the decoded response through `transformResult` too, so it
+  unwraps and throws exactly like the hooks do.
 </Aside>
 
 ## Conditional Queries

--- a/docs/src/content/docs/framework/queries.mdx
+++ b/docs/src/content/docs/framework/queries.mdx
@@ -107,6 +107,41 @@ function UserProfile({ userId }: { userId: string }) {
 
 TypeScript will also narrow the type of `data` correctly if you've checked for `pending` and `error` before accessing it.
 
+## Candid `Result` variants are unwrapped
+
+A method returning the common `variant { Ok : T; Err : E }` shape does **not**
+hand you the raw variant. The Reactor's default `transformResult` unwraps it, so:
+
+- **`data` is `T`** — the `Ok` payload directly, never `{ Ok: T }`.
+- **an `Err` is thrown**, as a `CanisterError` carrying the `Err` payload, and
+  surfaces through the query's `error` channel like any other failure.
+
+Both Rust (`Ok`/`Err`) and Motoko (`ok`/`err`) casings are recognised. A return
+value that is not a result variant passes through untouched.
+
+```tsx
+// Candid: claim : (blob) -> (variant { Ok : nat; Err : ClaimError })
+const { data, error } = useActorQuery({ functionName: "claim", args: [id] })
+
+// data  -> bigint | undefined      (the Ok payload, already unwrapped)
+// error -> CanisterError | null    (.detail is the Err payload)
+```
+
+This happens at the **candid-decoded layer**, after the call has succeeded at
+the transport level. A rejected call or a network failure is a `CallError`
+instead, so the two failure kinds stay distinguishable — see
+[Error Handling](/v3/guides/error-handling/).
+
+Declare the service type with the raw candid shape (`Result<T, E>`); the
+unwrapping is applied on top of it, and `ReactorReturnOk` is the type the hook
+actually gives you. You do not need an `unwrap()` helper of your own.
+
+<Aside type="tip">
+  If you want the raw variant — to branch on `Err` without a `try`/`catch` —
+  override `transformResult` on your Reactor subclass, or read the untransformed
+  value through `reactor.callMethod()`.
+</Aside>
+
 ## Conditional Queries
 
 You can use the `enabled` option to conditionally execute a query:

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -126,6 +126,42 @@ not work until you install it:
 pnpm add @icp-sdk/auth
 ```
 
+<Aside type="caution" title="npm cannot resolve this set on its own">
+  Every published `@icp-sdk/auth` — 7.0.0 through 8.0.3, checked 2026-08-22 —
+  declares `peerDependencies: { "@icp-sdk/core": "^5" }`, while
+  `@ic-reactor/react` needs `@icp-sdk/core@^6`. A strict `npm install` of the
+  advertised set therefore fails:
+
+  ```
+  npm error ERESOLVE unable to resolve dependency tree
+  npm error Found: @icp-sdk/core@5.4.0
+  npm error   peer @icp-sdk/core@"^5" from @icp-sdk/auth@8.0.3
+  npm error Could not resolve dependency:
+  npm error   peer @icp-sdk/core@"^6.0.0" from @ic-reactor/react
+  ```
+
+  This is stale metadata upstream, not an actual incompatibility: auth v8 works
+  against core v6, and IC Reactor's own suite runs that combination. `pnpm` and
+  `yarn` install it without complaint. For npm, tell it to use your `core` for
+  auth as well:
+
+  ```json
+  // package.json
+  {
+    "overrides": {
+      "@icp-sdk/auth": {
+        "@icp-sdk/core": "$@icp-sdk/core"
+      }
+    }
+  }
+  ```
+
+  That resolves to a single `@icp-sdk/core` with no duplication.
+  `legacy-peer-deps=true` in `.npmrc` also works but disables peer checking
+  everywhere, so prefer the scoped override. This note goes away once
+  `@icp-sdk/auth` publishes a `core@^6` peer.
+</Aside>
+
 Bundlers still **resolve** that specifier while building the module graph,
 which happens before any tree-shaking — so a missing peer cannot simply be
 optimized away. The import sits inside a `try` block, which **webpack-family

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -405,7 +405,21 @@ interface CanisterError<E> {
 
 ### Result Unwrapping
 
-Results are automatically unwrapped. The `extractOkResult` utility handles both uppercase (`Ok`/`Err`) and lowercase (`ok`/`err`) variants:
+A method returning `variant { Ok : T; Err : E }` does not hand you the raw
+variant. The Reactor's default `transformResult` unwraps it, so `data` is `T`
+and an `Err` is thrown as a `CanisterError` carrying the `Err` payload — which
+means it reaches the query/mutation `error` channel rather than `data`. This
+happens at the candid-decoded layer, after the call has already succeeded at the
+transport level, so a canister-level `Err` stays distinguishable from a
+`CallError`.
+
+Declare the service with the raw candid shape; the unwrapping applies on top of
+it, and `ReactorReturnOk` is the type the hooks actually give you. To keep the
+raw variant instead, override `transformResult` or read through
+`reactor.callMethod()`.
+
+The same logic is exported as `extractOkResult`, which handles both uppercase
+(`Ok`/`Err`) and lowercase (`ok`/`err`) variants:
 
 ```typescript
 import { extractOkResult } from "@ic-reactor/core"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -414,9 +414,12 @@ transport level, so a canister-level `Err` stays distinguishable from a
 `CallError`.
 
 Declare the service with the raw candid shape; the unwrapping applies on top of
-it, and `ReactorReturnOk` is the type the hooks actually give you. To keep the
-raw variant instead, override `transformResult` or read through
-`reactor.callMethod()`.
+it, and `ReactorReturnOk` is the type the hooks actually give you. The thrown
+`CanisterError` carries the raw payload on `.err`.
+
+To keep the raw variant instead, override `transformResult` on a Reactor
+subclass — that is the only way, since `callMethod()` passes its decoded
+response through `transformResult` as well.
 
 The same logic is exported as `extractOkResult`, which handles both uppercase
 (`Ok`/`Err`) and lowercase (`ok`/`err`) variants:

--- a/packages/core/src/types/reactor.ts
+++ b/packages/core/src/types/reactor.ts
@@ -31,15 +31,42 @@ export type FunctionType = "query" | "update"
 
 export type CanisterId = string | Principal
 
-// Extracts the argument types of an ActorMethod
+/**
+ * Extract the argument tuple of a service method.
+ *
+ * `ActorMethod` carries a `withOptions` member as well as a call signature, so a
+ * service written with plain function types — `claim: (id: Uint8Array) =>
+ * Promise<Result>` instead of `ActorMethod<[Uint8Array], Result>` — does not
+ * match it. That used to fall through to `never`, which compiles at the
+ * declaration site and then fails at every hook call site with
+ * "Type 'Uint8Array[]' is not assignable to type 'undefined'". didc/dfx output
+ * always uses `ActorMethod`, so only hand-written or third-party service types
+ * hit it, and the error never pointed at the cause.
+ *
+ * The plain-function fallback below makes both shapes infer identically.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ActorMethodParameters<T> =
-  T extends ActorMethod<infer Args, any> ? Args : never
+  T extends ActorMethod<infer Args, any>
+    ? Args
+    : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      T extends (...args: infer Args) => Promise<any>
+      ? Args
+      : never
 
-// Extracts the return type of an ActorMethod
+/**
+ * Extract the resolved return type of a service method.
+ *
+ * Same two shapes as {@link ActorMethodParameters}.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ActorMethodReturnType<T> =
-  T extends ActorMethod<any, infer Ret> ? Ret : never
+  T extends ActorMethod<any, infer Ret>
+    ? Ret
+    : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      T extends (...args: any[]) => Promise<infer Ret>
+      ? Ret
+      : never
 
 export interface ReactorParameters {
   clientManager: ClientManager

--- a/packages/core/tests/service-shape-inference.test-d.ts
+++ b/packages/core/tests/service-shape-inference.test-d.ts
@@ -1,0 +1,75 @@
+/**
+ * A service can be declared two ways, and both must infer identically.
+ *
+ * didc and dfx emit `ActorMethod<[Args], Ret>`, so projects using generated
+ * declarations never see a problem. A hand-written or third-party-typed service
+ * using plain function types used to compile at the declaration site and then
+ * fail at every hook call site with `never`/`undefined` argument types, with
+ * nothing pointing at the cause.
+ */
+import { describe, it, expectTypeOf } from "vitest"
+import type { ActorMethod } from "@icp-sdk/core/agent"
+import type {
+  ActorMethodParameters,
+  ActorMethodReturnType,
+} from "../src/types/reactor.js"
+
+interface ConstraintsView {
+  max: bigint
+}
+
+/** didc-style: what dfx generates. */
+interface DidcService {
+  get_constraints: ActorMethod<[], ConstraintsView>
+  claim: ActorMethod<[Uint8Array], { Ok: bigint }>
+}
+
+/** Hand-written: plain function types, no `withOptions`. */
+interface PlainService {
+  get_constraints: () => Promise<ConstraintsView>
+  claim: (giftId: Uint8Array) => Promise<{ Ok: bigint }>
+}
+
+describe("service method inference", () => {
+  it("infers arguments from didc-style ActorMethod declarations", () => {
+    expectTypeOf<
+      ActorMethodParameters<DidcService["get_constraints"]>
+    >().toEqualTypeOf<[]>()
+    expectTypeOf<ActorMethodParameters<DidcService["claim"]>>().toEqualTypeOf<
+      [Uint8Array]
+    >()
+  })
+
+  it("infers arguments from plain function-typed declarations", () => {
+    expectTypeOf<
+      ActorMethodParameters<PlainService["get_constraints"]>
+    >().toEqualTypeOf<[]>()
+    expectTypeOf<ActorMethodParameters<PlainService["claim"]>>().toEqualTypeOf<
+      [giftId: Uint8Array]
+    >()
+  })
+
+  it("infers return types from both shapes", () => {
+    expectTypeOf<
+      ActorMethodReturnType<DidcService["get_constraints"]>
+    >().toEqualTypeOf<ConstraintsView>()
+    expectTypeOf<
+      ActorMethodReturnType<PlainService["get_constraints"]>
+    >().toEqualTypeOf<ConstraintsView>()
+
+    expectTypeOf<ActorMethodReturnType<DidcService["claim"]>>().toEqualTypeOf<{
+      Ok: bigint
+    }>()
+    expectTypeOf<ActorMethodReturnType<PlainService["claim"]>>().toEqualTypeOf<{
+      Ok: bigint
+    }>()
+  })
+
+  it("still yields never for a member that is not a method", () => {
+    // The fallback must not start matching arbitrary values — a non-function,
+    // or a function that does not return a promise, is not a service method.
+    expectTypeOf<ActorMethodParameters<string>>().toBeNever()
+    expectTypeOf<ActorMethodParameters<() => number>>().toBeNever()
+    expectTypeOf<ActorMethodReturnType<string>>().toBeNever()
+  })
+})

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -13,6 +13,17 @@ pnpm add @ic-reactor/react @icp-sdk/core @tanstack/react-query
 pnpm add @icp-sdk/auth
 ```
 
+> **npm needs an override to install this set.** Every published
+> `@icp-sdk/auth` peers `@icp-sdk/core@^5`, while this package needs `^6`, so a
+> strict `npm install` fails with `ERESOLVE`. The metadata is stale rather than
+> the versions being incompatible — auth v8 runs against core v6, and this
+> repository's own suite exercises that combination. pnpm and yarn install it
+> as-is; for npm, add:
+>
+> ```json
+> { "overrides": { "@icp-sdk/auth": { "@icp-sdk/core": "$@icp-sdk/core" } } }
+> ```
+
 `@icp-sdk/auth` is an optional peer. `AuthenticationManager` reaches it through a
 literal `import("@icp-sdk/auth/client")`, so Vite, Rollup and webpack code-split
 it into its own async chunk. That chunk is never fetched unless something


### PR DESCRIPTION
Closes #326, closes #327, closes #328 — all three filed from building a real consumer app on 3.11.0.

---

## #327 — inference silently degraded (code fix)

`ActorMethod` carries a `withOptions` member as well as a call signature, so a service written with plain function types never matched it and the extraction conditionals fell through to `never`:

```ts
// compiles here…
interface _SERVICE {
  claim: (giftId: Uint8Array) => Promise<Result<ClaimOk>>
}
// …then fails at every call site:
//   Type 'Uint8Array[]' is not assignable to type 'undefined'
```

didc/dfx output always uses `ActorMethod`, so only hand-written or third-party-typed services hit this — and the error pointed nowhere near the cause. Both shapes now infer identically, via a plain-function fallback in each conditional.

A `.test-d.ts` pins the contract, including that the fallback does **not** start matching non-methods (a bare `() => number` stays `never`). Worth noting it is load-bearing rather than decorative: the existing `pnpm typecheck` gate runs it, and reverting the fix produces 4 type errors.

## #328 — the `{Ok}/{Err}` question, answered (docs)

It **does** unwrap. `transformResult` calls `extractOkResult` by default, so `data` is the `Ok` payload and an `Err` is thrown as a `CanisterError` that reaches the query/mutation `error` channel. This happens at the **candid-decoded** layer, after the call has succeeded at the transport level — which is precisely what keeps a canister-level `Err` distinguishable from a `CallError`.

Documented in the queries guide and sharpened in the core README, which previously described only the exported `extractOkResult` utility and not the behaviour every consumer gets by default. So the defensive `unwrap()` the issue reported writing is unnecessary.

## #326 — the peer set (docs, because nothing else can fix it)

Reproduced exactly as filed:

```
npm error Found: @icp-sdk/core@5.4.0
npm error   peer @icp-sdk/core@"^5" from @icp-sdk/auth@8.0.3
npm error   peerOptional @icp-sdk/auth@"^7.1.0 || ^8.0.0" from @ic-reactor/react@3.11.0
```

Every published `@icp-sdk/auth` — 7.0.0 through 8.0.3 — peers `core@^5`, while we need `^6`.

Two things worth being explicit about:

- **This is stale upstream metadata, not a real incompatibility.** auth v8 runs against core v6, and this repository's own suite exercises that pair across 467 react tests including live `AuthClient` integration.
- **Nothing in our manifest fixes it.** The clash is between auth's own peer and ours against the root's single `core`, so neither narrowing the auth range (which #329 did, for unrelated reasons) nor dropping it helps.

So it is documented, with the scoped `overrides` recipe — which I verified installs cleanly as a single `core@6.1.0` with no duplication, rather than just assuming it works. `legacy-peer-deps` is mentioned but not recommended, since it disables peer checking everywhere. pnpm and yarn are unaffected.

---

## Verification

`pnpm build` · `pnpm typecheck` (incl. the new type tests) · `pnpm test` 1273 passing · `pnpm typecheck:examples`.