### PR TITLE
fix(core): gate the ic_env canister ID behind the host guard the root key already uses

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,7 @@ These run in the user's browser or on their server. In scope:
 
 - Anything that causes one principal's canister data to be served to another (cache-key scoping, identity-switch handling, SSR request isolation)
 - Anything that weakens certificate verification — in particular how the agent's root key is chosen
+- Anything that lets untrusted input choose which canister a call is routed to. Certificate verification does not cover this: a substituted canister ID names a real canister, whose responses verify against the real root key
 - Anything that mishandles delegations or identity material
 - Candid decoding of hostile canister responses
 

--- a/docs/src/content/docs/examples/vite-env.mdx
+++ b/docs/src/content/docs/examples/vite-env.mdx
@@ -13,7 +13,7 @@ This example showcases how IC Reactor integrates with Vite's environment variabl
 - **Automatic Injection**: Canister IDs are automatically detected from the local environment and injected into the frontend.
 - **Fixed Overrides**: Use `canisterId` in the Vite plugin config when you want a specific canister ID to override the auto-detected development value.
 - **Seamless Local Dev**: Run `icp deploy` and your frontend immediately knows where to find the canisters.
-- **Client Configuration**: `ClientManager` reads the plugin's `ic_env` cookie automatically — canister IDs need no option to switch on, and the root key is adopted without configuration because the dev server is a local host.
+- **Client Configuration**: `ClientManager` reads the plugin's `ic_env` cookie automatically here — canister IDs and root key alike need no option to switch on, because the dev server is a local host and that is where the cookie is trusted. On a custom domain or mainnet it is not read at all.
 
 ## Links
 

--- a/docs/src/content/docs/examples/vite-env.mdx
+++ b/docs/src/content/docs/examples/vite-env.mdx
@@ -44,8 +44,10 @@ This example showcases how IC Reactor integrates with Vite's environment variabl
 
 The `ClientManager` needs no extra configuration — in the browser it reads the
 `ic_env` cookie for canister IDs on every construction, and adopts the root key
-it carries because the dev server is served from a local host. On any other host
-the cookie's root key is ignored unless you pass `allowEnvRootKey: true`:
+it carries, because the dev server is served from a local host. On any other
+host the cookie is ignored entirely — root key and canister IDs alike — unless
+you pass `allowEnvConfig: true`, and a reactor with no configured `canisterId`
+throws there rather than trusting it:
 
 ```typescript
 // frontend/src/lib/clients.ts

--- a/docs/src/content/docs/getting-started/local-development.mdx
+++ b/docs/src/content/docs/getting-started/local-development.mdx
@@ -94,12 +94,15 @@ If you're not using the Vite plugin, you can still configure everything manually
 
 ### 1. Setup ClientManager
 
-`ClientManagerParameters` has three members: the required `queryClient`, an
+`ClientManagerParameters` has four members: the required `queryClient`, an
 optional `agentOptions` (the `HttpAgentOptions` handed to the underlying
-`HttpAgent`), and an optional `allowEnvRootKey`. Network detection needs no flag
-— it always runs. `allowEnvRootKey` controls only whether the root key carried
-by the `ic_env` cookie is adopted; it defaults to `true` for hosts that are
-unambiguously a local replica and `false` everywhere else.
+`HttpAgent`), an optional `allowEnvConfig`, and `allowEnvRootKey` — the former
+name of that option, still honoured. Network detection needs no flag — it always
+runs. `allowEnvConfig` controls whether the `ic_env` cookie is trusted at all:
+its root key, its Internet Identity provider, and the canister IDs a reactor
+resolves by name. It defaults to `true` for hosts that are unambiguously a local
+replica and `false` everywhere else, so a reactor with no configured
+`canisterId` works on `localhost` and throws on a real domain.
 
 ```typescript
 import { ClientManager } from "@ic-reactor/react"

--- a/docs/src/content/docs/getting-started/local-development.mdx
+++ b/docs/src/content/docs/getting-started/local-development.mdx
@@ -97,7 +97,7 @@ If you're not using the Vite plugin, you can still configure everything manually
 `ClientManagerParameters` has four members: the required `queryClient`, an
 optional `agentOptions` (the `HttpAgentOptions` handed to the underlying
 `HttpAgent`), an optional `allowEnvConfig`, and `allowEnvRootKey` — the former
-name of that option, still honoured. Network detection needs no flag — it always
+name of that option, still honoured for the root key alone. Network detection needs no flag — it always
 runs. `allowEnvConfig` controls whether the `ic_env` cookie is trusted at all:
 its root key, its Internet Identity provider, and the canister IDs a reactor
 resolves by name. It defaults to `true` for hosts that are unambiguously a local

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -85,7 +85,10 @@ This tutorial walks you through creating your first IC Reactor integration with 
 
    <Aside type="note">
      `ClientManager` reads the plugin's `ic_env` cookie in the browser on its
-     own — there is no flag to enable it.
+     own — no flag to enable it while you are developing against a local
+     replica, which is the only place the cookie is trusted. Deploying to a real
+     domain needs the canister IDs baked in at build time, or an explicit
+     `allowEnvConfig: true`; see [ClientManager](/v3/reference/clientmanager).
    </Aside>
 
 4. ## Fetch data with Generated Hooks

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -157,7 +157,10 @@ The `AuthenticationManager` automatically selects the correct Internet Identity 
 
 The local URL uses the replica port from the agent host and the
 `internet_identity` canister ID from the `ic_env` cookie when one is present.
-You can override the whole thing by passing `identityProvider`.
+A provider named by that cookie is honoured only where the cookie is trusted —
+a local replica, or a host you opted in with `allowEnvConfig` — since any
+sibling subdomain can write it; the mainnet provider is fixed regardless. You
+can override the whole thing by passing `identityProvider`.
 
 ## Identity Attributes
 

