### PR TITLE
fix(candid): build vector items at their own path in both form visitors

### DIFF
--- a/packages/candid/src/visitor/arguments/index.test.ts
+++ b/packages/candid/src/visitor/arguments/index.test.ts
@@ -1451,10 +1451,7 @@ describe("ArgumentFieldVisitor", () => {
       vecField.createItemField(7)
 
       // A later traversal on the same visitor starts from a clean stack.
-      const later = visitor.visitFunc(
-        IDL.Func([IDL.Text], [], []),
-        "greet"
-      )
+      const later = visitor.visitFunc(IDL.Func([IDL.Text], [], []), "greet")
       expect(later.args[0].name).toBe("[0]")
     })
   })

--- a/packages/candid/src/visitor/arguments/index.test.ts
+++ b/packages/candid/src/visitor/arguments/index.test.ts
@@ -1344,6 +1344,119 @@ describe("ArgumentFieldVisitor", () => {
       expect(item.label).toBe("Item 2")
       expect(item.displayLabel).toBe("Item 2")
     })
+
+    // Every nested node bakes its absolute name at visit time, so an item has
+    // to be a fresh visit at its own path, not the `[0]` template with the
+    // top-level name swapped: that hands item N children still bound to item 0.
+
+    it("names an item's nested fields under the item, not under [0]", () => {
+      const funcType = IDL.Func(
+        [IDL.Vec(IDL.Record({ name: IDL.Text, age: IDL.Nat }))],
+        [],
+        []
+      )
+      const meta = visitor.visitFunc(funcType, "addPeople")
+      const vecField = meta.args[0] as VectorField
+
+      const item = vecField.createItemField(3) as RecordField
+      expect(item.name).toBe("[0][3]")
+      expect(item.fields.map((f) => f.name).sort()).toEqual([
+        "[0][3].age",
+        "[0][3].name",
+      ])
+    })
+
+    it("gives every item its own child nodes", () => {
+      const funcType = IDL.Func(
+        [IDL.Vec(IDL.Record({ name: IDL.Text }))],
+        [],
+        []
+      )
+      const meta = visitor.visitFunc(funcType, "addPeople")
+      const vecField = meta.args[0] as VectorField
+
+      const third = vecField.createItemField(3) as RecordField
+      const fifth = vecField.createItemField(5) as RecordField
+      expect(third.fields).not.toBe(fifth.fields)
+      expect(third.fields[0]).not.toBe(fifth.fields[0])
+      expect(third.fields[0]).not.toBe(
+        (vecField.itemField as RecordField).fields[0]
+      )
+    })
+
+    it("keeps the vector's own path for a vector nested in a record", () => {
+      const funcType = IDL.Func(
+        [IDL.Record({ tags: IDL.Vec(IDL.Text) })],
+        [],
+        []
+      )
+      const meta = visitor.visitFunc(funcType, "update")
+      const record = meta.args[0] as RecordField
+      const vecField = record.fields[0] as VectorField
+
+      expect(vecField.name).toBe("[0].tags")
+      expect(vecField.createItemField(2).name).toBe("[0].tags[2]")
+    })
+
+    it("binds an optional inside an item to that item", () => {
+      const funcType = IDL.Func(
+        [IDL.Vec(IDL.Record({ memo: IDL.Opt(IDL.Text) }))],
+        [],
+        []
+      )
+      const meta = visitor.visitFunc(funcType, "transferBatch")
+      const vecField = meta.args[0] as VectorField
+
+      const item = vecField.createItemField(2) as RecordField
+      const memo = item.fields[0] as OptionalField
+      expect(memo.name).toBe("[0][2].memo")
+      expect(memo.innerField.name).toBe("[0][2].memo")
+    })
+
+    it("chains through a vector of vectors", () => {
+      const funcType = IDL.Func([IDL.Vec(IDL.Vec(IDL.Nat))], [], [])
+      const meta = visitor.visitFunc(funcType, "matrix")
+      const rows = meta.args[0] as VectorField
+
+      const row = rows.createItemField(1) as VectorField
+      expect(row.name).toBe("[0][1]")
+      expect(row.createItemField(2).name).toBe("[0][1][2]")
+    })
+
+    it("infers the item's text format the same way the template does", () => {
+      // The visit runs under the template's label, so a `vec text` called
+      // "emails" still yields email inputs; only the item's own label is
+      // replaced.
+      const funcType = IDL.Func([IDL.Vec(IDL.Text)], [], [])
+      const meta = visitor.visitFunc(funcType, "emails")
+      const vecField = meta.args[0] as VectorField
+      const item = vecField.createItemField(1)
+
+      expect(item.type).toBe("text")
+      if (item.type === "text" && vecField.itemField.type === "text") {
+        expect(item.format).toBe(vecField.itemField.format)
+        expect(item.inputProps).toEqual(vecField.itemField.inputProps)
+      }
+      expect(item.label).toBe("Item 1")
+    })
+
+    it("leaves the visitor's name stack as it found it", () => {
+      const funcType = IDL.Func(
+        [IDL.Record({ tags: IDL.Vec(IDL.Text) })],
+        [],
+        []
+      )
+      const meta = visitor.visitFunc(funcType, "update")
+      const vecField = (meta.args[0] as RecordField).fields[0] as VectorField
+      vecField.createItemField(7)
+
+      // A later traversal on the same visitor starts from a clean stack.
+      const later = visitor.visitFunc(
+        IDL.Func([IDL.Text], [], []),
+        "greet"
+      )
+      expect(later.args[0].name).toBe("[0]")
+    })
   })
 
   // ════════════════════════════════════════════════════════════════════════

