### PR TITLE
fix(react): detect what the local Internet Identity build actually serves

### DIFF
--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -114,6 +114,23 @@ constructor, or per call to `login()` — the per-call value wins.
 `clientManager` (required), `authClient` (bring your own client instance), and
 `internetIdentityId` (canister ID of a locally deployed Internet Identity).
 
+<Aside type="caution" title="Local Internet Identity needs a pinned build">
+  Only a narrow range of Internet Identity releases can be used locally at all.
+  Builds from **`release-2026-03-23`** onward moved their frontend out of the
+  canister (the id.ai split), so the canister serves no sign-in UI and the login
+  popup lands on the gateway's *"Response Verification Error"* page. Builds
+  before 2026 serve the SPA at `/` behind a `#authorize` fragment instead of at
+  `/authorize`.
+
+  **`release-2026-03-16` is the newest `internet_identity_dev.wasm` that works.**
+
+  `AuthenticationManager` probes the canister during `prepareClient()` and adapts:
+  it uses `/authorize` when that is served, falls back to the legacy
+  `#authorize` flow with a warning for pre-2026 builds, and rejects `login()`
+  with an explanation naming this release when the build serves neither — rather
+  than opening a popup the app cannot see into.
+</Aside>
+
 <Aside type="caution">
   Set `derivationOrigin` whenever your app is served from more than one origin
   (a custom domain plus `<canisterId>.icp0.io`, say) — without it each origin

--- a/packages/react/src/auth/authentication-manager.ts
+++ b/packages/react/src/auth/authentication-manager.ts
@@ -11,8 +11,14 @@ import { ClientManager, isDev, allowsEnvRootKey } from "@ic-reactor/core"
 import { Principal } from "@icp-sdk/core/principal"
 import { safeGetCanisterEnv } from "@icp-sdk/core/agent/canister-env"
 import {
+  probeLocalInternetIdentity,
+  localInternetIdentityUnavailableError,
+  type AuthorizePath,
+} from "./local-ii-probe.js"
+import {
   IC_INTERNET_IDENTITY_PROVIDER,
   INTERNET_IDENTITY_PROVIDER_ENV_KEY,
+  LOCAL_INTERNET_IDENTITY_CANISTER_ID,
   localInternetIdentityProvider,
 } from "./constants.js"
 
@@ -61,6 +67,13 @@ export class AuthenticationManager {
   }
   private readonly identityProvider?: string | URL
   private readonly internetIdentityId?: string
+  /**
+   * Which authorize path the locally deployed Internet Identity serves, once
+   * probed. `undefined` means not probed yet; `null` means it serves no sign-in
+   * UI and login should fail with an explanation rather than open a popup onto
+   * a gateway error page.
+   */
+  private localAuthorizePath?: AuthorizePath | null
   private readonly defaultClientOptions: AuthenticationClientOptions
   public readonly clientManager: ClientManager
 
