### PR TITLE
chore: ignore the codegen output-owner marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,11 @@ target
 .astro
 **/*.tsbuildinfo
 docs/src/content/docs/libs/
+
+# Bookkeeping written by @ic-reactor/codegen into each output directory to record
+# which canister owns it, so a second canister generating into the same outDir is
+# stopped before it replaces the first one's declarations. It is not part of the
+# generated surface consumers import — which is why it is dot-prefixed — and the
+# examples commit their generated output, so without this every contributor sees
+# six untracked files after a build.
+**/.ic-reactor-owner


### PR DESCRIPTION
`@ic-reactor/codegen` writes `.ic-reactor-owner` into each output directory to record which canister owns it, so a second canister generating into the same `outDir` is refused **before** it replaces the first one's declarations (#330).

The examples commit their generated output, and CI now runs `pnpm build:examples` on every push (#338) — so after any local build, six of these show up as untracked files in every working tree. I hit it verifying the new build gate.

They are internal bookkeeping rather than part of the surface consumers import, which is exactly why they are dot-prefixed, so ignoring them is right rather than committing them.

Found while confirming #338's gate can actually fail: breaking one example produces `❌ Build failed in: query-demo` and exit 1, so the gate is real — it just leaves these behind.