--- a/packages/candid/src/visitor/arguments/index.ts
+++ b/packages/candid/src/visitor/arguments/index.ts
@@ -203,6 +203,23 @@ export class FieldVisitor<A = BaseActor> extends IDL.Visitor<
   }
 
   /**
+   * Execute function with the name stack replaced by one absolute path, then
+   * restore whatever was there. For closures that run after traversal has
+   * unwound — or, on a shared visitor, in the middle of someone else's — so
+   * the path they build is the one captured, not one relative to the stack
+   * they happen to find.
+   */
+  private atName<T>(name: string, fn: () => T): T {
+    const saved = this.nameStack
+    this.nameStack = name ? [name] : []
+    try {
+      return fn()
+    } finally {
+      this.nameStack = saved
+    }
+  }
+
+  /**
    * Get the current full name path for form binding.
    * Returns empty string for root level.
    */
@@ -544,13 +561,21 @@ export class FieldVisitor<A = BaseActor> extends IDL.Visitor<
       index: number,
       overrides?: { label?: string }
     ): FieldNode => {
-      // Replace [0] in template with actual index
       const itemName = name ? `${name}[${index}]` : `[${index}]`
       const itemLabel = overrides?.label ?? `Item ${index}`
 
+      // Re-run the visitor at the item's own path. Every nested node bakes its
+      // absolute name at visit time, so spreading the `[0]` template would
+      // hand item N children still named for item 0 — and the same child
+      // objects, shared across every item. The template's label is kept for
+      // the visit so text-format inference matches the template; only the
+      // item's own label is replaced.
+      const item = this.atName(itemName, () =>
+        ty.accept(this, `${label}_item`)
+      ) as FieldNode
+
       return {
-        ...itemField,
-        name: itemName,
+        ...item,
         label: itemLabel,
         displayLabel: formatLabel(itemLabel),
       }
@@ -589,9 +614,10 @@ export class FieldVisitor<A = BaseActor> extends IDL.Visitor<
       this.recursiveSchemas.set(typeName, schema)
     }
 
-    // Lazy extraction to prevent infinite loops
+    // Lazy extraction to prevent infinite loops. `name` is already absolute,
+    // so it replaces the stack rather than extending it.
     const extract = (): FieldNode =>
-      this.withName(name, () => ty.accept(this, label)) as FieldNode
+      this.atName(name, () => ty.accept(this, label)) as FieldNode
 
     // Helper to get inner default (evaluates lazily)
     const getInnerDefault = (): unknown => extract().defaultValue

--- a/packages/candid/src/visitor/candid/index.ts
+++ b/packages/candid/src/visitor/candid/index.ts
@@ -74,6 +74,22 @@ export class CandidFormVisitor<A = BaseActor> extends IDL.Visitor<
     return this.nameStack.join("")
   }
 
