### PR TITLE
ci: bump github/codeql-action to 4.37.9 across all three paths at once

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,14 +28,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Replaces dependabot's #370, #371 and #372.

Each of those bumps one of the three `codeql-action` paths on its own, and each fails its CodeQL check with:

```
Loaded a configuration file for version '4.37.7', but running version '4.37.9'
```

`init`, `autobuild` and `analyze` have to run the same version, so the only way a bump passes is all three at once. Same as #323 did for 4.37.7.

Pinned SHA `cdf488f595d80d6e07e03d4674febd5ab45fa938` is the one dependabot resolved for v4.37.9 in all three PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)