### PR TITLE
ci(release): gate every npm publish behind the npm-publish environment

### DIFF
--- a/.github/workflows/release-tools.yml
+++ b/.github/workflows/release-tools.yml
@@ -145,6 +145,15 @@ jobs:
     needs: [setup, preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Every publish leg deploys to the `npm-publish` environment, which carries a
+    # required reviewer and a deployment tag policy (v*, tools-v*, parser-v*) in
+    # repo settings. Preflight gates correctness and the `Release tags` ruleset
+    # gates who can create the tag; this is the only gate on the publish itself.
+    # npm versions are immutable, so a wrong publish can only be superseded.
+    # Self-approval is allowed, so for a solo maintainer it is a confirmation
+    # step, not a second-person requirement. Like preflight, it is read from the
+    # tagged revision: the tag policy is the part that holds regardless.
+    environment: npm-publish
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,15 @@ jobs:
     name: Release to npm
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Every publish leg deploys to the `npm-publish` environment, which carries a
+    # required reviewer and a deployment tag policy (v*, tools-v*, parser-v*) in
+    # repo settings. Preflight gates correctness and the `Release tags` ruleset
+    # gates who can create the tag; this is the only gate on the publish itself.
+    # npm versions are immutable, so a wrong publish can only be superseded.
+    # Self-approval is allowed, so for a solo maintainer it is a confirmation
+    # step, not a second-person requirement. Like preflight, it is read from the
+    # tagged revision: the tag policy is the part that holds regardless.
+    environment: npm-publish
     permissions:
       contents: write
       id-token: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,17 @@ If your CI needs to install private dependencies, create a **read-only** granula
 
 The release workflow also auto-selects a publish tag from the git tag name: prerelease tags containing a hyphen (e.g., `v3.0.0-beta.1`) are published with the `beta` tag; stable tags publish to `latest`.
 
+### Approving a release
+
+Pushing a release tag no longer publishes unattended. Both publish jobs (`release.yml` for `v*`, `release-tools.yml` for `tools-v*` and `parser-v*`) deploy to the `npm-publish` environment, which requires a reviewer to approve the run before any package is published. Preflight still runs first, so by the time the run pauses the tag has been checked against `main`, the manifests, the build, the tests and `verify:packages`. Approve it from the run's page under Actions, or from the pending-deployments prompt on the workflow run. Approving completes the release unchanged; rejecting it publishes nothing. npm versions are immutable, so this is the last point at which a wrong release can be stopped rather than superseded.
+
+The environment lives in repository settings (Settings → Environments → `npm-publish`) and carries:
+
+- a required reviewer (self-approval allowed, so for a solo maintainer this is a confirmation step, not a second-person requirement);
+- a deployment tag policy limited to `v*`, `tools-v*` and `parser-v*`, so a run from any other ref cannot deploy to it at all.
+
+The `environment:` key is read from the tagged revision, like the preflight, so a tag pointing at a commit that predates it would skip the pause. The tag policy is settings-enforced and holds regardless. The `Release tags` ruleset, which limits who can create those tags, is the third leg; none of the three is sufficient alone.
+
 ## Commits & PRs
 
 - Use clear, descriptive commit messages.


### PR DESCRIPTION
Closes #339.

## Problem

Pushing a release tag published to npm **unattended**. Both publish jobs mint an OIDC token and push to `latest`, with nobody between "a tag appeared" and "packages are live". Preflight gates correctness and the `Release tags` ruleset gates who can create the tag; nothing gated the publish itself. npm versions are immutable, so a wrong publish can only be superseded.

## Change

Both `release` jobs (`release.yml` for `v*`, `release-tools.yml` for `tools-v*` / `parser-v*`) now carry:

```yaml
environment: npm-publish
```

with a comment on why, and CONTRIBUTING.md gains an "Approving a release" section describing the pause, where to approve it, and the three-leg model (preflight, ruleset, environment) with the known limitation that the `environment:` key is read from the tagged revision.

## Needs one thing in repo settings before merging

The `npm-publish` environment does not exist yet. I tried to create it through the API and the session's permission policy blocked the settings write, so this is for you. Either in the UI (Settings → Environments → New environment → `npm-publish`, add yourself as required reviewer, set deployment branches and tags to "Selected" with tag rules `v*`, `tools-v*`, `parser-v*`), or:

```bash
gh api -X PUT repos/B3Pay/ic-reactor/environments/npm-publish \
  --input - <<'JSON'
{"reviewers":[{"type":"User","id":35742176}],"prevent_self_review":false,
 "deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}
JSON
for t in 'v*' 'tools-v*' 'parser-v*'; do
  gh api -X POST repos/B3Pay/ic-reactor/environments/npm-publish/deployment-branch-policies \
    -f name="$t" -f type=tag
done
```

(`35742176` is `b3hr4d`.) If the environment is missing when a tag is pushed, Actions creates it on the fly with **no** protection rules and the publish proceeds unattended, exactly as today. So create it first.

## Acceptance, per the issue

- a release tag pauses for approval before any package is published: the `release` job waits on the environment after preflight passes;
- approving completes the release unchanged: nothing else in the jobs changed;
- the deployment tag policy rejects a deploy from a non-release ref: settings-enforced by the tag rules above.

Not verifiable from a PR run, since these workflows only fire on tags. The next real tag is the test; the first `v3.12.2` will pause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)