@@ -131,6 +144,11 @@ export class AuthenticationManager {
    * what browser popup blockers and the ICRC-29 transport require.
    */
   public async prepareClient(options?: AuthenticationClientOptions) {
+    // Before resolving options, because resolving them is what picks the
+    // provider URL. This is the last async point before `login()` has to stay
+    // inside the user gesture, so the answer has to be cached by now.
+    await this.ensureLocalAuthorizePath()
+
     const clientOptions = this.resolveClientOptions(options)
 
     if (this.authClient && !this.shouldRecreateClient(clientOptions)) {
@@ -138,6 +156,40 @@ export class AuthenticationManager {
     }
 
     return this.initializeClient(clientOptions)
+  }
+
+  /**
+   * Probe the local Internet Identity canister once, and remember what it
+   * serves.
+   *
+   * Only for the derived local provider: an explicitly configured
+   * `identityProvider` is the caller's business, and mainnet is fixed.
+   */
+  private async ensureLocalAuthorizePath(): Promise<void> {
+    if (this.localAuthorizePath !== undefined) return
+    if (this.identityProvider) return
+    if (!this.clientManager.isLocal) return
+
+    const canisterId =
+      this.internetIdentityId ?? LOCAL_INTERNET_IDENTITY_CANISTER_ID
+
+    const { path, inconclusive } = await probeLocalInternetIdentity(
+      this.clientManager.agent,
+      canisterId
+    )
+
+    // An inconclusive probe must not change behaviour: the canister may be
+    // fine and merely unreachable from here, and a diagnostic that blocks a
+    // working login is worse than the failure it explains.
+    this.localAuthorizePath = inconclusive ? "/authorize" : path
+
+    if (path === "/#authorize" && !inconclusive) {
+      console.warn(
+        `[ic-reactor] Internet Identity canister ${canisterId} serves its sign-in UI at ` +
+          `"/" rather than "/authorize" — using the legacy #authorize flow. This is a ` +
+          `pre-2026 build; newer ones through release-2026-03-16 serve /authorize directly.`
+      )
+    }
   }
 
   /**
@@ -467,12 +519,26 @@ export class AuthenticationManager {
     if (this.identityProvider) {
       return this.identityProvider
     }
-    return this.clientManager.isLocal
-      ? localInternetIdentityProvider(
-          Number(this.clientManager.agentHost?.port) || 4943,
-          this.internetIdentityId
-        )
-      : IC_INTERNET_IDENTITY_PROVIDER
+    if (!this.clientManager.isLocal) {
+      return IC_INTERNET_IDENTITY_PROVIDER
+    }
+
+    const canisterId =
+      this.internetIdentityId ?? LOCAL_INTERNET_IDENTITY_CANISTER_ID
+
+    // `null` is the probe's positive finding that this build serves no sign-in
+    // UI. Throwing here surfaces an actionable message where the caller can see
+    // it, instead of opening a popup onto the gateway's verification-error page
+    // and leaving the app waiting until the user closes it.
+    if (this.localAuthorizePath === null) {
+      throw localInternetIdentityUnavailableError(canisterId)
+    }
+
+    return localInternetIdentityProvider(
+      Number(this.clientManager.agentHost?.port) || 4943,
+      this.internetIdentityId,
+      this.localAuthorizePath
+    )
   }
 
   private updateState(newState: Partial<AuthState>) {

--- a/packages/react/src/auth/constants.ts
+++ b/packages/react/src/auth/constants.ts
@@ -12,11 +12,18 @@ export const LOCAL_INTERNET_IDENTITY_CANISTER_ID = "rdmx6-jaaaa-aaaaa-aaadq-cai"
 
 /**
  * Builds the local Internet Identity provider URL for the given replica port.
+ *
+ * `authorizePath` selects the shape the installed build understands: modern
+ * builds serve `/authorize` as a real asset, while pre-2026 ones serve the SPA
+ * at `/` and drive the flow from a `#authorize` fragment. `AuthenticationManager`
+ * probes the canister and passes the right one; the default keeps the previous
+ * behaviour for direct callers.
  */
 export const localInternetIdentityProvider = (
   port: number,
-  canisterId: string = LOCAL_INTERNET_IDENTITY_CANISTER_ID
-) => `http://${canisterId}.localhost:${port}/authorize`
+  canisterId: string = LOCAL_INTERNET_IDENTITY_CANISTER_ID,
+  authorizePath: "/authorize" | "/#authorize" = "/authorize"
+) => `http://${canisterId}.localhost:${port}${authorizePath}`
 
 /**
  * Legacy default URL for local Internet Identity, using port `4943`.

--- a/packages/react/src/auth/local-ii-probe.ts
+++ b/packages/react/src/auth/local-ii-probe.ts
@@ -1,0 +1,147 @@
+/**
+ * Ask a locally deployed Internet Identity canister what it actually serves.
+ *
+ * `localInternetIdentityProvider` builds `http://<id>.localhost:<port>/authorize`,
+ * the id.ai-era path. Whether that works depends on which Internet Identity
+ * build is installed, and the window is narrow:
+ *
+ * - up to `release-2025-03-07`, the SPA lived at `/` and used a `#authorize`
+ *   fragment; `/authorize` is not an asset
+ * - `release-2026-01-05` through `release-2026-03-16` serve `/authorize`
+ * - from `release-2026-03-23` the frontend left the canister entirely (the id.ai
+ *   split), so `/authorize` 404s even on `.raw`
+ *
+ * Outside that window the login popup renders the gateway's
+ * "Response Verification Error" page and the app simply waits until the user
+ * closes it. Nothing points at the cause.
+ *
+ * Asking the canister over the agent avoids the gateway, so the answer is about
+ * the canister's assets rather than about how the gateway felt about them.
+ */
+
+import { Actor, type HttpAgent } from "@icp-sdk/core/agent"
+import { IDL } from "@icp-sdk/core/candid"
+
+/** The `http_request` query every asset-serving canister exposes. */
+const httpInterface: IDL.InterfaceFactory = ({ IDL }) => {
+  const HeaderField = IDL.Tuple(IDL.Text, IDL.Text)
+  return IDL.Service({
+    http_request: IDL.Func(
+      [
+        IDL.Record({
+          method: IDL.Text,
+          url: IDL.Text,
+          headers: IDL.Vec(HeaderField),
+          body: IDL.Vec(IDL.Nat8),
+        }),
+      ],
+      [
+        IDL.Record({
+          status_code: IDL.Nat16,
+          headers: IDL.Vec(HeaderField),
+          body: IDL.Vec(IDL.Nat8),
+        }),
+      ],
+      ["query"]
+    ),
+  })
+}
+
+interface HttpCapableActor {
+  http_request: (request: {
+    method: string
+    url: string
+    headers: [string, string][]
+    body: Uint8Array
+  }) => Promise<{ status_code: number }>
+}
+
+/** Where a given Internet Identity build expects the sign-in flow to start. */
+export type AuthorizePath = "/authorize" | "/#authorize"
+
+export interface LocalIiProbe {
+  /** The path that works, or `null` when the canister serves no sign-in UI. */
+  path: AuthorizePath | null
+  /**
+   * The probe could not reach a conclusion — the canister was unreachable, or
+   * it does not expose `http_request` at all. Callers keep their existing
+   * behaviour rather than blocking a login that might well work.
+   */
+  inconclusive: boolean
+}
+
+async function statusOf(
+  actor: HttpCapableActor,
+  url: string
+): Promise<number | undefined> {
+  try {
+    const response = await actor.http_request({
+      method: "GET",
+      url,
+      headers: [],
+      body: new Uint8Array(),
+    })
+    return response.status_code
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Determine which authorize path a locally deployed Internet Identity serves.
+ *
+ * Never throws. A probe that cannot answer returns `inconclusive`, because a
+ * diagnostic that blocks a working setup is worse than the failure it explains.
+ */
+export async function probeLocalInternetIdentity(
+  agent: HttpAgent,
+  canisterId: string
+): Promise<LocalIiProbe> {
+  let actor: HttpCapableActor
+  try {
+    actor = Actor.createActor<HttpCapableActor>(httpInterface, {
+      agent,
+      canisterId,
+    })
+  } catch {
+    return { path: "/authorize", inconclusive: true }
+  }
+
+  const authorize = await statusOf(actor, "/authorize")
+
+  // The canister does not answer http_request at all — not an asset canister,
+  // not deployed, or the replica is down. Not our call to make.
+  if (authorize === undefined) {
+    return { path: "/authorize", inconclusive: true }
+  }
+
+  if (authorize >= 200 && authorize < 300) {
+    return { path: "/authorize", inconclusive: false }
+  }
+
+  // Pre-2026 builds serve the SPA at the root and drive the flow from a
+  // `#authorize` fragment, which is a path the gateway never sees.
+  const root = await statusOf(actor, "/")
+  if (root !== undefined && root >= 200 && root < 300) {
+    return { path: "/#authorize", inconclusive: false }
+  }
+
+  return { path: null, inconclusive: false }
+}
+
+/**
+ * The error a login gets when the installed build serves no sign-in UI, in
+ * place of a 503 page inside a popup the app cannot see.
+ */
+export function localInternetIdentityUnavailableError(
+  canisterId: string
+): Error {
+  return new Error(
+    `[ic-reactor] The Internet Identity canister ${canisterId} does not serve a sign-in UI: ` +
+      `neither /authorize nor / returned a page. Internet Identity builds from ` +
+      `release-2026-03-23 onward moved their frontend out of the canister (the id.ai split) ` +
+      `and cannot be used locally. Install internet_identity_dev.wasm from release-2026-03-16, ` +
+      `the newest build that still self-serves /authorize, or point \`identityProvider\` at a ` +
+      `provider you host yourself.`
+  )
+}

--- a/packages/react/tests/auth/local-ii-probe.test.ts
+++ b/packages/react/tests/auth/local-ii-probe.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The three Internet Identity eras from the bisect in #334, and what the probe
+ * has to conclude for each.
+ *
+ * The failure this replaces is silent: the popup renders the gateway's
+ * "Response Verification Error" page and the app waits until the user closes
+ * it, with nothing naming the cause.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const agentMocks = vi.hoisted(() => ({ createActor: vi.fn() }))
+
+vi.mock("@icp-sdk/core/agent", () => ({
+  Actor: { createActor: agentMocks.createActor },
+}))
+
+import {
+  probeLocalInternetIdentity,
+  localInternetIdentityUnavailableError,
+} from "../../src/auth/local-ii-probe.js"
+
+const CANISTER_ID = "rdmx6-jaaaa-aaaaa-aaadq-cai"
+
+/** An asset canister answering `http_request` with the given per-URL statuses. */
+function canisterServing(statuses: Record<string, number>) {
+  const http_request = vi.fn(async ({ url }: { url: string }) => {
+    const status = statuses[url]
+    if (status === undefined) return { status_code: 404 }
+    return { status_code: status }
+  })
+  agentMocks.createActor.mockReturnValue({ http_request })
+  return http_request
+}
+
+/** A canister that does not answer `http_request` at all. */
+function canisterUnreachable() {
+  agentMocks.createActor.mockReturnValue({
+    http_request: vi.fn(async () => {
+      throw new Error("canister not found")
+    }),
+  })
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const agent = {} as any
+
+beforeEach(() => {
+  agentMocks.createActor.mockReset()
+})
+
+describe("probeLocalInternetIdentity", () => {
+  it("uses /authorize when the build serves it (release-2026-01-05 … -03-16)", async () => {
+    canisterServing({ "/authorize": 200 })
+
+    await expect(
+      probeLocalInternetIdentity(agent, CANISTER_ID)
+    ).resolves.toEqual({ path: "/authorize", inconclusive: false })
+  })
+
+  it("falls back to #authorize for pre-2026 builds that serve the SPA at /", async () => {
+    // `/authorize` is not an asset in that era; the flow runs off a fragment,
+    // which the gateway never sees.
+    const http_request = canisterServing({ "/authorize": 404, "/": 200 })
+
+    await expect(
+      probeLocalInternetIdentity(agent, CANISTER_ID)
+    ).resolves.toEqual({ path: "/#authorize", inconclusive: false })
+    expect(http_request).toHaveBeenCalledTimes(2)
+  })
+
+  it("reports no sign-in UI for frontend-less builds (release-2026-03-23 onward)", async () => {
+    // The id.ai split moved the frontend out of the canister entirely.
+    canisterServing({ "/authorize": 404, "/": 404 })
+
+    await expect(
+      probeLocalInternetIdentity(agent, CANISTER_ID)
+    ).resolves.toEqual({ path: null, inconclusive: false })
+  })
+
+  it("stays inconclusive when the canister cannot be reached", async () => {
+    // A replica that is down, or a canister that is not an asset canister, must
+    // not turn into a hard login failure — the setup may be fine and merely
+    // unreachable from here.
+    canisterUnreachable()
+
+    await expect(
+      probeLocalInternetIdentity(agent, CANISTER_ID)
+    ).resolves.toEqual({ path: "/authorize", inconclusive: true })
+  })
+
+  it("stays inconclusive when the actor cannot even be built", async () => {
+    agentMocks.createActor.mockImplementation(() => {
+      throw new Error("bad canister id")
+    })
+
+    await expect(
+      probeLocalInternetIdentity(agent, CANISTER_ID)
+    ).resolves.toEqual({ path: "/authorize", inconclusive: true })
+  })
+
+  it("treats any 2xx as served", async () => {
+    canisterServing({ "/authorize": 204 })
+
+    await expect(
+      probeLocalInternetIdentity(agent, CANISTER_ID)
+    ).resolves.toEqual({ path: "/authorize", inconclusive: false })
+  })
+
+  it("never throws", async () => {
+    canisterUnreachable()
+    await expect(
+      probeLocalInternetIdentity(agent, CANISTER_ID)
+    ).resolves.toBeDefined()
+  })
+})
+
+describe("localInternetIdentityUnavailableError", () => {
+  it("names the canister and the release that still works", () => {
+    const error = localInternetIdentityUnavailableError(CANISTER_ID)
+
+    expect(error.message).toContain(CANISTER_ID)
+    expect(error.message).toContain("release-2026-03-16")
+    // The whole point is that the user learns why, not just that it failed.
+    expect(error.message).toContain("id.ai split")
+  })
+})


### PR DESCRIPTION
Closes #334.

## The failure

`localInternetIdentityProvider` builds `http://<id>.localhost:<port>/authorize` and assumes the installed Internet Identity build self-serves that SPA. Per the bisect in the issue, only a narrow range does:

| build | `/authorize` | result |
| --- | --- | --- |
| up to `release-2025-03-07` | not an asset | gateway verification-error page |
| `release-2026-01-05` … `release-2026-03-16` | served + certified 200 | works |
| `release-2026-03-23` onward | 404 — frontend left the canister (id.ai split) | gateway verification-error page |

Outside the window the popup renders **"Error 503 — Response Verification Error"** and the app just waits until the user closes it. Nothing points at the cause, and the only way to find it is to bisect II releases — which is what the reporter did.

## The fix

Ask the canister rather than letting the popup find out. `prepareClient()` is already async and already runs ahead of the login gesture, so it probes `http_request` for `/authorize` **over the agent** — which bypasses the gateway, so the answer is about the canister's assets rather than the gateway's opinion of them.

| probe | behaviour |
| --- | --- |
| 2xx on `/authorize` | use it, exactly as before |
| 404, but `/` serves a page | fall back to the legacy `/#authorize` flow, with a warning |
| neither | reject `login()` with an error naming the canister and `release-2026-03-16` |

The result is cached because `login()` has to build the provider URL synchronously to keep the user gesture — the probe cannot happen there.

**The probe never throws and never blocks on doubt.** An unreachable canister, or one with no `http_request`, is *inconclusive* and keeps the previous behaviour. A diagnostic that breaks a working setup would be worse than the failure it explains, so the only hard failure is the positive finding that the canister serves no sign-in UI at all.

`localInternetIdentityProvider` takes the path as an optional third argument, defaulting to `/authorize`, so direct callers are unaffected.

## Docs

The authentication guide now names `release-2026-03-16` as the newest working `internet_identity_dev.wasm`. That is the part that saves someone the bisect even in setups where the probe cannot run, and it was the issue's own minimum ask.

## Verification

8 new tests covering all three eras plus both inconclusive paths and the "never throws" property. `pnpm build` · `pnpm typecheck` · `pnpm test` **1281 passing** (react 475).

## Not done

The issue also floats a `cli` sub-command that downloads the pinned dev wasm. That is a separate feature rather than a fix, so it is not here.