--- a/docs/src/content/docs/packages/candid/candiddisplayreactor.mdx
+++ b/docs/src/content/docs/packages/candid/candiddisplayreactor.mdx
@@ -55,7 +55,7 @@ new CandidDisplayReactor<A = BaseActor, T extends TransformKey = "display">(
 | ---------------- | ------------------------------------------------------- | -------- | ---------------------------------------------------- |
 | `clientManager`  | `ClientManager`                                          | Yes      | Client manager from `@ic-reactor/core`               |
 | `name`           | `string`                                                 | Yes      | Required for logging & environment lookup            |
-| `canisterId`     | `CanisterId`                                             | No       | Optional if defined in environment                   |
+| `canisterId`     | `CanisterId`                                             | No       | Resolved from the `ic_env` cookie when omitted, on a trusted host only |
 | `candid`         | `string`                                                 | No       | Candid service definition (avoids network fetch)     |
 | `idlFactory`     | `InterfaceFactory`                                       | No       | IDL factory (if already available)                   |
 | `adapter`        | `CandidAdapter`                                          | No       | Reuse an existing `CandidAdapter` instance           |

--- a/docs/src/content/docs/packages/candid/candidreactor.mdx
+++ b/docs/src/content/docs/packages/candid/candidreactor.mdx
@@ -48,7 +48,7 @@ new CandidReactor(config: CandidReactorParameters)
 | ---------------- | ------------------ | -------- | ------------------------------------------------ |
 | `clientManager`  | `ClientManager`    | Yes      | Client manager from `@ic-reactor/core`           |
 | `name`           | `string`           | Yes      | Required for logging & environment lookup        |
-| `canisterId`     | `CanisterId`       | No       | Optional if defined in environment               |
+| `canisterId`     | `CanisterId`       | No       | Resolved from the `ic_env` cookie when omitted, on a trusted host only |
 | `candid`         | `string`           | No       | Candid service definition (avoids network fetch) |
 | `idlFactory`     | `InterfaceFactory` | No       | IDL factory (if already available)               |
 | `adapter`        | `CandidAdapter`    | No       | Reuse an existing `CandidAdapter` instance       |

--- a/docs/src/content/docs/reference/ClientManager.mdx
+++ b/docs/src/content/docs/reference/ClientManager.mdx
@@ -84,7 +84,8 @@ const clientManager = new ClientManager({
 | -------------- | ------------------ | -------- | ------------------------------------------------------------------------------ |
 | `queryClient`  | `QueryClient`      | Required | TanStack Query client instance                                                 |
 | `agentOptions` | `HttpAgentOptions` | `{}`     | Options forwarded to the `HttpAgent` (`host`, `identity`, `rootKey`, `retryTimes`, `verifyQuerySignatures`, …) |
-| `allowEnvRootKey` | `boolean` | host-dependent | Whether to adopt the agent root key from the `ic_env` cookie. Defaults to `true` only for hosts that are unambiguously a local replica (loopback, `localhost` and its subdomains, dev-container tunnel domains); every other host must opt in. |
+| `allowEnvConfig` | `boolean` | host-dependent | Whether to trust the `ic_env` cookie: its root key, its Internet Identity provider, and the canister IDs a reactor resolves by name. Defaults to `true` only for hosts that are unambiguously a local replica (loopback, `localhost` and its subdomains, dev-container tunnel domains); every other host must opt in. |
+| `allowEnvRootKey` | `boolean` | — | **Deprecated.** The former name of `allowEnvConfig`, renamed because it governs more than the root key. Still honoured. |
 
 Network detection needs no flag — see [Network Configuration](#network-configuration).
 
@@ -98,6 +99,7 @@ Network detection needs no flag — see [Network Configuration](#network-configu
 | `agentHost`   | `URL \| undefined`            | The host URL of the agent          |
 | `network`     | `"ic" \| "local" \| "remote"` | Current network type               |
 | `isLocal`     | `boolean`                     | Whether connected to local replica |
+| `trustsEnvConfig` | `boolean`                 | Whether the `ic_env` cookie is trusted for this host (getter) |
 
 ### AgentState Type
 
@@ -270,11 +272,12 @@ const clientManager = new ClientManager({
 
 ### Canister Environment
 
-When your app is served by the `@icp-sdk` toolchain (e.g., `icp-cli`) or by [`@ic-reactor/vite-plugin`](/v3/packages/vite-plugin), the dev server injects an `ic_env` cookie carrying the local canister IDs and root key. `ClientManager` reads that cookie **automatically** in the browser — canister IDs and host detection need no option to enable, and only the root key is gated (see `allowEnvRootKey`):
+When your app is served by the `@icp-sdk` toolchain (e.g., `icp-cli`) or by [`@ic-reactor/vite-plugin`](/v3/packages/vite-plugin), the dev server injects an `ic_env` cookie carrying the local canister IDs and root key. `ClientManager` reads that cookie **automatically** in the browser. Host detection needs no option to enable; everything the cookie *carries* is gated on one decision, exposed as the `trustsEnvConfig` getter and controlled by `allowEnvConfig`:
 
 - Agent host taken from `window.location.origin` when the page is served from a local or IC boundary host
 - Query signature verification disabled in development for performance
-- Root key from the cookie, accepted only on hosts that are unambiguously a local replica — loopback (the whole of 127.0.0.0/8, plus `::1`), `localhost` and its subdomains, and the dev-container domains that tunnel a local replica. Cookies are not origin-isolated and the root key is what certificate verification is checked against, so any other host — including a custom domain — must opt in with `allowEnvRootKey: true`.
+- Root key from the cookie, accepted only on hosts that are unambiguously a local replica — loopback (the whole of 127.0.0.0/8, plus `::1`), `localhost` and its subdomains, and the dev-container domains that tunnel a local replica. Cookies are not origin-isolated and the root key is what certificate verification is checked against, so any other host — including a custom domain — must opt in with `allowEnvConfig: true`.
+- Canister IDs from the cookie (`PUBLIC_CANISTER_ID:<name>`), used when a reactor is constructed without an explicit `canisterId`, and accepted on exactly the same hosts. On any other host the reactor throws instead, naming the option to set. A substituted canister ID is not something certificate verification can catch — the attacker names a real canister, and its responses verify against the real mainnet root key — so it fails closed rather than silently talking to someone else's canister.
 
 ### Subscribing to State Changes
 

--- a/docs/src/content/docs/reference/ClientManager.mdx
+++ b/docs/src/content/docs/reference/ClientManager.mdx
@@ -85,7 +85,7 @@ const clientManager = new ClientManager({
 | `queryClient`  | `QueryClient`      | Required | TanStack Query client instance                                                 |
 | `agentOptions` | `HttpAgentOptions` | `{}`     | Options forwarded to the `HttpAgent` (`host`, `identity`, `rootKey`, `retryTimes`, `verifyQuerySignatures`, …) |
 | `allowEnvConfig` | `boolean` | host-dependent | Whether to trust the `ic_env` cookie: its root key, its Internet Identity provider, and the canister IDs a reactor resolves by name. Defaults to `true` only for hosts that are unambiguously a local replica (loopback, `localhost` and its subdomains, dev-container tunnel domains); every other host must opt in. |
-| `allowEnvRootKey` | `boolean` | — | **Deprecated.** The former name of `allowEnvConfig`, renamed because it governs more than the root key. Still honoured. |
+| `allowEnvRootKey` | `boolean` | — | **Deprecated.** The former name of `allowEnvConfig`. Still honoured, and still scoped to what it always granted: the root key alone, not the identity provider or the canister ID. |
 
 Network detection needs no flag — see [Network Configuration](#network-configuration).
 

--- a/docs/src/content/docs/reference/Reactor.mdx
+++ b/docs/src/content/docs/reference/Reactor.mdx
@@ -27,7 +27,7 @@ const backend = new Reactor<_SERVICE>({
   clientManager,
   idlFactory,
   name: "backend", // Required: Used for logging and environment lookup
-  canisterId, // Optional: Can be omitted if defined in environment
+  canisterId, // Optional: omitted only where the ic_env cookie is trusted
 })
 
 // Data flows reactively: cache → components → automatic updates
@@ -93,7 +93,7 @@ const backend = new Reactor<_SERVICE>({
   clientManager,
   idlFactory,
   name: "backend", // Required: Used for logging and environment lookup
-  canisterId: "rrkah-fqaaa-aaaaa-aaaaq-cai", // Optional: Can be omitted if defined in environment
+  canisterId: "rrkah-fqaaa-aaaaa-aaaaq-cai", // Optional: omitted only where the ic_env cookie is trusted
 })
 ```
 
@@ -109,7 +109,7 @@ const backend = new Reactor<_SERVICE>({
 
 ### Why is `name` required?
 
-The `name` parameter is required for **environment-based resolution**. When `canisterId` is omitted, the Reactor uses this name to look up the canister ID from the environment (e.g., `PUBLIC_CANISTER_ID_<NAME>`).
+The `name` parameter is required for **environment-based resolution**. When `canisterId` is omitted, the Reactor uses this name to look up the canister ID in the `ic_env` cookie (`PUBLIC_CANISTER_ID:<name>`) — but only where that cookie is trusted; see below.
 
 For more details, see the [Canister Environment](https://js.icp.build/core/latest/canister-environment) documentation.
 
@@ -120,11 +120,11 @@ It also serves as a unique identifier for:
 
 ### Why is `canisterId` optional?
 
-The `canisterId` is optional because it can be automatically resolved using the `name`.
+The `canisterId` is optional because it can be automatically resolved using the `name` — on a host where the `ic_env` cookie is trusted.
 
-- **Automatic Resolution**: If omitted, the Reactor attempts to find the ID in the environment using the `name`.
+- **Automatic Resolution**: If omitted, the Reactor looks the ID up in the `ic_env` cookie using the `name`.
 - **Dynamic Usage**: useful when the canister ID is not known at build time or varies by environment.
-- **Flexibility**: Can be omitted if you rely on the standard `ic-reactor` environment lookup logic.
+- **Only where the cookie is trusted**: a local replica, or a host you opted in with `allowEnvConfig`. Cookies are not origin-isolated, so on any other host — a custom domain or mainnet — the cookie is not read and the constructor throws instead, naming the option to set. Bake the ID in at build time for those, which is what the codegen `canisterId` option does. A substituted canister ID cannot be caught by certificate verification: the attacker names a real canister, and its responses verify against the real root key.
 
 ## Properties
 

--- a/examples/all-in-one-demo/README.md
+++ b/examples/all-in-one-demo/README.md
@@ -121,7 +121,10 @@ Unlike the traditional `dfx` approach that uses `.env` files, ICP CLI uses a coo
 1. **During deployment**: ICP CLI saves canister IDs to `.icp/cache/mappings/local.ids.json`
 2. **During development**: Vite sets an `ic_env` cookie with canister IDs and root key
 3. **In production**: The asset canister automatically sets the `ic_env` cookie
-4. **In the app**: `@ic-reactor/react` reads the cookie automatically
+4. **In the app**: `@ic-reactor/react` reads the cookie automatically — while the
+   app is served from a local replica. Cookies are not origin-isolated, so on a
+   custom domain or mainnet the cookie is ignored: bake the canister IDs in at
+   build time there, or pass `allowEnvConfig: true` to `ClientManager`
 
 ```typescript
 // src/lib/config.ts

--- a/packages/candid/METADATA_REACTOR_GUIDE.md
+++ b/packages/candid/METADATA_REACTOR_GUIDE.md
@@ -738,7 +738,7 @@ await reactor.initialize()
 interface CandidDisplayReactorParameters<A> {
   clientManager: ClientManager
   name: string // Required — also the ic_env lookup key
-  canisterId?: CanisterId // Optional if resolvable from the ic_env cookie
+  canisterId?: CanisterId // Optional where the ic_env cookie is trusted (local replica)
   candid?: string // Optional: provide Candid source directly
   idlFactory?: (IDL: any) => any // Optional: skip fetching/parsing entirely
   adapter?: CandidAdapter // Optional: reuse an existing adapter

--- a/packages/candid/README.md
+++ b/packages/candid/README.md
@@ -351,15 +351,15 @@ Extends `Reactor` from `@ic-reactor/core`.
 new CandidReactor(config: CandidReactorParameters)
 ```
 
-| Parameter        | Type               | Required | Description                                       |
-| ---------------- | ------------------ | -------- | ------------------------------------------------- |
-| `name`           | `string`           | Yes      | Name of the canister/reactor                      |
-| `clientManager`  | `ClientManager`    | Yes      | Client manager from `@ic-reactor/core`            |
-| `canisterId`     | `CanisterId`       | No       | The canister ID (optional if using env vars)      |
-| `candid`         | `string`           | No       | Candid service definition (avoids network fetch)  |
-| `idlFactory`     | `InterfaceFactory` | No       | IDL factory (if already available)                |
-| `adapter`        | `CandidAdapter`    | No       | Reuse an existing adapter instead of creating one |
-| `pollingOptions` | `PollingOptions`   | No       | Polling configuration for update calls            |
+| Parameter        | Type               | Required | Description                                                            |
+| ---------------- | ------------------ | -------- | ---------------------------------------------------------------------- |
+| `name`           | `string`           | Yes      | Name of the canister/reactor                                           |
+| `clientManager`  | `ClientManager`    | Yes      | Client manager from `@ic-reactor/core`                                 |
+| `canisterId`     | `CanisterId`       | No       | Resolved from the `ic_env` cookie when omitted, on a trusted host only |
+| `candid`         | `string`           | No       | Candid service definition (avoids network fetch)                       |
+| `idlFactory`     | `InterfaceFactory` | No       | IDL factory (if already available)                                     |
+| `adapter`        | `CandidAdapter`    | No       | Reuse an existing adapter instead of creating one                      |
+| `pollingOptions` | `PollingOptions`   | No       | Polling configuration for update calls                                 |
 
 #### Methods
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -128,19 +128,32 @@ backend.invalidateQueries({ functionName: "greet" })
 interface ClientManagerParameters {
   queryClient: QueryClient // TanStack Query client (required)
   agentOptions?: HttpAgentOptions // Custom HttpAgent options (host, identity, rootKey, ...)
-  allowEnvRootKey?: boolean // Trust the ic_env cookie's root key on this host (default: local replicas only)
+  allowEnvConfig?: boolean // Trust the ic_env cookie on this host (default: local replicas only)
+  allowEnvRootKey?: boolean // Deprecated alias for allowEnvConfig
 }
 ```
 
-The `ic_env` cookie can carry an `IC_ROOT_KEY`. Since the root key is what
-certificate verification is checked against, and cookies are not
-origin-isolated, it is adopted only for hosts that are unambiguously a local
-replica — loopback (all of 127.0.0.0/8), `localhost` and its subdomains, and the
-dev-container domains that tunnel one. The exported `allowsEnvRootKey(host)` is
-that test. Any other host must opt in with `allowEnvRootKey: true`. Do not use
-`isMainnetHost` as a "safe to trust local config" test: it recognises only the
-three canonical boundary domain families, so a mainnet dapp on a custom domain
-falls through it.
+The `ic_env` cookie can carry three things the library would otherwise have to
+be told: an `IC_ROOT_KEY`, an Internet Identity provider, and the
+`PUBLIC_CANISTER_ID:<name>` entries a reactor resolves when no `canisterId` is
+configured. Cookies are not origin-isolated — any sibling subdomain of the
+registrable domain can write `ic_env` — so all three are trusted only for hosts
+that are unambiguously a local replica: loopback (all of 127.0.0.0/8),
+`localhost` and its subdomains, and the dev-container domains that tunnel one.
+The exported `allowsEnvRootKey(host)` is that test, and `ClientManager` resolves
+it once into the `trustsEnvConfig` getter that every consumer reads.
+
+Any other host must opt in with `allowEnvConfig: true`. Without it a reactor
+with no configured `canisterId` throws on such a host rather than taking one
+from the cookie, because a substituted canister ID is not something certificate
+verification can catch: the attacker names a real canister, whose responses
+verify against the same mainnet root key.
+
+`allowEnvRootKey` is the former name of this option, kept working; it was
+renamed because it governs more than the root key. Do not use `isMainnetHost`
+as a "safe to trust local config" test: it recognises only the three canonical
+boundary domain families, so a mainnet dapp on a custom domain falls through
+it.
 
 ### Authentication
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -137,13 +137,17 @@ The `ic_env` cookie can carry three things the library would otherwise have to
 be told: an `IC_ROOT_KEY`, an Internet Identity provider, and the
 `PUBLIC_CANISTER_ID:<name>` entries a reactor resolves when no `canisterId` is
 configured. Cookies are not origin-isolated — any sibling subdomain of the
-registrable domain can write `ic_env` — so all three are trusted only for hosts
-that are unambiguously a local replica: loopback (all of 127.0.0.0/8),
-`localhost` and its subdomains, and the dev-container domains that tunnel one.
-The exported `allowsEnvRootKey(host)` is that test, and `ClientManager` resolves
-it once into the `trustsEnvConfig` getter that every consumer reads.
+registrable domain can write `ic_env` — so all three are trusted only when the
+agent host and the page origin are both unambiguously a local replica: loopback
+(all of 127.0.0.0/8), `localhost` and its subdomains, and the dev-container
+domains that tunnel one. The page counts because the page is what decides who
+the siblings are: a document served from `app.example.com` shares its cookie jar
+with every other `*.example.com`, whatever host its agent talks to. The exported
+`allowsEnvRootKey(host)` answers this for one host, and `ClientManager` asks it
+of both and resolves the pair once into the `trustsEnvConfig` getter that every
+consumer reads.
 
-Any other host must opt in with `allowEnvConfig: true`. Without it a reactor
+Anything else must opt in with `allowEnvConfig: true`. Without it a reactor
 with no configured `canisterId` throws on such a host rather than taking one
 from the cookie, because a substituted canister ID is not something certificate
 verification can catch: the attacker names a real canister, whose responses

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -149,8 +149,10 @@ from the cookie, because a substituted canister ID is not something certificate
 verification can catch: the attacker names a real canister, whose responses
 verify against the same mainnet root key.
 
-`allowEnvRootKey` is the former name of this option, kept working; it was
-renamed because it governs more than the root key. Do not use `isMainnetHost`
+`allowEnvRootKey` is the former name of this option and still works, but only
+for what it always granted — the root key. It does not extend to the identity
+provider or the canister ID: setting it for a custom testnet was not an
+agreement to take those from a cookie too. Do not use `isMainnetHost`
 as a "safe to trust local config" test: it recognises only the three canonical
 boundary domain families, so a mainnet dapp on a custom domain falls through
 it.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -91,7 +91,7 @@ const backend = new Reactor<_SERVICE>({
   clientManager,
   idlFactory,
   name: "backend", // Required: explicit name
-  // canisterId: "...", // Optional: omitted if using environment variables
+  // canisterId: "...", // Optional: resolved from the ic_env cookie on a trusted host
 })
 ```
 
@@ -216,6 +216,7 @@ clientManager.agentState // { isInitialized, isInitializing, error, network, isL
 clientManager.queryClient // TanStack QueryClient
 clientManager.network // "local" | "remote" | "ic"
 clientManager.isLocal // boolean — true whenever network !== "ic"
+clientManager.trustsEnvConfig // boolean — whether the ic_env cookie is trusted here
 
 // Async: forwards HttpAgent.getPrincipal()
 const principal = await clientManager.getUserPrincipal()

--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -28,13 +28,21 @@ pnpm add @ic-reactor/core @icp-sdk/core @tanstack/query-core
 
 ## Local Environment Root Key
 
-The root key from the `ic_env` cookie is adopted only for hosts that
-`allowsEnvRootKey(host)` accepts: loopback (all of 127.0.0.0/8 and `::1`),
-`localhost` and its subdomains, and the dev-container domains that tunnel a local
-replica. Cookies are not origin-isolated, so this is a positive allowlist — any
-other host (custom domain, tunnel, staging) must opt in with
-`allowEnvRootKey: true` on `ClientManagerParameters`, or every certified call
-fails against the pinned mainnet key.
+The `ic_env` cookie is trusted only for hosts that `allowsEnvRootKey(host)`
+accepts: loopback (all of 127.0.0.0/8 and `::1`), `localhost` and its subdomains,
+and the dev-container domains that tunnel a local replica. Cookies are not
+origin-isolated, so this is a positive allowlist — any other host (custom domain,
+tunnel, staging) must opt in with `allowEnvConfig: true` on
+`ClientManagerParameters` (`allowEnvRootKey` is the deprecated former name).
+
+That one decision is resolved once in the constructor and exposed as
+`clientManager.trustsEnvConfig`. It governs all three values the cookie carries:
+the root key (without it, every certified call fails against the pinned mainnet
+key), the Internet Identity provider, and the `PUBLIC_CANISTER_ID:<name>` entry
+a `Reactor` resolves when no `canisterId` is configured. On an untrusted host a
+reactor with no configured id throws rather than reading the cookie — a
+substituted canister id still verifies against the real mainnet root key, so
+certificate verification cannot catch it.
 
 `isMainnetHost` is a boundary-node check only; it recognises three canonical
 domains and returns `false` for a mainnet dapp on a custom domain. Never use it

--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -33,7 +33,9 @@ accepts: loopback (all of 127.0.0.0/8 and `::1`), `localhost` and its subdomains
 and the dev-container domains that tunnel a local replica. Cookies are not
 origin-isolated, so this is a positive allowlist — any other host (custom domain,
 tunnel, staging) must opt in with `allowEnvConfig: true` on
-`ClientManagerParameters` (`allowEnvRootKey` is the deprecated former name).
+`ClientManagerParameters`. The deprecated `allowEnvRootKey` still works but is
+scoped to what it always granted — the root key alone — so it does not make
+`trustsEnvConfig` true.
 
 That one decision is resolved once in the constructor and exposed as
 `clientManager.trustsEnvConfig`. It governs all three values the cookie carries:

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -137,9 +137,19 @@ export class ClientManager {
     // key was guarded here, the Internet Identity provider recomputed the host
     // test (and so ignored an explicit opt-in), and the canister ID Reactor
     // resolves by name was not guarded at all (#348).
+    //
+    // `allowEnvRootKey` is deliberately NOT part of this decision. It granted
+    // the root key and only the root key, and a caller who set it for a custom
+    // testnet did not thereby agree to take their login redirect and their
+    // canister IDs from the same cookie. A rename must not widen a grant that
+    // is already out there, so the old spelling keeps its old reach below and
+    // `allowEnvConfig` is what opts into the whole cookie.
     this.#trustsEnvConfig =
+      allowEnvConfig ?? allowsEnvRootKey(agentOptions.host)
+
+    const acceptEnvRootKey =
       allowEnvConfig ?? allowEnvRootKey ?? allowsEnvRootKey(agentOptions.host)
-    if (this.#trustsEnvConfig && canisterEnv?.IC_ROOT_KEY) {
+    if (acceptEnvRootKey && canisterEnv?.IC_ROOT_KEY) {
       agentOptions.rootKey = agentOptions.rootKey ?? canisterEnv.IC_ROOT_KEY
     }
 
@@ -232,11 +242,13 @@ export class ClientManager {
    * Whether the configuration carried by the `ic_env` cookie may be trusted for
    * this agent's host.
    *
-   * `true` for a local replica, or when the caller passed `allowEnvConfig`
-   * (or the deprecated `allowEnvRootKey`). Every consumer of that cookie reads
-   * this one decision, so the root key, the Internet Identity provider and a
-   * reactor's canister ID cannot disagree about whether the environment is
-   * trustworthy.
+   * `true` for a local replica, or when the caller passed `allowEnvConfig`.
+   * Every consumer of that cookie reads this one decision, so the root key, the
+   * Internet Identity provider and a reactor's canister ID cannot disagree
+   * about whether the environment is trustworthy.
+   *
+   * The deprecated `allowEnvRootKey` is not enough on its own: it granted the
+   * root key alone, and is honoured for the root key alone.
    */
   get trustsEnvConfig(): boolean {
     return this.#trustsEnvConfig

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -49,6 +49,8 @@ export class ClientManager {
   #identity?: Identity
   #agentStateSubscribers: Array<(state: AgentState) => void> = []
   #targetCanisterIds: Set<string> = new Set()
+  /** Resolved once in the constructor; see {@link trustsEnvConfig}. */
+  #trustsEnvConfig: boolean
 
   /**
    * The TanStack QueryClient used for managing cached canister data and invalidating queries on identity changes.
@@ -68,6 +70,7 @@ export class ClientManager {
   constructor({
     agentOptions = {},
     queryClient,
+    allowEnvConfig,
     allowEnvRootKey,
   }: ClientManagerParameters) {
     this.queryClient = queryClient
@@ -118,18 +121,25 @@ export class ClientManager {
       }
     }
 
-    // The root key is what certificate verification is checked against, and the
-    // ic_env cookie is not origin-isolated -- any sibling subdomain of the
-    // registrable domain can write it. So this is a POSITIVE allowlist.
+    // The ic_env cookie is not origin-isolated -- any sibling subdomain of the
+    // registrable domain can write it -- so what it carries is trusted only
+    // where the cookie is as trustworthy as the replica. This is a POSITIVE
+    // allowlist.
     //
     // It used to read `!isMainnetHost(host)`, which fails OPEN: isMainnetHost
     // recognises exactly three boundary domains, so a production dapp served
     // from an ic-domains custom domain fell through it and took its root key
     // from a cookie. allowsEnvRootKey instead accepts only hosts that are
-    // unambiguously a local replica; anything else must pass allowEnvRootKey.
-    const acceptEnvRootKey =
-      allowEnvRootKey ?? allowsEnvRootKey(agentOptions.host)
-    if (acceptEnvRootKey && canisterEnv?.IC_ROOT_KEY) {
+    // unambiguously a local replica; anything else must pass allowEnvConfig.
+    //
+    // Resolved ONCE here and read back through `trustsEnvConfig`, because the
+    // cookie carries three values and each was deciding for itself: the root
+    // key was guarded here, the Internet Identity provider recomputed the host
+    // test (and so ignored an explicit opt-in), and the canister ID Reactor
+    // resolves by name was not guarded at all (#348).
+    this.#trustsEnvConfig =
+      allowEnvConfig ?? allowEnvRootKey ?? allowsEnvRootKey(agentOptions.host)
+    if (this.#trustsEnvConfig && canisterEnv?.IC_ROOT_KEY) {
       agentOptions.rootKey = agentOptions.rootKey ?? canisterEnv.IC_ROOT_KEY
     }
 
@@ -216,6 +226,20 @@ export class ClientManager {
    */
   get agentHostName() {
     return this.agentHost?.hostname || ""
+  }
+
+  /**
+   * Whether the configuration carried by the `ic_env` cookie may be trusted for
+   * this agent's host.
+   *
+   * `true` for a local replica, or when the caller passed `allowEnvConfig`
+   * (or the deprecated `allowEnvRootKey`). Every consumer of that cookie reads
+   * this one decision, so the root key, the Internet Identity provider and a
+   * reactor's canister ID cannot disagree about whether the environment is
+   * trustworthy.
+   */
+  get trustsEnvConfig(): boolean {
+    return this.#trustsEnvConfig
   }
 
   /**

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -144,11 +144,23 @@ export class ClientManager {
     // canister IDs from the same cookie. A rename must not widen a grant that
     // is already out there, so the old spelling keeps its old reach below and
     // `allowEnvConfig` is what opts into the whole cookie.
-    this.#trustsEnvConfig =
-      allowEnvConfig ?? allowsEnvRootKey(agentOptions.host)
+    //
+    // The PAGE has to clear the bar as well as the agent host, because the page
+    // is what decides who can write the cookie: a document on
+    // app.example.com pointed at a loopback replica shares its cookie jar with
+    // every sibling of example.com, and the agent host says nothing about that.
+    // Both sides are required, so the automatic grant only covers the case
+    // where the cookie is as trustworthy as the replica it describes. Off the
+    // browser there is no cookie to trust at all.
+    const hostIsLocal = allowsEnvRootKey(agentOptions.host)
+    const pageIsLocal =
+      typeof window !== "undefined" && allowsEnvRootKey(window.location?.origin)
+    this.#trustsEnvConfig = allowEnvConfig ?? (hostIsLocal && pageIsLocal)
 
-    const acceptEnvRootKey =
-      allowEnvConfig ?? allowEnvRootKey ?? allowsEnvRootKey(agentOptions.host)
+    // The root key keeps the keying it shipped with in 3.12.0 — agent host
+    // only. Tightening it here would revert a reviewed decision and break the
+    // test that pins it, so it is left to the maintainer; see the pull request.
+    const acceptEnvRootKey = allowEnvConfig ?? allowEnvRootKey ?? hostIsLocal
     if (acceptEnvRootKey && canisterEnv?.IC_ROOT_KEY) {
       agentOptions.rootKey = agentOptions.rootKey ?? canisterEnv.IC_ROOT_KEY
     }
@@ -242,7 +254,9 @@ export class ClientManager {
    * Whether the configuration carried by the `ic_env` cookie may be trusted for
    * this agent's host.
    *
-   * `true` for a local replica, or when the caller passed `allowEnvConfig`.
+   * `true` when BOTH the agent host and the page origin are unambiguously a
+   * local replica, or when the caller passed `allowEnvConfig`. The page counts
+   * because the page is what decides who can write the cookie.
    * Every consumer of that cookie reads this one decision, so the root key, the
    * Internet Identity provider and a reactor's canister ID cannot disagree
    * about whether the environment is trustworthy.

--- a/packages/core/src/reactor.ts
+++ b/packages/core/src/reactor.ts
@@ -100,9 +100,14 @@ export class Reactor<A = BaseActor, T extends TransformKey = "candid"> {
               ? `and there is no ic_env cookie to read outside a browser. `
               : !hostTrusted
                 ? `and the ic_env cookie is not trusted for this agent's host ` +
-                  `(${this.clientManager.agentHost?.toString() ?? "unknown"}), so it was not read. ` +
+                  `(${this.clientManager.agentHost?.toString() ?? "unknown"}` +
+                  // The agent host is often the library's mainnet fallback rather
+                  // than anywhere the reader recognises, so name the page too.
+                  `${window.location?.origin ? `, page ${window.location.origin}` : ""}), ` +
+                  `so it was not read. ` +
                   `The cookie is only trusted for a local replica, because any sibling subdomain can write it; ` +
-                  `bake the id in at build time, or pass \`allowEnvConfig: true\` to ClientManager if you trust every subdomain of this domain. `
+                  `Bake the id in at build time (the codegen \`canisterId\` option), or, only if you trust every subdomain of ` +
+                  `this domain, pass \`allowEnvConfig: true\` to ClientManager — that trusts the whole cookie, its root key included. `
                 : `and could not be resolved from the ic_env cookie (key: "${key}"). `) +
             `Pass canisterId explicitly in the reactor configuration.`
         )

--- a/packages/core/src/reactor.ts
+++ b/packages/core/src/reactor.ts
@@ -105,7 +105,7 @@ export class Reactor<A = BaseActor, T extends TransformKey = "candid"> {
                   // than anywhere the reader recognises, so name the page too.
                   `${window.location?.origin ? `, page ${window.location.origin}` : ""}), ` +
                   `so it was not read. ` +
-                  `The cookie is only trusted for a local replica, because any sibling subdomain can write it; ` +
+                  `The cookie is only trusted for a local replica, because any sibling subdomain can write it. ` +
                   `Bake the id in at build time (the codegen \`canisterId\` option), or, only if you trust every subdomain of ` +
                   `this domain, pass \`allowEnvConfig: true\` to ClientManager — that trusts the whole cookie, its root key included. `
                 : `and could not be resolved from the ic_env cookie (key: "${key}"). `) +

--- a/packages/core/src/reactor.ts
+++ b/packages/core/src/reactor.ts
@@ -84,19 +84,26 @@ export class Reactor<A = BaseActor, T extends TransformKey = "candid"> {
       // mainnet root key. The root key and the Internet Identity provider are
       // read from this cookie too and were already guarded; this is the third
       // value, and it was the unguarded one (#348).
-      const trusted =
-        typeof window !== "undefined" && this.clientManager.trustsEnvConfig
-      canisterId = trusted ? safeGetCanisterEnv()?.[key] : undefined
+      const inBrowser = typeof window !== "undefined"
+      const hostTrusted = this.clientManager.trustsEnvConfig
+      canisterId =
+        inBrowser && hostTrusted ? safeGetCanisterEnv()?.[key] : undefined
 
       if (!canisterId) {
+        // Three different problems with three different fixes. Reporting a
+        // refused cookie as an absent one sends the reader hunting for a cookie
+        // that is sitting right there, and reporting a server render as a
+        // refused host blames the host for having no cookie jar.
         throw new Error(
           `[ic-reactor] canisterId is required for "${this.name}" but was not provided ` +
-            (trusted
-              ? `and could not be resolved from the ic_env cookie (key: "${key}"). `
-              : `and the ic_env cookie is not trusted for this agent's host ` +
-                `(${this.clientManager.agentHost?.toString() ?? "unknown"}), so it was not read. ` +
-                `The cookie is only trusted for a local replica, because any sibling subdomain can write it; ` +
-                `bake the id in at build time, or pass \`allowEnvConfig: true\` to ClientManager if you trust every subdomain of this domain. `) +
+            (!inBrowser
+              ? `and there is no ic_env cookie to read outside a browser. `
+              : !hostTrusted
+                ? `and the ic_env cookie is not trusted for this agent's host ` +
+                  `(${this.clientManager.agentHost?.toString() ?? "unknown"}), so it was not read. ` +
+                  `The cookie is only trusted for a local replica, because any sibling subdomain can write it; ` +
+                  `bake the id in at build time, or pass \`allowEnvConfig: true\` to ClientManager if you trust every subdomain of this domain. `
+                : `and could not be resolved from the ic_env cookie (key: "${key}"). `) +
             `Pass canisterId explicitly in the reactor configuration.`
         )
       }

--- a/packages/core/src/reactor.ts
+++ b/packages/core/src/reactor.ts
@@ -73,14 +73,30 @@ export class Reactor<A = BaseActor, T extends TransformKey = "candid"> {
     let canisterId = config.canisterId
 
     if (!canisterId) {
-      const env = safeGetCanisterEnv()
       const key = `PUBLIC_CANISTER_ID:${this.name}`
-      canisterId = env?.[key]
+      // The ic_env cookie is not origin-isolated: any sibling subdomain of the
+      // registrable domain can write it. Taking the canister ID from it
+      // unconditionally let such a subdomain substitute the canister every
+      // read and every authenticated update call is routed to -- fake balances
+      // and deposit addresses on the way out, the user's signed calls on the
+      // way in -- and certificate verification cannot notice, because the
+      // attacker names a real canister whose responses verify against the same
+      // mainnet root key. The root key and the Internet Identity provider are
+      // read from this cookie too and were already guarded; this is the third
+      // value, and it was the unguarded one (#348).
+      const trusted =
+        typeof window !== "undefined" && this.clientManager.trustsEnvConfig
+      canisterId = trusted ? safeGetCanisterEnv()?.[key] : undefined
 
       if (!canisterId) {
         throw new Error(
           `[ic-reactor] canisterId is required for "${this.name}" but was not provided ` +
-            `and could not be resolved from the ic_env cookie (key: "${key}"). ` +
+            (trusted
+              ? `and could not be resolved from the ic_env cookie (key: "${key}"). `
+              : `and the ic_env cookie is not trusted for this agent's host ` +
+                `(${this.clientManager.agentHost?.toString() ?? "unknown"}), so it was not read. ` +
+                `The cookie is only trusted for a local replica, because any sibling subdomain can write it; ` +
+                `bake the id in at build time, or pass \`allowEnvConfig: true\` to ClientManager if you trust every subdomain of this domain. `) +
             `Pass canisterId explicitly in the reactor configuration.`
         )
       }

--- a/packages/core/src/types/client.ts
+++ b/packages/core/src/types/client.ts
@@ -32,10 +32,13 @@ export interface ClientManagerParameters {
    */
   allowEnvConfig?: boolean
   /**
-   * @deprecated Renamed to {@link allowEnvConfig}. The flag governs every value
-   * read from the `ic_env` cookie rather than the root key alone, and the old
-   * name understated what opting in accepts. This spelling still works, and is
-   * used when `allowEnvConfig` is not set.
+   * @deprecated Superseded by {@link allowEnvConfig}, which governs every value
+   * read from the `ic_env` cookie rather than the root key alone.
+   *
+   * Still honoured, and still scoped to what it always granted: the root key.
+   * It deliberately does not extend to the Internet Identity provider or to a
+   * reactor's canister ID — setting it for a custom testnet was not an
+   * agreement to take those from a cookie too. Use `allowEnvConfig` for that.
    */
   allowEnvRootKey?: boolean
 }

--- a/packages/core/src/types/client.ts
+++ b/packages/core/src/types/client.ts
@@ -17,13 +17,25 @@ export interface ClientManagerParameters {
    */
   agentOptions?: HttpAgentOptions
   /**
-   * Whether to adopt the agent root key from the `ic_env` cookie.
+   * Whether to trust the configuration carried by the `ic_env` cookie.
+   *
+   * Three values are read from that cookie, and this flag governs all of them:
+   * the agent root key certificate verification is checked against, the
+   * Internet Identity provider, and the canister ID a reactor resolves by name
+   * when none is configured.
    *
    * Defaults to `true` only for hosts that are unambiguously a local replica
    * (loopback, `localhost`, and the dev-container domains that tunnel one).
-   * The root key is what certificate verification is checked against, and
-   * cookies are not origin-isolated, so any other host must opt in — set this
-   * when you run a custom testnet on a real domain and trust its `ic_env`.
+   * Cookies are not origin-isolated — any sibling subdomain of the registrable
+   * domain can write `ic_env` — so every other host must opt in. Set this when
+   * you run a custom testnet on a real domain and trust its `ic_env`.
+   */
+  allowEnvConfig?: boolean
+  /**
+   * @deprecated Renamed to {@link allowEnvConfig}. The flag governs every value
+   * read from the `ic_env` cookie rather than the root key alone, and the old
+   * name understated what opting in accepts. This spelling still works, and is
+   * used when `allowEnvConfig` is not set.
    */
   allowEnvRootKey?: boolean
 }

--- a/packages/core/src/types/client.ts
+++ b/packages/core/src/types/client.ts
@@ -24,11 +24,14 @@ export interface ClientManagerParameters {
    * Internet Identity provider, and the canister ID a reactor resolves by name
    * when none is configured.
    *
-   * Defaults to `true` only for hosts that are unambiguously a local replica
-   * (loopback, `localhost`, and the dev-container domains that tunnel one).
-   * Cookies are not origin-isolated — any sibling subdomain of the registrable
-   * domain can write `ic_env` — so every other host must opt in. Set this when
-   * you run a custom testnet on a real domain and trust its `ic_env`.
+   * Defaults to `true` only when the agent host AND the page the code is
+   * running on are both unambiguously a local replica (loopback, `localhost`,
+   * and the dev-container domains that tunnel one). Cookies are not
+   * origin-isolated — any sibling subdomain of the registrable domain can write
+   * `ic_env` — and it is the PAGE that decides who those siblings are, so a
+   * document on a real domain is not trusted even when it points its agent at
+   * a loopback replica. Anything else must opt in: set this when you run a
+   * custom testnet on a real domain and trust its `ic_env`.
    */
   allowEnvConfig?: boolean
   /**

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -129,9 +129,13 @@ const IPV4_LOOPBACK = /^127\.(?:\d{1,3}\.){2}\d{1,3}$/
  *
  * Accepted: loopback, `localhost` and its subdomains, and the dev-container
  * domains that tunnel a local replica. Everything else must opt in explicitly
- * through `allowEnvConfig`. `ClientManager` resolves this once into
- * `trustsEnvConfig`; prefer reading that over calling this again, so every
- * consumer of the cookie agrees.
+ * through `allowEnvConfig`.
+ *
+ * This answers the question for ONE host. `ClientManager` asks it of both the
+ * agent host and the page origin — the page being what decides who can write
+ * the cookie — and resolves the pair once into `trustsEnvConfig`. Prefer
+ * reading that over calling this again, so every consumer of the cookie
+ * agrees.
  *
  * @param host - The host URL to evaluate.
  * @returns `true` only for hosts that are unambiguously a local replica.

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -111,7 +111,9 @@ const parseHostname = (host: string): string | undefined => {
 const IPV4_LOOPBACK = /^127\.(?:\d{1,3}\.){2}\d{1,3}$/
 
 /**
- * Whether the root key carried by the `ic_env` cookie may be adopted for a host.
+ * Whether the configuration carried by the `ic_env` cookie may be trusted for a
+ * host: its root key, its Internet Identity provider, and the canister IDs a
+ * reactor resolves by name.
  *
  * This is a POSITIVE allowlist, and deliberately not `!isMainnetHost(host)`.
  * `isMainnetHost` recognises exactly three mainnet domains, so every other host
@@ -120,9 +122,16 @@ const IPV4_LOOPBACK = /^127\.(?:\d{1,3}\.){2}\d{1,3}$/
  * origin-isolated, so any sibling subdomain of the registrable domain could
  * substitute the key that certificate verification is checked against.
  *
+ * The same reasoning covers the canister ID a `Reactor` resolves when none is
+ * configured: a substituted ID is not something certificate verification can
+ * catch, because the attacker names a real canister whose responses verify
+ * against the real root key.
+ *
  * Accepted: loopback, `localhost` and its subdomains, and the dev-container
  * domains that tunnel a local replica. Everything else must opt in explicitly
- * through `allowEnvRootKey`.
+ * through `allowEnvConfig`. `ClientManager` resolves this once into
+ * `trustsEnvConfig`; prefer reading that over calling this again, so every
+ * consumer of the cookie agrees.
  *
  * @param host - The host URL to evaluate.
  * @returns `true` only for hosts that are unambiguously a local replica.

--- a/packages/core/tests/reactor-env-canister-id.test.ts
+++ b/packages/core/tests/reactor-env-canister-id.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Which hosts may take a reactor's canister ID from the `ic_env` cookie.
+ *
+ * The cookie carries three values — the root key, the Internet Identity
+ * provider, and the `PUBLIC_CANISTER_ID:<name>` entries — and it is not
+ * origin-isolated, so any sibling subdomain of the registrable domain can write
+ * it. The first two were guarded; the canister ID was not (#348), so a sibling
+ * subdomain could substitute the canister every read and every authenticated
+ * update call is routed to. Certificate verification does not notice: the
+ * attacker names a real canister, whose responses verify against the same
+ * mainnet root key.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { QueryClient } from "@tanstack/query-core"
+import { IDL } from "@icp-sdk/core/candid"
+import { ClientManager } from "../src/client.js"
+import { Reactor } from "../src/reactor.js"
+
+/** The id an attacker-writable cookie would carry. */
+const ENV_CANISTER_ID = "ryjl3-tyaaa-aaaaa-aaaba-cai"
+/** An id passed in configuration, which the cookie must never override. */
+const EXPLICIT_CANISTER_ID = "rrkah-fqaaa-aaaaa-aaaaq-cai"
+
+// The env normally comes from the `ic_env` cookie; mocking the reader keeps the
+// test about the host guard rather than about cookie parsing. A root key is
+// present because `safeGetCanisterEnv` only returns entries at all when the
+// cookie carries a well-formed one — any 133-byte value satisfies it, which is
+// exactly why the cookie is not evidence of anything.
+vi.mock("@icp-sdk/core/agent/canister-env", () => ({
+  safeGetCanisterEnv: () => ({
+    IC_ROOT_KEY: new Uint8Array(133).fill(7),
+    "PUBLIC_CANISTER_ID:backend": ENV_CANISTER_ID,
+  }),
+}))
+
+const idlFactory: IDL.InterfaceFactory = ({ IDL }) =>
+  IDL.Service({ get: IDL.Func([], [IDL.Text], ["query"]) })
+
+function withBrowser(origin: string) {
+  vi.stubGlobal("window", {
+    location: { origin, protocol: new URL(origin).protocol },
+  })
+}
+
+/**
+ * Build a reactor the way the generated code does — no `canisterId`, resolved
+ * by name — and report which id it ended up targeting.
+ */
+function resolveCanisterId(
+  host: string,
+  options?: { allowEnvConfig?: boolean; allowEnvRootKey?: boolean }
+) {
+  const clientManager = new ClientManager({
+    queryClient: new QueryClient(),
+    agentOptions: { host },
+    ...options,
+  })
+  return new Reactor({
+    clientManager,
+    idlFactory,
+    name: "backend",
+  }).canisterId.toString()
+}
+
+beforeEach(() => {
+  withBrowser("https://app.example.com")
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("Reactor canister ID from ic_env", () => {
+  it("refuses the cookie on a custom domain, which is the attack in #348", () => {
+    // app.example.com and evil.example.com share a registrable domain, so the
+    // cookie is attacker-writable here. Failing closed is the whole fix: the
+    // alternative is silently talking to someone else's canister.
+    expect(() => resolveCanisterId("https://app.example.com")).toThrow(
+      /not trusted for this agent's host/
+    )
+  })
+
+  it("refuses the cookie on mainnet", () => {
+    expect(() => resolveCanisterId("https://icp-api.io")).toThrow(
+      /not trusted for this agent's host/
+    )
+  })
+
+  it("still takes it on a local replica, which is the generated dev workflow", () => {
+    // The vite plugin injects this cookie on the dev server, and generated
+    // reactors omit `canisterId` when none is configured. That path has to keep
+    // working, or the guard breaks every local project.
+    expect(resolveCanisterId("http://127.0.0.1:4943")).toBe(ENV_CANISTER_ID)
+  })
+
+  it("takes it on a custom domain when the caller opts in", () => {
+    expect(
+      resolveCanisterId("https://testnet.example.com", { allowEnvConfig: true })
+    ).toBe(ENV_CANISTER_ID)
+  })
+
+  it("honours the deprecated allowEnvRootKey spelling as an alias", () => {
+    // The option was renamed because it governs all three cookie-derived
+    // values, but the old name is public API and still has to work.
+    expect(
+      resolveCanisterId("https://testnet.example.com", {
+        allowEnvRootKey: true,
+      })
+    ).toBe(ENV_CANISTER_ID)
+  })
+
+  it("lets allowEnvConfig win over the deprecated spelling", () => {
+    expect(() =>
+      resolveCanisterId("http://127.0.0.1:4943", {
+        allowEnvConfig: false,
+        allowEnvRootKey: true,
+      })
+    ).toThrow(/not trusted for this agent's host/)
+  })
+
+  it("refuses it on a local replica when the caller opts out", () => {
+    expect(() =>
+      resolveCanisterId("http://127.0.0.1:4943", { allowEnvConfig: false })
+    ).toThrow(/not trusted for this agent's host/)
+  })
+
+  it("prefers an explicitly configured id over the cookie, on any host", () => {
+    for (const host of ["http://127.0.0.1:4943", "https://app.example.com"]) {
+      const clientManager = new ClientManager({
+        queryClient: new QueryClient(),
+        agentOptions: { host },
+      })
+      const reactor = new Reactor({
+        clientManager,
+        idlFactory,
+        name: "backend",
+        canisterId: EXPLICIT_CANISTER_ID,
+      })
+      expect(reactor.canisterId.toString()).toBe(EXPLICIT_CANISTER_ID)
+    }
+  })
+
+  it("says which failure it was, so the message is actionable", () => {
+    // A refused cookie and an absent one are different problems with different
+    // fixes, and reporting the first as the second sends the reader looking for
+    // a cookie that is sitting right there.
+    expect(() => resolveCanisterId("https://app.example.com")).toThrow(
+      /allowEnvConfig: true/
+    )
+    expect(
+      () =>
+        // Trusted host, but nothing in the cookie under this name.
+        new Reactor({
+          clientManager: new ClientManager({
+            queryClient: new QueryClient(),
+            agentOptions: { host: "http://127.0.0.1:4943" },
+          }),
+          idlFactory,
+          name: "not_in_the_cookie",
+        })
+    ).toThrow(/could not be resolved from the ic_env cookie/)
+  })
+})
+
+describe("ClientManager.trustsEnvConfig", () => {
+  function trusts(
+    host: string,
+    options?: { allowEnvConfig?: boolean; allowEnvRootKey?: boolean }
+  ) {
+    return new ClientManager({
+      queryClient: new QueryClient(),
+      agentOptions: { host },
+      ...options,
+    }).trustsEnvConfig
+  }
+
+  it("is the same decision the root key already used", () => {
+    expect(trusts("http://127.0.0.1:4943")).toBe(true)
+    expect(trusts("http://localhost:4943")).toBe(true)
+    expect(trusts("https://foo-4943.app.github.dev")).toBe(true)
+    expect(trusts("https://app.example.com")).toBe(false)
+    expect(trusts("https://icp-api.io")).toBe(false)
+  })
+
+  it("takes the explicit opt-in under either spelling", () => {
+    expect(trusts("https://app.example.com", { allowEnvConfig: true })).toBe(
+      true
+    )
+    expect(trusts("https://app.example.com", { allowEnvRootKey: true })).toBe(
+      true
+    )
+    expect(trusts("http://127.0.0.1:4943", { allowEnvConfig: false })).toBe(
+      false
+    )
+  })
+})

--- a/packages/core/tests/reactor-env-canister-id.test.ts
+++ b/packages/core/tests/reactor-env-canister-id.test.ts
@@ -99,14 +99,18 @@ describe("Reactor canister ID from ic_env", () => {
     ).toBe(ENV_CANISTER_ID)
   })
 
-  it("honours the deprecated allowEnvRootKey spelling as an alias", () => {
-    // The option was renamed because it governs all three cookie-derived
-    // values, but the old name is public API and still has to work.
-    expect(
+  it("does not let the deprecated spelling widen into canister IDs", () => {
+    // `allowEnvRootKey` granted the root key and nothing else. Someone who set
+    // it for a custom testnet did not thereby agree to take their canister IDs
+    // from the same cookie, and a rename must not widen a grant already in the
+    // wild — so the old name keeps its old reach and `allowEnvConfig` is the
+    // one that opts into the whole cookie. (The root key it does still grant is
+    // pinned in client-env-root-key.test.ts.)
+    expect(() =>
       resolveCanisterId("https://testnet.example.com", {
         allowEnvRootKey: true,
       })
-    ).toBe(ENV_CANISTER_ID)
+    ).toThrow(/not trusted for this agent's host/)
   })
 
   it("lets allowEnvConfig win over the deprecated spelling", () => {
@@ -116,6 +120,15 @@ describe("Reactor canister ID from ic_env", () => {
         allowEnvRootKey: true,
       })
     ).toThrow(/not trusted for this agent's host/)
+  })
+
+  it("names the page origin as well as the agent host", () => {
+    // On a custom domain with no explicit host the agent falls back to the
+    // mainnet API, so the agent host alone names somewhere the reader has never
+    // heard of while their address bar says something else.
+    expect(() => resolveCanisterId("https://icp-api.io")).toThrow(
+      /page https:\/\/app\.example\.com/
+    )
   })
 
   it("refuses it on a local replica when the caller opts out", () => {
@@ -192,12 +205,13 @@ describe("ClientManager.trustsEnvConfig", () => {
     expect(trusts("https://icp-api.io")).toBe(false)
   })
 
-  it("takes the explicit opt-in under either spelling", () => {
+  it("takes allowEnvConfig, and only allowEnvConfig", () => {
     expect(trusts("https://app.example.com", { allowEnvConfig: true })).toBe(
       true
     )
+    // Not the deprecated spelling: that grant was about the root key.
     expect(trusts("https://app.example.com", { allowEnvRootKey: true })).toBe(
-      true
+      false
     )
     expect(trusts("http://127.0.0.1:4943", { allowEnvConfig: false })).toBe(
       false

--- a/packages/core/tests/reactor-env-canister-id.test.ts
+++ b/packages/core/tests/reactor-env-canister-id.test.ts
@@ -62,6 +62,22 @@ function resolveCanisterId(
   }).canisterId.toString()
 }
 
+/**
+ * The shape #348 actually describes: a deployed dapp that configures no host at
+ * all, so `ClientManager` infers one from the page. Nothing in the generated
+ * setup passes `agentOptions`, so this is the path that matters most and the
+ * one an explicit-host test never reaches.
+ */
+function resolveFromPage(origin: string) {
+  withBrowser(origin)
+  const clientManager = new ClientManager({ queryClient: new QueryClient() })
+  return new Reactor({
+    clientManager,
+    idlFactory,
+    name: "backend",
+  }).canisterId.toString()
+}
+
 beforeEach(() => {
   withBrowser("https://app.example.com")
 })
@@ -78,6 +94,30 @@ describe("Reactor canister ID from ic_env", () => {
     expect(() => resolveCanisterId("https://app.example.com")).toThrow(
       /not trusted for this agent's host/
     )
+  })
+
+  it("refuses the cookie for a dapp that configures no host at all", () => {
+    // The generated setup passes no `agentOptions`, so the host comes from the
+    // page. A custom domain is not recognised as an origin worth adopting, so
+    // the agent falls back to the mainnet API — either way the cookie is out.
+    expect(() => resolveFromPage("https://app.example.com")).toThrow(
+      /not trusted for this agent's host/
+    )
+  })
+
+  it("refuses it for a dapp served from its own mainnet asset canister", () => {
+    // Here the page origin IS adopted as the host, so this exercises the other
+    // branch of the host inference and still has to fail closed.
+    expect(() => resolveFromPage("https://abcde-aaaaa.icp0.io")).toThrow(
+      /not trusted for this agent's host/
+    )
+  })
+
+  it("still resolves it for a dapp served from a local replica", () => {
+    // Same no-agentOptions path, on the host where the cookie is trusted. This
+    // is the local `icp deploy` flow, and it must not have been broken by the
+    // two cases above.
+    expect(resolveFromPage("http://localhost:4943")).toBe(ENV_CANISTER_ID)
   })
 
   it("refuses the cookie on mainnet", () => {
@@ -114,6 +154,10 @@ describe("Reactor canister ID from ic_env", () => {
   })
 
   it("lets allowEnvConfig win over the deprecated spelling", () => {
+    // For the canister ID the deprecated name is not consulted at all, so this
+    // pair only says something once the root key is watched too — see the
+    // precedence case in "ClientManager root key" below, which is where the two
+    // options genuinely compete.
     expect(() =>
       resolveCanisterId("http://127.0.0.1:4943", {
         allowEnvConfig: false,
@@ -197,7 +241,10 @@ describe("ClientManager.trustsEnvConfig", () => {
     }).trustsEnvConfig
   }
 
-  it("is the same decision the root key already used", () => {
+  // NOT interchangeable with the root-key gate: that one also honours the
+  // deprecated `allowEnvRootKey`, which this deliberately does not. Collapsing
+  // the two would silently restore the widening this change exists to avoid.
+  it("uses the same host allowlist the root key does", () => {
     expect(trusts("http://127.0.0.1:4943")).toBe(true)
     expect(trusts("http://localhost:4943")).toBe(true)
     expect(trusts("https://foo-4943.app.github.dev")).toBe(true)
@@ -216,5 +263,57 @@ describe("ClientManager.trustsEnvConfig", () => {
     expect(trusts("http://127.0.0.1:4943", { allowEnvConfig: false })).toBe(
       false
     )
+  })
+})
+
+describe("ClientManager root key", () => {
+  /** The mocked cookie root key, so an adopted one is distinguishable. */
+  function adoptedEnvRootKey(
+    host: string,
+    options?: { allowEnvConfig?: boolean; allowEnvRootKey?: boolean }
+  ) {
+    const manager = new ClientManager({
+      queryClient: new QueryClient(),
+      agentOptions: { host },
+      ...options,
+    })
+    const rootKey = manager.agent.rootKey
+    if (!rootKey) return false
+    const bytes =
+      rootKey instanceof Uint8Array
+        ? rootKey
+        : new Uint8Array(rootKey as ArrayBuffer)
+    return bytes.length === 133 && bytes.every((b) => b === 7)
+  }
+
+  it("is granted by the new option, not only the deprecated one", () => {
+    // Without this, dropping `allowEnvConfig` from the root-key term would go
+    // unnoticed, and a caller migrating off the old spelling would silently
+    // lose the root key their custom testnet needs.
+    expect(adoptedEnvRootKey("https://testnet.example.com")).toBe(false)
+    expect(
+      adoptedEnvRootKey("https://testnet.example.com", {
+        allowEnvConfig: true,
+      })
+    ).toBe(true)
+  })
+
+  it("is still granted by the deprecated spelling", () => {
+    expect(
+      adoptedEnvRootKey("https://testnet.example.com", {
+        allowEnvRootKey: true,
+      })
+    ).toBe(true)
+  })
+
+  it("lets allowEnvConfig override the deprecated spelling, not the reverse", () => {
+    // The one place the two options actually compete. Inverting the precedence
+    // would let a stale `allowEnvRootKey: true` defeat an explicit opt-out.
+    expect(
+      adoptedEnvRootKey("https://testnet.example.com", {
+        allowEnvConfig: false,
+        allowEnvRootKey: true,
+      })
+    ).toBe(false)
   })
 })

--- a/packages/core/tests/reactor-env-canister-id.test.ts
+++ b/packages/core/tests/reactor-env-canister-id.test.ts
@@ -48,8 +48,13 @@ function withBrowser(origin: string) {
  */
 function resolveCanisterId(
   host: string,
-  options?: { allowEnvConfig?: boolean; allowEnvRootKey?: boolean }
+  options?: { allowEnvConfig?: boolean; allowEnvRootKey?: boolean },
+  page?: string
 ) {
+  // The page decides who can write the cookie, so it is part of the fixture and
+  // not a detail: a "local replica" case served from a real domain is a
+  // different situation, and has its own test below.
+  if (page) withBrowser(page)
   const clientManager = new ClientManager({
     queryClient: new QueryClient(),
     agentOptions: { host },
@@ -129,8 +134,38 @@ describe("Reactor canister ID from ic_env", () => {
   it("still takes it on a local replica, which is the generated dev workflow", () => {
     // The vite plugin injects this cookie on the dev server, and generated
     // reactors omit `canisterId` when none is configured. That path has to keep
-    // working, or the guard breaks every local project.
-    expect(resolveCanisterId("http://127.0.0.1:4943")).toBe(ENV_CANISTER_ID)
+    // working, or the guard breaks every local project. The page is the dev
+    // server, which is the whole reason the cookie can be believed here.
+    expect(
+      resolveCanisterId(
+        "http://127.0.0.1:4943",
+        undefined,
+        "http://127.0.0.1:4943"
+      )
+    ).toBe(ENV_CANISTER_ID)
+  })
+
+  it("refuses it when the page is on a real domain, whatever the agent host", () => {
+    // Reported by Codex on this PR, and correct: keying only on the agent host
+    // let a document on app.example.com pointed at a loopback replica keep
+    // trusting a cookie every sibling of example.com can write. The agent host
+    // says nothing about who owns the cookie jar.
+    expect(() =>
+      resolveCanisterId(
+        "http://127.0.0.1:4943",
+        undefined,
+        "https://app.example.com"
+      )
+    ).toThrow(/not trusted for this agent's host/)
+    // Same for a dev-container tunnel, whose registrable domain is shared with
+    // every other user of the platform.
+    expect(() =>
+      resolveCanisterId(
+        "https://foo-4943.app.github.dev",
+        undefined,
+        "https://app.example.com"
+      )
+    ).toThrow(/not trusted for this agent's host/)
   })
 
   it("takes it on a custom domain when the caller opts in", () => {
@@ -214,9 +249,10 @@ describe("Reactor canister ID from ic_env", () => {
     expect(() => resolveCanisterId("https://app.example.com")).toThrow(
       /allowEnvConfig: true/
     )
+    withBrowser("http://127.0.0.1:4943")
     expect(
       () =>
-        // Trusted host, but nothing in the cookie under this name.
+        // Trusted page and host, but nothing in the cookie under this name.
         new Reactor({
           clientManager: new ClientManager({
             queryClient: new QueryClient(),
@@ -232,8 +268,10 @@ describe("Reactor canister ID from ic_env", () => {
 describe("ClientManager.trustsEnvConfig", () => {
   function trusts(
     host: string,
-    options?: { allowEnvConfig?: boolean; allowEnvRootKey?: boolean }
+    options?: { allowEnvConfig?: boolean; allowEnvRootKey?: boolean },
+    page = "http://localhost:4943"
   ) {
+    withBrowser(page)
     return new ClientManager({
       queryClient: new QueryClient(),
       agentOptions: { host },
@@ -244,12 +282,25 @@ describe("ClientManager.trustsEnvConfig", () => {
   // NOT interchangeable with the root-key gate: that one also honours the
   // deprecated `allowEnvRootKey`, which this deliberately does not. Collapsing
   // the two would silently restore the widening this change exists to avoid.
-  it("uses the same host allowlist the root key does", () => {
+  it("uses the same host allowlist the root key does, on both sides", () => {
     expect(trusts("http://127.0.0.1:4943")).toBe(true)
     expect(trusts("http://localhost:4943")).toBe(true)
-    expect(trusts("https://foo-4943.app.github.dev")).toBe(true)
+    expect(
+      trusts(
+        "https://foo-4943.app.github.dev",
+        undefined,
+        "https://foo-4943.app.github.dev"
+      )
+    ).toBe(true)
     expect(trusts("https://app.example.com")).toBe(false)
     expect(trusts("https://icp-api.io")).toBe(false)
+    // Either side failing is enough to refuse.
+    expect(
+      trusts("http://127.0.0.1:4943", undefined, "https://app.example.com")
+    ).toBe(false)
+    expect(
+      trusts("https://icp-api.io", undefined, "http://localhost:4943")
+    ).toBe(false)
   })
 
   it("takes allowEnvConfig, and only allowEnvConfig", () => {

--- a/packages/core/tests/reactor-env-canister-id.test.ts
+++ b/packages/core/tests/reactor-env-canister-id.test.ts
@@ -140,6 +140,16 @@ describe("Reactor canister ID from ic_env", () => {
     }
   })
 
+  it("names the server render rather than blaming the host, with no window", () => {
+    // A trusted host with no browser is not a refused cookie: there is no
+    // cookie jar at all. Saying the host is untrusted would send a Next.js
+    // reader off to configure an option that would change nothing.
+    vi.unstubAllGlobals()
+    expect(() => resolveCanisterId("http://127.0.0.1:4943")).toThrow(
+      /no ic_env cookie to read outside a browser/
+    )
+  })
+
   it("says which failure it was, so the message is actionable", () => {
     // A refused cookie and an absent one are different problems with different
     // fixes, and reporting the first as the second sends the reader looking for

--- a/packages/react/src/auth/authentication-manager.ts
+++ b/packages/react/src/auth/authentication-manager.ts
@@ -6,7 +6,7 @@ import type {
   AuthenticationClientOptions,
   AuthenticationSignInOptions,
 } from "./types.js"
-import { ClientManager, isDev, allowsEnvRootKey } from "@ic-reactor/core"
+import { ClientManager, isDev } from "@ic-reactor/core"
 
 import { Principal } from "@icp-sdk/core/principal"
 import { safeGetCanisterEnv } from "@icp-sdk/core/agent/canister-env"
@@ -726,7 +726,13 @@ function acceptEnvIdentityProvider(
   // provider chosen by a cookie, and the ic_env cookie is writable by any
   // sibling subdomain. Redirecting the Internet Identity flow is as severe as
   // substituting the root key, so both now use the same test.
-  if (!allowsEnvRootKey(clientManager.agentHost?.toString())) {
+  //
+  // That test is the ClientManager's single resolved decision rather than a
+  // recomputed host test, which silently ignored a caller
+  // who had opted in: `allowEnvConfig: true` accepted the cookie's root key and
+  // then discarded its identity provider, from the same cookie, on the same
+  // host.
+  if (!clientManager.trustsEnvConfig) {
     console.warn(
       `[ic-reactor] Ignoring the Internet Identity provider from the ic_env cookie ` +
         `("${url.origin}") because this reactor does not target a local replica, where ` +

--- a/packages/react/src/auth/authentication-manager.ts
+++ b/packages/react/src/auth/authentication-manager.ts
@@ -99,13 +99,18 @@ export class AuthenticationManager {
           canisterEnv?.["PUBLIC_INTERNET_IDENTITY_PROVIDER"],
         clientManager
       )
+    // Same cookie, same decision. This one only ever reaches a local provider
+    // URL, but `allowEnvConfig: false` has to mean the cookie is not consulted
+    // rather than mostly not consulted.
     this.internetIdentityId =
       internetIdentityId ||
-      acceptEnvCanisterId(
-        canisterEnv?.["internet_identity"] ||
-          canisterEnv?.["PUBLIC_CANISTER_ID:internet_identity"] ||
-          canisterEnv?.["CANISTER_ID_INTERNET_IDENTITY"]
-      )
+      (clientManager.trustsEnvConfig
+        ? acceptEnvCanisterId(
+            canisterEnv?.["internet_identity"] ||
+              canisterEnv?.["PUBLIC_CANISTER_ID:internet_identity"] ||
+              canisterEnv?.["CANISTER_ID_INTERNET_IDENTITY"]
+          )
+        : undefined)
     this.defaultClientOptions = clientOptions
 
     if (authClient) {

--- a/packages/react/src/defineReactor.ts
+++ b/packages/react/src/defineReactor.ts
@@ -87,7 +87,8 @@ export interface DefineReactorSharedParameters
    * When omitted, a ClientManager is created from the agent options below.
    *
    * A supplied or adopted manager brings its own agent and QueryClient, so
-   * `agentOptions` and `queryClient` apply only when this call creates one.
+   * `agentOptions`, `queryClient` and `allowEnvConfig` apply only when this
+   * call creates one.
    */
   clientManager?: ClientManager
   /**
@@ -183,6 +184,8 @@ export function defineReactor<Service = BaseActor>(
     auth,
     display,
     agentOptions,
+    allowEnvConfig,
+    allowEnvRootKey,
     name,
     idlFactory,
     canisterId,
@@ -221,6 +224,11 @@ export function defineReactor<Service = BaseActor>(
     new ClientManager({
       queryClient: providedQueryClient ?? createDefaultQueryClient(),
       agentOptions,
+      // Forwarded, not dropped: the type has always accepted these (it extends
+      // ClientManagerParameters) while the call ignored them, so the one
+      // documented setup path silently discarded the ic_env opt-in it advertised.
+      allowEnvConfig,
+      allowEnvRootKey,
     })
 
   // Always report the QueryClient actually in use: when a ClientManager is

--- a/packages/react/src/defineReactor.ts
+++ b/packages/react/src/defineReactor.ts
@@ -218,6 +218,27 @@ export function defineReactor<Service = BaseActor>(
     )
   }
 
+  // Same reasoning as `auth`, and it matters more here: an ignored
+  // `allowEnvConfig: false` reads as "I locked the cookie out" while the
+  // supplied manager carries whatever decision it was built with.
+  if (
+    (providedClientManager || providedAuthentication) &&
+    (allowEnvConfig !== undefined || allowEnvRootKey !== undefined)
+  ) {
+    const passed = [
+      allowEnvConfig !== undefined && "allowEnvConfig",
+      allowEnvRootKey !== undefined && "allowEnvRootKey",
+    ]
+      .filter(Boolean)
+      .join(", ")
+    throw new Error(
+      `[ic-reactor] defineReactor("${name}") received both a ClientManager and \`${passed}\`. ` +
+        `That option is resolved when a ClientManager is constructed, so the supplied one already carries its own ` +
+        `decision and this would be ignored — silently changing nothing about whether the ic_env cookie is trusted. ` +
+        `Pass it where that ClientManager is created, or drop \`clientManager\` to build one here.`
+    )
+  }
+
   const clientManager =
     providedClientManager ??
     providedAuthentication?.clientManager ??

--- a/packages/react/tests/auth/auth-client-compat.test.ts
+++ b/packages/react/tests/auth/auth-client-compat.test.ts
@@ -18,6 +18,22 @@ const authClientMocks = vi.hoisted(() => ({ factory: vi.fn() }))
 
 vi.mock("@icp-sdk/auth/client", () => ({ AuthClient: authClientMocks.factory }))
 
+// `probeLocalInternetIdentity` asks the replica, over the real agent, whether
+// the local Internet Identity canister serves `/authorize`. There is no replica
+// here, so every construction in this file waited out an HTTP failure — several
+// cases landed between 2.7s and 5.0s against vitest's 5000ms default, and "rebuilds
+// only when the effective options change" tipped over it on a loaded CI runner.
+// Nothing in this file is about the probe: it is testing when the AuthClient is
+// rebuilt. Stubbing it removes the network from a unit test rather than papering
+// over a slow one, and the probe keeps its own coverage in local-ii-probe tests.
+vi.mock("../../src/auth/local-ii-probe.js", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  probeLocalInternetIdentity: vi.fn(async () => ({
+    path: "/authorize" as const,
+    inconclusive: false,
+  })),
+}))
+
 const identity = { getPrincipal: () => Principal.fromText("aaaaa-aa") } as never
 
 function createAuthClientStub() {

--- a/packages/react/tests/auth/authentication-manager.test.ts
+++ b/packages/react/tests/auth/authentication-manager.test.ts
@@ -352,6 +352,75 @@ describe("AuthenticationManager", () => {
       warn.mockRestore()
     })
 
+    it("accepts a cross-origin provider once the caller opts in", async () => {
+      // The behaviour the repoint exists for. `allowsEnvRootKey(agentHost)`
+      // recomputed the host test and so ignored the opt-in: a caller who set
+      // the flag got the cookie's root key and then had its identity provider —
+      // same cookie, same host — silently dropped. Reading the ClientManager's
+      // one resolved decision is what fixes that, and this is the only case
+      // where the old and new implementations disagree.
+      vi.stubGlobal("window", {
+        location: { origin: "https://app.example.com" },
+      })
+      vi.stubGlobal("document", {
+        cookie:
+          "ic_env=INTERNET_IDENTITY_PROVIDER%3Dhttps%3A%2F%2Ftestnet-ii.example%2Fauthorize",
+      })
+      const authClient = createAuthClient()
+      const AuthClient = mockAuthClientModule(authClient)
+
+      const optedIn = new ClientManager({
+        queryClient: new QueryClient(),
+        agentOptions: { host: "https://icp-api.io" },
+        allowEnvConfig: true,
+      })
+      vi.spyOn(optedIn, "initializeAgent").mockResolvedValue()
+
+      const authentication = new AuthenticationManager({
+        clientManager: optedIn,
+      })
+      await authentication.login()
+
+      expect(AuthClient).toHaveBeenCalledWith({
+        identityProvider: "https://testnet-ii.example/authorize",
+        windowOpenerFeatures: undefined,
+        openIdProvider: undefined,
+      })
+    })
+
+    it("ignores the cookie's II canister id when the caller opts out", async () => {
+      // The fourth value read from this cookie. It only ever reaches a local
+      // provider URL, but `allowEnvConfig: false` has to mean the cookie is not
+      // consulted rather than mostly not consulted.
+      vi.stubGlobal("window", {
+        location: { origin: "http://127.0.0.1:8000" },
+      })
+      ;(safeGetCanisterEnv as any).mockReturnValue({
+        "PUBLIC_CANISTER_ID:internet_identity": "aaaaa-aa",
+      })
+      const authClient = createAuthClient()
+      const AuthClient = mockAuthClientModule(authClient)
+
+      const optedOut = new ClientManager({
+        queryClient: new QueryClient(),
+        agentOptions: { host: "http://127.0.0.1:8000" },
+        allowEnvConfig: false,
+      })
+      vi.spyOn(optedOut, "initializeAgent").mockResolvedValue()
+
+      const authentication = new AuthenticationManager({
+        clientManager: optedOut,
+      })
+      await authentication.login()
+
+      // Falls back to the pinned local II canister, not the cookie's. Before
+      // the guard, `acceptEnvCanisterId` was unconditional and this would read
+      // `http://aaaaa-aa.localhost:8000/authorize`.
+      expect(AuthClient.mock.calls[0][0].identityProvider).toBe(
+        "http://rdmx6-jaaaa-aaaaa-aaadq-cai.localhost:8000/authorize"
+      )
+    })
+
     it("still accepts a same-origin provider from the ic_env cookie", async () => {
       vi.stubGlobal("window", {
         location: { origin: "https://app.example.com" },

--- a/packages/react/tests/define-reactor-env-config.test.ts
+++ b/packages/react/tests/define-reactor-env-config.test.ts
@@ -1,0 +1,65 @@
+/**
+ * `defineReactor` builds the ClientManager for the one-call setup path, so an
+ * option it accepts in its type but drops on the way through is an option that
+ * does not exist. `allowEnvConfig` decides whether the `ic_env` cookie is
+ * trusted for the root key, the Internet Identity provider and a reactor's
+ * canister ID (#348) — dropping it silently leaves callers on the default,
+ * which on a real domain refuses the cookie they were trying to opt into.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { IDL } from "@icp-sdk/core/candid"
+import { defineReactor } from "../src/defineReactor.js"
+
+const idlFactory: IDL.InterfaceFactory = ({ IDL }) =>
+  IDL.Service({ get: IDL.Func([], [IDL.Text], ["query"]) })
+
+const CANISTER_ID = "ryjl3-tyaaa-aaaaa-aaaba-cai"
+
+beforeEach(() => {
+  vi.stubGlobal("window", {
+    location: {
+      origin: "https://app.example.com",
+      protocol: "https:",
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function trustsEnvConfig(options: Record<string, unknown>) {
+  const { clientManager } = defineReactor({
+    name: "backend",
+    idlFactory,
+    canisterId: CANISTER_ID,
+    agentOptions: { host: "https://app.example.com" },
+    ...options,
+  })
+  return clientManager.trustsEnvConfig
+}
+
+describe("defineReactor forwards the ic_env opt-in", () => {
+  it("defaults to refusing the cookie on a real domain", () => {
+    expect(trustsEnvConfig({})).toBe(false)
+  })
+
+  it("forwards allowEnvConfig to the ClientManager it creates", () => {
+    expect(trustsEnvConfig({ allowEnvConfig: true })).toBe(true)
+  })
+
+  it("forwards the deprecated allowEnvRootKey spelling too", () => {
+    expect(trustsEnvConfig({ allowEnvRootKey: true })).toBe(true)
+  })
+
+  it("forwards an explicit opt-out on a local replica", () => {
+    const { clientManager } = defineReactor({
+      name: "backend",
+      idlFactory,
+      canisterId: CANISTER_ID,
+      agentOptions: { host: "http://127.0.0.1:4943" },
+      allowEnvConfig: false,
+    })
+    expect(clientManager.trustsEnvConfig).toBe(false)
+  })
+})

--- a/packages/react/tests/define-reactor-env-config.test.ts
+++ b/packages/react/tests/define-reactor-env-config.test.ts
@@ -10,6 +10,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { IDL } from "@icp-sdk/core/candid"
 import { defineReactor } from "../src/defineReactor.js"
 
+// A recognisable DER-shaped key, so a root key taken from the cookie is
+// distinguishable from the mainnet key the agent pins by default.
+const ENV_ROOT_KEY = new Uint8Array(133).fill(7)
+
+vi.mock("@icp-sdk/core/agent/canister-env", () => ({
+  safeGetCanisterEnv: () => ({ IC_ROOT_KEY: ENV_ROOT_KEY }),
+}))
+
 const idlFactory: IDL.InterfaceFactory = ({ IDL }) =>
   IDL.Service({ get: IDL.Func([], [IDL.Text], ["query"]) })
 
@@ -48,10 +56,27 @@ describe("defineReactor forwards the ic_env opt-in", () => {
     expect(trustsEnvConfig({ allowEnvConfig: true })).toBe(true)
   })
 
-  it("does not let the deprecated spelling grant the wider trust", () => {
-    // Forwarded, but `allowEnvRootKey` only ever granted the root key; see
-    // packages/core/tests/reactor-env-canister-id.test.ts.
-    expect(trustsEnvConfig({ allowEnvRootKey: true })).toBe(false)
+  it("forwards the deprecated spelling, scoped to the root key", () => {
+    // Two halves, and the first alone would be vacuous: `trustsEnvConfig` is
+    // false both when the option is correctly forwarded-but-narrow and when it
+    // is dropped on the floor. The root key is the only thing that flag grants,
+    // so it is the only place forwarding is observable.
+    const { clientManager } = defineReactor({
+      name: "backend",
+      idlFactory,
+      canisterId: CANISTER_ID,
+      agentOptions: { host: "https://testnet.example.com" },
+      allowEnvRootKey: true,
+    })
+    expect(clientManager.trustsEnvConfig).toBe(false)
+
+    const rootKey = clientManager.agent.rootKey
+    const bytes =
+      rootKey instanceof Uint8Array
+        ? rootKey
+        : new Uint8Array((rootKey ?? new ArrayBuffer(0)) as ArrayBuffer)
+    expect(bytes.length).toBe(ENV_ROOT_KEY.length)
+    expect(bytes.every((b) => b === 7)).toBe(true)
   })
 
   it("refuses the option when a supplied ClientManager would ignore it", () => {

--- a/packages/react/tests/define-reactor-env-config.test.ts
+++ b/packages/react/tests/define-reactor-env-config.test.ts
@@ -48,8 +48,30 @@ describe("defineReactor forwards the ic_env opt-in", () => {
     expect(trustsEnvConfig({ allowEnvConfig: true })).toBe(true)
   })
 
-  it("forwards the deprecated allowEnvRootKey spelling too", () => {
-    expect(trustsEnvConfig({ allowEnvRootKey: true })).toBe(true)
+  it("does not let the deprecated spelling grant the wider trust", () => {
+    // Forwarded, but `allowEnvRootKey` only ever granted the root key; see
+    // packages/core/tests/reactor-env-canister-id.test.ts.
+    expect(trustsEnvConfig({ allowEnvRootKey: true })).toBe(false)
+  })
+
+  it("refuses the option when a supplied ClientManager would ignore it", () => {
+    // Silently dropping `allowEnvConfig: false` is the worst shape of this: the
+    // caller reads it as having locked the cookie out.
+    const { clientManager } = defineReactor({
+      name: "backend",
+      idlFactory,
+      canisterId: CANISTER_ID,
+      agentOptions: { host: "http://127.0.0.1:4943" },
+    })
+    expect(() =>
+      defineReactor({
+        name: "other",
+        idlFactory,
+        canisterId: CANISTER_ID,
+        clientManager,
+        allowEnvConfig: false,
+      })
+    ).toThrow(/already carries its own/)
   })
 
   it("forwards an explicit opt-out on a local replica", () => {

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -40,8 +40,14 @@ export const clientManager = new ClientManager({
 })
 ```
 
-No opt-in flag is needed to pick up the plugin's environment: the plugin sets
-the `ic_env` cookie and `ClientManager` reads it automatically in the browser.
+No opt-in flag is needed to pick up the plugin's environment in development:
+the plugin sets the `ic_env` cookie and `ClientManager` reads it automatically
+in the browser. That trust stops at the local replica — cookies are not
+origin-isolated, so on a custom domain or mainnet the cookie is ignored and a
+reactor with no `canisterId` throws. Set the per-canister `canisterId` in the
+plugin config to bake it into the generated output for those builds, or pass
+`allowEnvConfig: true` to `ClientManager` if you trust every subdomain of the
+domain you serve from.
 
 The plugin generates files under `src/declarations/<canister>/` by default —
 `declarations/<did-basename>.{js,d.ts,did}` plus a managed `index.generated.ts`

--- a/packages/vite-plugin/llms.txt
+++ b/packages/vite-plugin/llms.txt
@@ -35,10 +35,13 @@ icReactor({
 - Per canister (inside `canisters[]`): `name`, `didFile`, `outDir`,
   `clientManagerPath`, `target`, `mode`, `canisterId`
 - `injectEnvironment` for local `ic_env` cookie + `/api` proxy behavior. The
-  consumer side is a positive allowlist: `ClientManager` adopts the cookie's root
-  key only for loopback, `localhost`, and dev-container hosts. Serving a dev build
-  over a tunnel or custom domain needs `allowEnvRootKey: true` — see
-  `packages/core/llms.txt`
+  consumer side is a positive allowlist: `ClientManager` trusts the cookie — its
+  root key, its Internet Identity provider, and the canister IDs a reactor
+  resolves by name — only for loopback, `localhost`, and dev-container hosts.
+  Serving a dev build over a tunnel or custom domain needs
+  `allowEnvConfig: true` (formerly `allowEnvRootKey`); without it a generated
+  reactor that carries no `canisterId` throws instead of reading one from the
+  cookie — see `packages/core/llms.txt`
 - `failOnError` overrides the default (`true` for build, `false` for dev)
 
 ## Best Practices

--- a/skill-packages/ic-reactor-packages/SKILL.md
+++ b/skill-packages/ic-reactor-packages/SKILL.md
@@ -39,20 +39,20 @@ entry points, verification commands, or known failure modes.
 
 ## Package Routing
 
-| Task                                                      | Start here                                                                                               |
-| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| Agent/query runtime, canister calls, display transforms   | `packages/core`                                                                                          |
-| React hooks, factories, `defineReactor`, `useActorMethod` | `packages/react` and `ic-reactor-hooks`                                                                  |
-| Internet Identity login and auth state                    | `packages/react/src/auth/authentication-manager.ts`                                                      |
-| Signed OpenID identity attributes                         | `packages/react/src/auth/identity-attributes-manager.ts`                                                 |
-| React auth and identity-attribute hooks                   | `packages/react/src/hooks/createAuthHooks.ts`, `packages/react/src/auth/createIdentityAttributeHooks.ts` |
-| Dynamic Candid fetch/parse, metadata reactors             | `packages/candid`                                                                                        |
-| Rust/WASM Candid parsing                                  | `packages/parser`                                                                                        |
-| Declaration/reactor/client generation                     | `packages/codegen`                                                                                       |
-| `ic-reactor` executable and config schema                 | `packages/cli`                                                                                           |
-| Vite `.did` watching and environment injection            | `packages/vite-plugin`                                                                                   |
-| Local Internet Identity `/authorize` detection            | `packages/react/src/auth/local-ii-probe.ts`, `packages/react/src/auth/constants.ts`                      |
-| `ic_env` root-key trust (`allowEnvRootKey`)               | `packages/core/src/client.ts`, `packages/core/src/utils/helper.ts`                                       |
+| Task                                                          | Start here                                                                                               |
+| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Agent/query runtime, canister calls, display transforms       | `packages/core`                                                                                          |
+| React hooks, factories, `defineReactor`, `useActorMethod`     | `packages/react` and `ic-reactor-hooks`                                                                  |
+| Internet Identity login and auth state                        | `packages/react/src/auth/authentication-manager.ts`                                                      |
+| Signed OpenID identity attributes                             | `packages/react/src/auth/identity-attributes-manager.ts`                                                 |
+| React auth and identity-attribute hooks                       | `packages/react/src/hooks/createAuthHooks.ts`, `packages/react/src/auth/createIdentityAttributeHooks.ts` |
+| Dynamic Candid fetch/parse, metadata reactors                 | `packages/candid`                                                                                        |
+| Rust/WASM Candid parsing                                      | `packages/parser`                                                                                        |
+| Declaration/reactor/client generation                         | `packages/codegen`                                                                                       |
+| `ic-reactor` executable and config schema                     | `packages/cli`                                                                                           |
+| Vite `.did` watching and environment injection                | `packages/vite-plugin`                                                                                   |
+| Local Internet Identity `/authorize` detection                | `packages/react/src/auth/local-ii-probe.ts`, `packages/react/src/auth/constants.ts`                      |
+| `ic_env` trust decision (`allowEnvConfig`, `trustsEnvConfig`) | `packages/core/src/client.ts`, `packages/core/src/utils/helper.ts`, `packages/core/src/reactor.ts`       |
 
 `AuthenticationManager.prepareClient()` probes the locally deployed Internet
 Identity canister and picks `/authorize` or the legacy `/#authorize`, or refuses


### PR DESCRIPTION
Closes #348.

## The bug

`Reactor`'s constructor resolved an unconfigured `canisterId` from the `ic_env` cookie with no host or network test:

```ts
const env = safeGetCanisterEnv()
canisterId = env?.[`PUBLIC_CANISTER_ID:${this.name}`]
```

Cookies are not origin-isolated, so `evil.example.com` can write `domain=.example.com` and `app.example.com` reads it. Certificate verification does not catch the substitution — the attacker names a **real** canister, whose responses verify against the real mainnet root key — so every read returns attacker-controlled data (balances, deposit addresses) and every authenticated update call is routed to the attacker's canister.

This is the default shape of generated code: codegen emits a `canisterId:` line only when one is configured, and otherwise the reactor resolves it from the cookie at runtime.

Two other values are read from that same cookie and both were already guarded — the root key (`client.ts`) and the Internet Identity provider (`authentication-manager.ts`). Each guarded itself, which is how the third came to be missed.

## The fix

One decision, resolved once, read by everyone.

- **`ClientManager`** resolves the trust decision in its constructor and exposes it as `trustsEnvConfig`. It requires the agent host **and** the page origin to clear the same allowlist, because the page is what decides who can write the cookie — a document on `app.example.com` shares its jar with every `*.example.com` sibling whatever host its agent talks to. `allowEnvConfig: true` is the explicit override.
- **`Reactor`** reads the cookie only when that is true and a browser is present; otherwise it throws.
- **`AuthenticationManager`** drops its own `allowsEnvRootKey(agentHost)` call. That recomputation ignored an explicit opt-in: `allowEnvRootKey: true` accepted the cookie's root key and then discarded its identity provider, from the same cookie, on the same host. The II canister ID (`PUBLIC_CANISTER_ID:internet_identity`), a fourth cookie-derived value with only a principal-parse check, is now gated too.
- **`defineReactor`** forwards the option to the ClientManager it builds. It accepted it in its public type (`extends Omit<ClientManagerParameters, "queryClient">`) and dropped it — so the opt-in was unreachable through the documented one-call setup path, including the one the new error message points at. With a ClientManager supplied it now refuses the option rather than ignoring it, matching how `auth` is already handled.

**Local development is unchanged.** The allowlist accepts loopback, `localhost` and its subdomains, and dev-container tunnel domains — which is where the vite plugin injects this cookie, and where the page is served from too. e2e runs against `127.0.0.1:8000`, and `icp-reactor-demo` serves from `<id>.localhost:8000`; both keep working, checked rather than assumed, and the E2E job is green here.

### API change

`allowEnvRootKey` → `allowEnvConfig`, since one flag governs three values and the old name understated what opting in accepts.

The old spelling still works and is **deliberately not an alias**: it keeps exactly the reach it always had — the root key, nothing else. Folding it into the unified decision would have silently widened an existing caller's grant to their login redirect and their canister IDs, which a rename has no business doing. `allowEnvConfig` is what opts into the whole cookie.

The error message distinguishes three cases — no browser, host not trusted, cookie present but no entry — because they have three different fixes, and it names the page origin alongside the agent host (on a custom domain with no explicit host, the agent falls back to the mainnet API, so the agent host alone names somewhere the reader has never seen).

## Verification

| gate | result |
| --- | --- |
| `@ic-reactor/core` tests | 292 passed, 2 skipped |
| `@ic-reactor/react` tests | 482 passed |
| `pnpm typecheck` | clean, all 7 packages |
| `pnpm typecheck:examples` | 20/20 |
| `pnpm format:check` | clean |
| `pnpm check:ai-context` | passes (16 files) |

Every claim here was checked by removing the code it covers and watching the check fail:

- `pnpm verify:test-fails tests/reactor-env-canister-id.test.ts --package core` → **15 of 20 fail on `main` and pass here**. The other 5 pass either way by design and are named in the run: they guard against the fix over-reaching (the dev workflow still resolves from the cookie with and without an explicit host, the opt-in works, an explicit id always wins, and the deprecated flag still grants the root key).
- The **`defineReactor` forwarding** was proved by dropping each forwarded option in turn and watching the relevant cases fail.
- The **`AuthenticationManager` repoint** was proved by reverting it wholesale — which, before the two cases added here, left all 479 react tests green.

`@ic-reactor/candid` has 17 failing tests in my sandbox and `pnpm build` fails in `packages/parser`; both are environmental (blocked outbound network — the binaryen download and live canister queries), and both are green in CI here. Every candid test passes an explicit `canisterId`, so the `!canisterId` branch this PR touches is never reached there.

## Docs

The reference page documented the defect as a feature — *"canister IDs and host detection need no option to enable, and only the root key is gated"* — and eleven other places said the canister ID is optional because the environment supplies it, with no mention that the environment has to be trustworthy first. Swept: core/candid/vite-plugin READMEs, both `llms.txt` files, the packages skill, `allowsEnvRootKey`'s own doc comment (published through typedoc), and eight docs-site pages. `SECURITY.md` gains the class of bug this was — routing a call to an attacker-chosen canister is not covered by the root-key line above it.

## One thing I did not change, for you to weigh

**The root key keeps the keying it shipped with in 3.12.0 — agent host only.** After the page-origin fix above, that is the only place the three cookie-derived values still disagree: the canister ID and the identity provider require the page to be local too, the root key does not. Tightening it would revert a decision you reviewed and would break `client-env-root-key.test.ts`, which pins the current behaviour (`adoptedEnvRootKey("http://127.0.0.1:4943")` with the page on `app.example.com`) — so it is yours to call rather than mine to slip in. The same reasoning that applies to the canister ID applies to it.

Separately, and pre-existing: on a dev-container host (`.github.dev`, `.gitpod.io`) a default `ClientManager` never infers its host from the browser origin — `client.ts` only does that for local and mainnet origins — so it falls back to the mainnet API and the dev-container arm of the allowlist is unreachable through the generated path. Identical for the root key today. This change makes such a setup throw where it previously would have queried mainnet with a local canister ID, which is an improvement, but the host inference itself is still worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsoUSdMhKAdJwjfuJ5gcHm