+  /**
+   * Run `fn` with the name stack replaced by one absolute path, then restore
+   * it. For closures that run after traversal has unwound — or, on the shared
+   * `MetadataReactor` instance, in the middle of someone else's — so the path
+   * they build is the one captured, not one relative to the stack they find.
+   */
+  private atName<T>(name: string, fn: () => T): T {
+    const saved = this.nameStack
+    this.nameStack = name ? [name] : []
+    try {
+      return fn()
+    } finally {
+      this.nameStack = saved
+    }
+  }
+
   public visitService(t: IDL.ServiceClass): FormServiceMeta<A> {
     const result = {} as FormServiceMeta<A>
     for (const [functionName, func] of t._fields) {
@@ -415,8 +431,12 @@ export class CandidFormVisitor<A = BaseActor> extends IDL.Visitor<
       ty.accept(this, `${label}_item`)
     ) as FormFieldNode
 
+    // Runs after traversal, when the stack is empty, so the vector's own path
+    // has to be re-seeded: pushing `[index]` alone named every item as if it
+    // sat at the root, `[2]` for a vector at `[0].tags`.
     const createItemField = (index: number, overrides?: { label?: string }) => {
-      return this.withName(`[${index}]`, () =>
+      const itemName = name ? `${name}[${index}]` : `[${index}]`
+      return this.atName(itemName, () =>
         ty.accept(this, overrides?.label ?? String(index))
       ) as FormFieldNode
     }
@@ -468,8 +488,9 @@ export class CandidFormVisitor<A = BaseActor> extends IDL.Visitor<
       defaultValue: undefined,
       schema,
       typeName: ty.name,
+      // `name` is already absolute, so it replaces the stack, not extends it.
       extract: () =>
-        this.withName(name, () => ty.accept(this, label)) as FormFieldNode,
+        this.atName(name, () => ty.accept(this, label)) as FormFieldNode,
     }
 
     this.recCache.set(t, node)

--- a/packages/candid/tests/unit/candid-form-visitor.test.ts
+++ b/packages/candid/tests/unit/candid-form-visitor.test.ts
@@ -1,0 +1,124 @@
+import { IDL } from "@icp-sdk/core/candid"
+import { describe, expect, it } from "vitest"
+import { CandidFormVisitor } from "../../src/visitor/candid/index.js"
+import type {
+  FormFieldNode,
+  FormVectorField,
+} from "../../src/visitor/candid/types.js"
+
+/**
+ * `createItemField` is a closure consumers call after traversal, when the
+ * visitor's name stack is empty (or, on the `MetadataReactor` instance every
+ * reactor shares, while it is busy with something else). The path it builds
+ * has to be the vector's own path plus the index, whatever the stack holds.
+ */
+describe("CandidFormVisitor createItemField", () => {
+  const visitor = new CandidFormVisitor()
+
+  const vectorAt = (
+    meta: { args: FormFieldNode[] },
+    pick: (arg: FormFieldNode) => FormFieldNode = (arg) => arg
+  ) => {
+    const field = pick(meta.args[0])
+    if (field.type !== "vector")
+      throw new Error(`expected a vector, got ${field.type}`)
+    return field as FormVectorField
+  }
+
+  const childOf = (field: FormFieldNode, key: string): FormFieldNode => {
+    if (field.type !== "record")
+      throw new Error(`expected a record, got ${field.type}`)
+    const child = field.fields.find((f) => f.label === key)
+    if (!child) throw new Error(`no field ${key}`)
+    return child
+  }
+
+  it("names a root vector's items under the argument's path", () => {
+    const meta = visitor.buildFunctionMeta(
+      IDL.Func([IDL.Vec(IDL.Text)], [], []),
+      "addTags"
+    )
+    const vec = vectorAt(meta)
+
+    expect(vec.name).toBe("[0]")
+    expect(vec.itemField.name).toBe("[0][0]")
+    // Not "[3]", which is the path of argument 3.
+    expect(vec.createItemField(3).name).toBe("[0][3]")
+  })
+
+  it("keeps the parent path for a vector nested in a record", () => {
+    const meta = visitor.buildFunctionMeta(
+      IDL.Func([IDL.Record({ tags: IDL.Vec(IDL.Text) })], [], []),
+      "update"
+    )
+    const vec = vectorAt(meta, (arg) => childOf(arg, "tags"))
+
+    expect(vec.name).toBe("[0].tags")
+    expect(vec.createItemField(2).name).toBe("[0].tags[2]")
+  })
+
+  it("names an item's nested fields under the item", () => {
+    const meta = visitor.buildFunctionMeta(
+      IDL.Func(
+        [IDL.Record({ posts: IDL.Vec(IDL.Record({ title: IDL.Text })) })],
+        [],
+        []
+      ),
+      "publish"
+    )
+    const vec = vectorAt(meta, (arg) => childOf(arg, "posts"))
+
+    const item = vec.createItemField(1)
+    expect(item.name).toBe("[0].posts[1]")
+    expect(childOf(item, "title").name).toBe("[0].posts[1].title")
+  })
+
+  it("chains through a vector of vectors", () => {
+    const meta = visitor.buildFunctionMeta(
+      IDL.Func([IDL.Vec(IDL.Vec(IDL.Nat))], [], []),
+      "matrix"
+    )
+    const rows = vectorAt(meta)
+
+    const row = rows.createItemField(1)
+    expect(row.name).toBe("[0][1]")
+    if (row.type !== "vector") throw new Error("expected a vector row")
+    expect(row.createItemField(2).name).toBe("[0][1][2]")
+  })
+
+  it("builds the item's path from the vector, not from whatever is on the stack", () => {
+    // Simulate the shared visitor being mid-way through another traversal:
+    // a caller invoking createItemField from inside a visit of a different
+    // type must still get the captured vector path.
+    const meta = visitor.buildFunctionMeta(
+      IDL.Func([IDL.Record({ tags: IDL.Vec(IDL.Text) })], [], []),
+      "update"
+    )
+    const vec = vectorAt(meta, (arg) => childOf(arg, "tags"))
+
+    let seenName: string | undefined
+    class Probe extends IDL.TextClass {
+      override accept<D, R>(v: IDL.Visitor<D, R>, d: D): R {
+        seenName = vec.createItemField(4).name
+        return super.accept(v, d)
+      }
+    }
+    visitor.buildFunctionMeta(
+      IDL.Func([IDL.Record({ x: new Probe() })], [], []),
+      "other"
+    )
+
+    expect(seenName).toBe("[0].tags[4]")
+  })
+
+  it("keeps a custom label", () => {
+    const meta = visitor.buildFunctionMeta(
+      IDL.Func([IDL.Vec(IDL.Text)], [], []),
+      "addTags"
+    )
+    const item = vectorAt(meta).createItemField(2, { label: "Second tag" })
+
+    expect(item.label).toBe("Second tag")
+    expect(item.name).toBe("[0][2]")
+  })
+})


### PR DESCRIPTION
Closes #351. Closes #352.

Both visitors bake every node's absolute form path at visit time, and both hand consumers a `createItemField(index)` closure that runs after traversal. Each got it wrong in its own way, and the fix shape is the same, so one PR.

## #351 — `FieldVisitor` (arguments)

`createItemField` spread the `[0]` template and rewrote only the top-level name. Every nested node keeps the name it was given at visit time, so for `vec record { name; age }` item 3 was named `[0][3]` but its children were still `[0][0].name` and `[0][0].age`. And they were the same child objects for every item. A TanStack Form rendering item 3 read and wrote item 0's values. This is the path `examples/tanstack-form-demo` binds.

It now re-runs the visitor at the item's own path. The visit runs under the template's label (`${label}_item`) so text-format inference is unchanged from the template — a `vec text` called `emails` still yields email inputs — and only the item's own label is replaced, so `Item N` and custom labels behave as before.

## #352 — `CandidFormVisitor`

`createItemField` pushed `[index]` onto the name stack, which is empty by the time a consumer calls the closure. A vector at `[0].tags` named its items `[2]`, and a root vector's items `[3]`, which is argument 3's path. It now seeds the vector path it captured.

## Shared mechanism

Both use a new private `atName(name, fn)` that **replaces** the stack for the duration of the closure instead of extending it, and restores it after. The result is the same whether the stack is empty or, on the `MetadataReactor.formVisitor` instance every reactor shares, in the middle of someone else's traversal. The `extract()` closures on recursive types had the same stack-relative shape and use it too; they were correct on an empty stack and wrong otherwise. That is the one change beyond the two issues, and it is a one-line swap in each visitor.

No public API change. `createItemField` signatures and the labels it produces are as before.

## Verification

| gate | result |
| --- | --- |
| `@ic-reactor/candid` tests | 404 passed |
| `pnpm typecheck` (candid) | clean |
| `pnpm format:check` | clean |

`pnpm verify:test-fails`, one file at a time (the script takes one):

- `tests/unit/candid-form-visitor.test.ts` (new): **6 of 6 fail on `main`**, including the mid-traversal probe.
- `src/visitor/arguments/index.test.ts`: **4 new cases fail on `main`** (nested child names, per-item child objects, optional inside an item, vec of vec). Three new cases pass either way by design: nested-vector path was already right in this visitor, text-format parity guards the label choice above, and the stack-restoration case guards `atName`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)