### PR TITLE
fix(core): sign each poll's read_state with the identity that submitted the call

### DIFF
--- a/packages/core/src/utils/agent.ts
+++ b/packages/core/src/utils/agent.ts
@@ -13,6 +13,7 @@ import {
   isV2ResponseBody,
   isV4ResponseBody,
   Certificate,
+  encodePath,
   lookupResultToBuffer,
   pollForResponse,
   QueryResponseStatus,
@@ -70,6 +71,69 @@ export function processQueryCallResponse(
 // ══════════════════════════════════════════════════════════════════════
 // UPDATE CALL RESPONSE PROCESSING
 // ══════════════════════════════════════════════════════════════════════
+
+type ReadStateArgs = Parameters<Agent["readState"]>
+
+/**
+ * Wrap `agent` so that every read_state `pollForResponse` sends is signed by
+ * `identity` — the one that submitted the call — rather than by whatever the
+ * shared agent holds by the time each poll goes out.
+ *
+ * `HttpAgent.readState` takes an identity parameter and ignores it: the
+ * declaration names it `_identity`, and the body signs a fresh request with
+ * the agent's own identity on every call. The one input it sends verbatim is a
+ * pre-signed `request`, so that is where the pin has to live. The request is
+ * built through `createReadStateRequest`, which does honour an explicit
+ * identity, and is rebuilt on every poll so each carries a fresh ingress
+ * expiry, exactly as the unpinned path does.
+ *
+ * `createReadStateRequest` is overridden too, for two reasons. With
+ * `preSignReadStateRequest: true`, `pollForResponse` calls it on the agent it
+ * was handed and passes no identity, so it has to default to the pinned one.
+ * And a prototype delegate must never let an `HttpAgent` method run with the
+ * delegate as `this`: those methods touch private fields, which throw on any
+ * object that is not the instance itself. Both overrides call the real agent.
+ *
+ * Everything else — transforms, root key, subnet-key cache, time sync — is
+ * still the underlying agent's, reached through the prototype chain.
+ *
+ * As of @icp-sdk/core 6.1.0 the `preSignReadStateRequest` path never gets as
+ * far as the read: `pollForResponse` validates the built request by looking
+ * for `toHash` as an own property of the expiry, which `Expiry` defines on its
+ * prototype, so every `HttpAgent` request is rejected as invalid. That is
+ * upstream and independent of this wrapper; the default path is the one that
+ * runs.
+ */
+export function pinPollingIdentity(agent: Agent, identity: Identity): Agent {
+  const createReadStateRequest = agent.createReadStateRequest?.bind(agent)
+
+  const sign = (
+    fields: Parameters<NonNullable<Agent["createReadStateRequest"]>>[0],
+    requested?: Identity
+  ) => createReadStateRequest?.(fields, requested ?? identity)
+
+  return Object.create(agent, {
+    createReadStateRequest: { value: sign },
+    readState: {
+      value: async (
+        target: ReadStateArgs[0],
+        fields: ReadStateArgs[1],
+        requested?: ReadStateArgs[2],
+        request?: ReadStateArgs[3]
+      ) => {
+        // `readState` encodes the paths itself before signing, so a request
+        // built ahead of it has to carry them already encoded.
+        const signed =
+          request ??
+          (await sign(
+            { ...fields, paths: fields.paths.map(encodePath) },
+            requested
+          ))
+        return agent.readState(target, fields, requested ?? identity, signed)
+      },
+    },
+  })
+}
 
 /**
  * Process an update call response following the exact logic from @icp-sdk/core/agent Actor.
@@ -178,30 +242,11 @@ export async function processUpdateCallResponse(
 
   // Fall back to polling if we receive an Accepted response code
   if (result.response.status === 202) {
-    // Contains the certificate and the reply from the boundary node
-    // `pollForResponse` signs its read_state through `agent.readState`, which
-    // reads whatever identity the shared agent currently holds. Pin it to the
-    // one that submitted, or a sign-in/sign-out mid-poll makes the replica
-    // reject the read for a call that has already committed. The delegate keeps
-    // the same agent underneath, so transforms, root key and subnet-key caching
-    // are untouched.
-    const pollingAgent: Agent = identity
-      ? Object.create(agent, {
-          readState: {
-            value: (
-              target: Parameters<Agent["readState"]>[0],
-              fields: Parameters<Agent["readState"]>[1],
-              _identity?: unknown,
-              request?: unknown
-            ) =>
-              (
-                agent.readState as (
-                  ...args: unknown[]
-                ) => ReturnType<Agent["readState"]>
-              )(target, fields, identity, request),
-          },
-        })
-      : agent
+    // `pollForResponse` signs its read_state through the agent it is handed,
+    // which reads whatever identity the shared agent holds at that moment. Pin
+    // it to the one that submitted, or a sign-in/sign-out mid-poll makes the
+    // replica reject the read for a call that has already committed.
+    const pollingAgent = identity ? pinPollingIdentity(agent, identity) : agent
 
     const response = await pollForResponse(
       pollingAgent,

--- a/packages/core/tests/reactor-poll-identity-pinning.test.ts
+++ b/packages/core/tests/reactor-poll-identity-pinning.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { QueryClient } from "@tanstack/query-core"
+import { LookupPathStatus } from "@icp-sdk/core/agent"
+import type { Agent, PollingOptions } from "@icp-sdk/core/agent"
+import { Ed25519KeyIdentity } from "@icp-sdk/core/identity"
+import { IDL } from "@icp-sdk/core/candid"
+import type { Principal } from "@icp-sdk/core/principal"
+import { ClientManager } from "../src/client.js"
+import { Reactor } from "../src/reactor.js"
+import { pinPollingIdentity } from "../src/utils/agent.js"
+
+const CANISTER_ID = "ryjl3-tyaaa-aaaaa-aaaba-cai"
+const REQUEST_ID = new Uint8Array(32).fill(7)
+
+const idlFactory: IDL.InterfaceFactory = ({ IDL }) =>
+  IDL.Service({ transfer: IDL.Func([], [IDL.Nat], []) })
+
+/** What the boundary node answers when a call outlives the sync-call window. */
+const accepted = () => ({
+  requestId: REQUEST_ID,
+  response: {
+    ok: true,
+    status: 202,
+    statusText: "Accepted",
+    body: null,
+    headers: [],
+  },
+})
+
+/** A verified certificate with no request_status entry yet: the poll goes on. */
+const stillPending = () => ({
+  certificate: new Uint8Array(),
+  verifiedCertificate: {
+    lookup_path: () => ({ status: LookupPathStatus.Absent }),
+  },
+})
+
+/** No delay between polls. */
+const pollingOptions: PollingOptions = { strategy: async () => {} }
+
+interface SignedReadState {
+  body: {
+    content: {
+      request_type: string
+      sender: Principal
+      paths: Uint8Array[][]
+    }
+    sender_pubkey: Uint8Array
+  }
+}
+
+const senderOf = (request: unknown) =>
+  (request as SignedReadState).body.content.sender.toText()
+
+/**
+ * `Reactor.executeCall` captures the identity that submits an update call and
+ * hands it to the poll loop, so a sign-in or sign-out mid-poll cannot re-sign
+ * the request_status read for a call that has already committed. The replica
+ * only lets the original sender read request_status, so a read signed by anyone
+ * else is a 403, and a committed transfer surfaces as a failure.
+ *
+ * `HttpAgent.readState` ignores its identity parameter and signs with whatever
+ * the agent holds; the only thing it sends as given is a pre-signed request.
+ * These tests therefore look at the request each poll actually sends.
+ */
+describe("poll-time identity pinning", () => {
+  let clientManager: ClientManager
+  let submitter: Ed25519KeyIdentity
+  let next: Ed25519KeyIdentity
+
+  const reactor = (options: PollingOptions = pollingOptions) =>
+    new Reactor({
+      clientManager,
+      name: "ledger",
+      canisterId: CANISTER_ID,
+      idlFactory,
+      pollingOptions: options,
+    })
+
+  beforeEach(() => {
+    clientManager = new ClientManager({
+      queryClient: new QueryClient(),
+      agentOptions: { host: "https://icp-api.io" },
+    })
+    submitter = Ed25519KeyIdentity.generate()
+    next = Ed25519KeyIdentity.generate()
+    clientManager.updateAgent(submitter)
+    vi.spyOn(clientManager.agent, "call").mockResolvedValue(accepted() as never)
+  })
+
+  it("signs every poll with the submitting identity across a sign-in mid-poll", async () => {
+    const readState = vi
+      .spyOn(clientManager.agent, "readState")
+      // The first poll finds nothing yet, and the user signs in as someone
+      // else while it is in flight.
+      .mockImplementationOnce(async () => {
+        clientManager.updateAgent(next)
+        return stillPending() as never
+      })
+      .mockRejectedValueOnce(new Error("stop after the second poll"))
+
+    await reactor()
+      .callMethod({ functionName: "transfer" as never })
+      .catch(() => undefined)
+
+    expect(readState).toHaveBeenCalledTimes(2)
+    const [first, second] = readState.mock.calls.map((call) => call[3])
+    expect(senderOf(first)).toBe(submitter.getPrincipal().toText())
+    expect(senderOf(second)).toBe(submitter.getPrincipal().toText())
+    // The agent itself has moved on; only the in-flight call stayed pinned.
+    expect((await clientManager.agent.getPrincipal()).toText()).toBe(
+      next.getPrincipal().toText()
+    )
+  })
+
+  it("re-signs each poll for the submitted call's request_status path", async () => {
+    const readState = vi
+      .spyOn(clientManager.agent, "readState")
+      .mockResolvedValueOnce(stillPending() as never)
+      .mockRejectedValueOnce(new Error("stop after the second poll"))
+
+    await reactor()
+      .callMethod({ functionName: "transfer" as never })
+      .catch(() => undefined)
+
+    const [first, second] = readState.mock.calls.map(
+      (call) => call[3] as SignedReadState
+    )
+    // A fresh request per poll, so each carries its own ingress expiry.
+    expect(first).not.toBe(second)
+    for (const request of [first, second]) {
+      expect(request.body.content.request_type).toBe("read_state")
+      expect(request.body.sender_pubkey).toEqual(
+        submitter.getPublicKey().toDer()
+      )
+      const [[label, requestId]] = request.body.content.paths
+      expect(new TextDecoder().decode(label)).toBe("request_status")
+      expect(requestId).toEqual(REQUEST_ID)
+    }
+  })
+
+  it("leaves a callConfig-supplied agent to sign with its own identity", async () => {
+    // Guards against over-reach: the caller brought their own agent, and
+    // nothing is pinned for it, so its polls are invoked exactly as before.
+    const custom = {
+      call: vi.fn().mockResolvedValue(accepted()),
+      readState: vi
+        .fn()
+        .mockRejectedValue(new Error("stop after the first poll")),
+      createReadStateRequest: vi.fn(),
+    }
+
+    await reactor()
+      .callMethod({
+        functionName: "transfer" as never,
+        callConfig: { agent: custom as unknown as Agent },
+      })
+      .catch(() => undefined)
+
+    expect(custom.readState).toHaveBeenCalledTimes(1)
+    expect(custom.readState.mock.calls[0][3]).toBeUndefined()
+    expect(custom.createReadStateRequest).not.toHaveBeenCalled()
+  })
+
+  /**
+   * `pollForResponse` with `preSignReadStateRequest: true` builds its request
+   * through `createReadStateRequest` on the agent it was handed, passing no
+   * identity, and then sends it as the `request` argument on every poll. The
+   * SDK's own validator on that path rejects every `HttpAgent` request in
+   * 6.1.0 (it looks for `toHash` as an own property of the expiry, which is a
+   * prototype method), so it is exercised here at the wrapper, not end to end.
+   */
+  describe("the pinned agent's request builder", () => {
+    const requestStatus = () => ({
+      paths: [[new TextEncoder().encode("request_status"), REQUEST_ID]],
+    })
+
+    it("signs with the submitting identity when handed none", async () => {
+      clientManager.updateAgent(next)
+      const pinned = pinPollingIdentity(clientManager.agent, submitter)
+
+      // Runs the real builder against the real agent: a prototype delegate
+      // that let it run with the delegate as `this` would throw on the
+      // agent's private fields.
+      const request = await pinned.createReadStateRequest!(
+        requestStatus(),
+        undefined
+      )
+
+      expect(senderOf(request)).toBe(submitter.getPrincipal().toText())
+    })
+
+    it("lets an identity the caller names win over the pin", async () => {
+      const pinned = pinPollingIdentity(clientManager.agent, submitter)
+
+      const request = await pinned.createReadStateRequest!(
+        requestStatus(),
+        next
+      )
+
+      expect(senderOf(request)).toBe(next.getPrincipal().toText())
+    })
+
+    it("sends a request it is handed as given, without re-signing it", async () => {
+      // Guards against over-reach: a request the caller signed themselves is
+      // theirs, and `pollForResponse` reuses one across polls.
+      const theirs = await clientManager.agent.createReadStateRequest(
+        requestStatus(),
+        next
+      )
+      const readState = vi
+        .spyOn(clientManager.agent, "readState")
+        .mockRejectedValue(new Error("stop"))
+      const pinned = pinPollingIdentity(clientManager.agent, submitter)
+
+      await pinned
+        .readState(
+          { canisterId: CANISTER_ID },
+          requestStatus(),
+          undefined,
+          theirs
+        )
+        .catch(() => undefined)
+
+      expect(readState.mock.calls[0][3]).toBe(theirs)
+    })
+  })
+})

--- a/packages/react/tests/public-exports.test.ts
+++ b/packages/react/tests/public-exports.test.ts
@@ -78,6 +78,7 @@ const RUNTIME_EXPORTS: Record<string, "function" | "string" | "object"> = {
   toReactorQueryData: "function",
   processQueryCallResponse: "function",
   processUpdateCallResponse: "function",
+  pinPollingIdentity: "function",
   createPollingStrategy: "function",
   generateKey: "function",
   toHashableKeySegment: "function",


### PR DESCRIPTION
Closes #349.

## The bug

`processUpdateCallResponse` pinned the submitting identity by passing it as the third argument of the polling delegate's `readState`. `HttpAgent.readState` ignores that argument: the declaration names it `_identity`, and the body signs a fresh request with the agent's **current** identity every time. So the pin was dead, while the comments around it, `Reactor.executeCall`, and `client-agent-pinning.test.ts` all said it worked. That test only checked the `agent.call` argument, which the SDK does honour; nothing looked at the poll path.

An update that outlived the sync-call window (HTTP 202, then `pollForResponse`) and raced an `updateAgent()` had its `request_status` read signed by the new identity. The replica only lets the original sender read `request_status`, so it answered 403 for a call that had already committed, and the caller saw a `CallError` inviting a retry of a transfer that went through.

## The fix

The one input `readState` sends verbatim is a pre-signed `request`. The delegate now builds one per poll through `createReadStateRequest`, which does honour an explicit identity, and passes it as the fourth argument. A fresh request per poll keeps a fresh ingress expiry, exactly as the unpinned path does.

`createReadStateRequest` is overridden on the delegate as well, for two reasons:

- with `preSignReadStateRequest: true`, `pollForResponse` calls it on the agent it was handed and passes no identity, so the pinned one has to be the default;
- a prototype delegate must never let an `HttpAgent` method run with the delegate as `this`. Those methods touch private fields, which throw on any object that is not the instance itself. Before this change that path threw a `TypeError` (the "separate latent issue" the audit noted).

The wrapper lives in `pinPollingIdentity`, exported so it can be tested directly.

## Upstream, for you to weigh

While testing the pre-sign path I found that `preSignReadStateRequest: true` never reaches the read on `@icp-sdk/core` 6.1.0 at all, with or without ic-reactor. `pollForResponse` validates the built request by looking for `toHash` as an **own** property of the expiry, but `Expiry` defines it on the prototype, so every `HttpAgent` request is rejected with `Invalid read state request`. Reproduced against a raw `HttpAgent` with no ic-reactor code involved, and the check is unchanged on their `main`. I have not filed anything upstream; the code carries a note, and the pre-sign coverage here is at the wrapper rather than end to end.

## Verification

| gate | result |
| --- | --- |
| `@ic-reactor/core` tests | 298 passed, 2 skipped |
| `pnpm typecheck` (core) | clean |
| `pnpm format:check` | clean |

`pnpm verify:test-fails tests/reactor-poll-identity-pinning.test.ts --package core`: **5 of 6 fail on `main` and pass here.** The two end-to-end cases (mid-poll sign-in, fresh request per poll) fail on `main` on behaviour. The three wrapper-level cases fail on `main` because the export does not exist there, so they prove less on their own; the first of them runs the real builder against the real agent, which is what catches the private-field `TypeError`. The sixth passes either way by design: it guards that a `callConfig`-supplied agent stays unpinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)