### PR TITLE
fix(react): publish identity attributes the request itself signed in for

### DIFF
--- a/packages/react/src/auth/createIdentityAttributeHooks.ts
+++ b/packages/react/src/auth/createIdentityAttributeHooks.ts
@@ -39,9 +39,17 @@ export function createIdentityAttributeHooks(
     /**
      * A request started before a sign-out or an account switch resolves after
      * it, and publishing that result would put the previous user's decoded PII
-     * back on screen with no further auth event to clear it again. Results are
-     * therefore only committed while the principal that asked for them is still
-     * the one signed in.
+     * back on screen with no further auth event to clear it again. So a result
+     * is committed only when it is the signed-in user's own: it carries the
+     * principal that is current when it resolves, or the session has not
+     * changed since it was asked for.
+     *
+     * The first test is the one the default flow needs. With `signIn: true`
+     * the request itself signs the user in, so the principal seen before the
+     * request (none, for a first sign-in; the old account, for a switch made
+     * inside the provider window) is never the one the result belongs to.
+     * Comparing against the pre-request principal alone left the hook's
+     * `attributes` null after every successful first-time sign-in.
      */
     const isCurrent = useCallback(
       (requestedFor: string | undefined) => requestedFor === currentPrincipal(),
@@ -50,11 +58,14 @@ export function createIdentityAttributeHooks(
 
     const publishIfCurrent = useCallback(
       (requestedFor: string | undefined, result: IdentityAttributeResult) => {
-        if (!isCurrent(requestedFor)) return false
+        const current = currentPrincipal()
+        if (result.principal !== current && requestedFor !== current) {
+          return false
+        }
         setAttributes(result)
         return true
       },
-      [isCurrent]
+      [currentPrincipal]
     )
 
     const requestAttributes = useCallback(

--- a/packages/react/tests/auth/createAuthHooks.test.tsx
+++ b/packages/react/tests/auth/createAuthHooks.test.tsx
@@ -557,6 +557,145 @@ describe("useIdentityAttributes — PII is dropped when the principal changes", 
   })
 })
 
+describe("useIdentityAttributes — the request itself signs the user in", () => {
+  // With the default `signIn: true`, `request()` signs the user in and commits
+  // the new identity before it resolves. The principal seen before the request
+  // is therefore never the one the result belongs to: none for a first
+  // sign-in, the old account for a switch made inside the provider window.
+  // Every other test mocks the request at the manager level, so auth state
+  // never moves mid-request and this path stayed invisible.
+  let queryClient: QueryClient
+  let clientManager: ClientManager
+  let authentication: ReturnType<typeof makeAuthentication>
+  let identityAttributes: IdentityAttributesManager
+
+  const ADA = "aaaaa-aa"
+  const GRACE = "ryjl3-tyaaa-aaaaa-aaaba-cai"
+
+  const attributesOf = (principal: string, email: string) => ({
+    principal,
+    requestedKeys: ["openid:https://issuer.example.com:email"],
+    signedAttributes: {
+      data: new Uint8Array([1]),
+      signature: new Uint8Array([2]),
+    },
+    decodedAttributes: { email },
+    completedAt: new Date().toISOString(),
+  })
+
+  const signInAs = (principal: string) =>
+    (authentication as any).updateState({
+      identity: { getPrincipal: () => Principal.fromText(principal) },
+      isAuthenticated: true,
+    })
+
+  /** A request that, like the real one, commits the identity before resolving. */
+  const requestThatSignsInAs = (principal: string, email: string) =>
+    vi.spyOn(identityAttributes, "requestOpenId").mockImplementation(
+      (async () => {
+        signInAs(principal)
+        return attributesOf(principal, email)
+      }) as never
+    )
+
+  const request = async (result: { current: any }) => {
+    await act(async () => {
+      await result.current.requestOpenIdAttributes({
+        openIdProvider: "https://issuer.example.com",
+        keys: ["email"],
+        nonce: new Uint8Array([1, 2, 3]),
+      })
+    })
+  }
+
+  beforeEach(() => {
+    queryClient = makeQueryClient()
+    clientManager = makeClientManager(queryClient)
+    authentication = makeAuthentication(clientManager)
+    identityAttributes = new IdentityAttributesManager(authentication)
+    vi.spyOn(clientManager, "initialize").mockResolvedValue(clientManager)
+  })
+
+  it("publishes the result of a first-time sign-in-plus-attributes request", async () => {
+    // Signed out, then one click signs in and grants attributes: the
+    // documented "Continue with provider" flow.
+    requestThatSignsInAs(ADA, "ada@example.com")
+
+    const { useIdentityAttributes } =
+      createIdentityAttributeHooks(identityAttributes)
+    const { result } = renderHook(() => useIdentityAttributes(), {
+      wrapper: wrapper(queryClient),
+    })
+
+    await request(result)
+
+    expect(result.current.attributes?.principal).toBe(ADA)
+    expect(result.current.attributes?.decodedAttributes).toEqual({
+      email: "ada@example.com",
+    })
+    expect(result.current.attributeError).toBeNull()
+  })
+
+  it("publishes the result when the user switched accounts inside the provider window", async () => {
+    signInAs(ADA)
+    requestThatSignsInAs(GRACE, "grace@example.com")
+
+    const { useIdentityAttributes } =
+      createIdentityAttributeHooks(identityAttributes)
+    const { result } = renderHook(() => useIdentityAttributes(), {
+      wrapper: wrapper(queryClient),
+    })
+
+    await request(result)
+
+    // The result is the now-signed-in user's own.
+    expect(result.current.attributes?.principal).toBe(GRACE)
+    expect(result.current.attributes?.decodedAttributes).toEqual({
+      email: "grace@example.com",
+    })
+  })
+
+  it("still drops a result that belongs to a user who has since been switched away from", async () => {
+    // Guards the other direction: the account switched by some other path
+    // while the request was outstanding, and the result is the previous
+    // user's. Same shape as the sign-out race, with a different principal
+    // instead of none.
+    signInAs(ADA)
+    let release: (v: unknown) => void = () => {}
+    vi.spyOn(identityAttributes, "requestOpenId").mockImplementation(
+      () => new Promise((resolve) => (release = resolve)) as never
+    )
+
+    const { useIdentityAttributes } =
+      createIdentityAttributeHooks(identityAttributes)
+    const { result } = renderHook(() => useIdentityAttributes(), {
+      wrapper: wrapper(queryClient),
+    })
+
+    let pending!: Promise<unknown>
+    act(() => {
+      pending = result.current
+        .requestOpenIdAttributes({
+          openIdProvider: "https://issuer.example.com",
+          keys: ["email"],
+          nonce: new Uint8Array([1, 2, 3]),
+        })
+        .catch(() => undefined)
+    })
+
+    await act(async () => {
+      signInAs(GRACE)
+    })
+
+    await act(async () => {
+      release(attributesOf(ADA, "ada@example.com"))
+      await pending
+    })
+
+    expect(result.current.attributes).toBeNull()
+  })
+})
+
 describe("createAuthHooks — argument guard", () => {
   it("rejects a ClientManager with a message that names the mistake", () => {
     // TypeScript catches this; a JS caller used to get no error until render,

--- a/packages/react/tests/auth/createAuthHooks.test.tsx
+++ b/packages/react/tests/auth/createAuthHooks.test.tsx
@@ -591,12 +591,12 @@ describe("useIdentityAttributes — the request itself signs the user in", () =>
 
   /** A request that, like the real one, commits the identity before resolving. */
   const requestThatSignsInAs = (principal: string, email: string) =>
-    vi.spyOn(identityAttributes, "requestOpenId").mockImplementation(
-      (async () => {
+    vi
+      .spyOn(identityAttributes, "requestOpenId")
+      .mockImplementation((async () => {
         signInAs(principal)
         return attributesOf(principal, email)
-      }) as never
-    )
+      }) as never)
 
   const request = async (result: { current: any }) => {
     await act(async () => {


### PR DESCRIPTION
Closes #350.

## The bug

`useIdentityAttributes` captured the signed-in principal **before** calling `request()` and only published the result if that same principal was still signed in afterwards. With the default `signIn: true`, the request itself signs the user in and commits the new identity before it resolves. So the pre-request principal is never the one the result belongs to: `undefined` for a first sign-in, the old account for a switch made inside the provider window. After every successful first-time sign-in-plus-attributes flow the hook's `attributes` stayed `null` with no error. The README's "Continue with provider" button, which renders `attributes?.decodedAttributes.email`, reverted to its idle label after success.

The guard was added for the sign-out race (a request resolving after the user signed out must not put their PII back on screen) and never considered that the request is what signs the user in.

## The fix

A result is committed when it is the signed-in user's own, by either test:

- it carries the principal current at resolution, which is how the default flow ends; or
- the session has not changed since it was asked for, which keeps the `signIn: false` path and the existing tests' seeded results as they were.

A result for a user who has since signed out (current principal `undefined`) or been switched away from (a different principal) fails both and is dropped, exactly as before.

## Tests

Every existing hook test mocks the request at the manager level, so auth state never moved mid-request and this path was invisible to CI. The new suite commits an identity inside the mocked request, the way the real one does:

- first-time sign-in plus attributes publishes;
- an account switch inside the provider window publishes the new user's own result;
- a result for a user switched away from by another path is still dropped (guard, passes either way by design).

## Verification

| gate | result |
| --- | --- |
| `@ic-reactor/react` tests | 486 passed |
| `pnpm typecheck` (react) | clean |
| `pnpm format:check` | clean |
| `pnpm verify:test-fails tests/auth/createAuthHooks.test.tsx --package react` | 2 fail on `main`, pass here; the third is the guard |

No public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)