### PR TITLE
fix(core): unwrap display-shaped Result arms that carry no payload

### DIFF
--- a/packages/core/src/display-reactor.ts
+++ b/packages/core/src/display-reactor.ts
@@ -17,7 +17,7 @@ import {
   TransformKey,
 } from "./types/reactor.js"
 import { extractOkResult } from "./utils/helper.js"
-import { ValidationError } from "./errors/index.js"
+import { CanisterError, ValidationError } from "./errors/index.js"
 import {
   DisplayReactorParameters,
   DisplayValidator,
@@ -364,6 +364,19 @@ export class DisplayReactor<
     if (this.codecs.has(methodName)) {
       const codec = this.codecs.get(methodName)!
       transformedResult = transformResultWithCodec(codec.result, result)
+
+      // The display codec renders a null variant arm as `{ _type: key }` with
+      // no payload key, so Result<(), E>'s Ok and Result<T, ()>'s Err arrive
+      // here without the key extractOkResult looks for: an empty Err would be
+      // returned as the success value, an empty Ok as a truthy object where
+      // the declared display type is null. Unwrap those two shapes the way
+      // their raw forms unwrap. Arms with a payload keep their key.
+      if (isEmptyDisplayArm(transformedResult, OK_TAGS)) {
+        return null as ReactorReturnOk<A, M, T>
+      }
+      if (isEmptyDisplayArm(transformedResult, ERR_TAGS)) {
+        throw new CanisterError(null)
+      }
     }
 
     // 2. Extract Ok value from the TRANSFORMED (or raw) result
@@ -374,4 +387,24 @@ export class DisplayReactor<
       T
     >
   }
+}
+
+const OK_TAGS = ["Ok", "ok"]
+const ERR_TAGS = ["Err", "err"]
+
+/**
+ * A display-transformed variant arm with no payload is exactly `{ _type: key }`
+ * and nothing else. The key count is what separates it from a record that
+ * happens to carry a text field called `_type`, which keeps its other fields.
+ */
+function isEmptyDisplayArm(value: unknown, tags: readonly string[]): boolean {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false
+  }
+  const keys = Object.keys(value)
+  return (
+    keys.length === 1 &&
+    keys[0] === "_type" &&
+    tags.includes((value as { _type: unknown })._type as string)
+  )
 }

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -243,6 +243,24 @@ export function extractOkResult<T>(result: T): OkResult<T> {
     throw new CanisterError(result.err)
   }
 
+  // The display codec renders a variant as { _type: key, [key]: payload } and
+  // drops the payload key when the arm is `null`. So by the time a
+  // DisplayReactor result reaches here, { Ok: null } is { _type: "Ok" } and
+  // { Err: null } is { _type: "Err" } -- Result<(), E> and Result<T, ()> --
+  // and neither matched above. They unwrap the way their raw shapes do: an
+  // empty Ok is null, an empty Err throws. Arms with a payload keep the key
+  // and were caught above.
+  if ("_type" in result) {
+    switch (result._type) {
+      case "Ok":
+      case "ok":
+        return null as OkResult<T>
+      case "Err":
+      case "err":
+        throw new CanisterError(null)
+    }
+  }
+
   // Non-Result type, return as-is
   return result as OkResult<T>
 }

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -243,24 +243,6 @@ export function extractOkResult<T>(result: T): OkResult<T> {
     throw new CanisterError(result.err)
   }
 
-  // The display codec renders a variant as { _type: key, [key]: payload } and
-  // drops the payload key when the arm is `null`. So by the time a
-  // DisplayReactor result reaches here, { Ok: null } is { _type: "Ok" } and
-  // { Err: null } is { _type: "Err" } -- Result<(), E> and Result<T, ()> --
-  // and neither matched above. They unwrap the way their raw shapes do: an
-  // empty Ok is null, an empty Err throws. Arms with a payload keep the key
-  // and were caught above.
-  if ("_type" in result) {
-    switch (result._type) {
-      case "Ok":
-      case "ok":
-        return null as OkResult<T>
-      case "Err":
-      case "err":
-        throw new CanisterError(null)
-    }
-  }
-
   // Non-Result type, return as-is
   return result as OkResult<T>
 }

--- a/packages/core/tests/display-reactor-null-result.test.ts
+++ b/packages/core/tests/display-reactor-null-result.test.ts
@@ -6,7 +6,6 @@ import { ClientManager } from "../src/client.js"
 import { DisplayReactor } from "../src/display-reactor.js"
 import { Reactor } from "../src/reactor.js"
 import { CanisterError } from "../src/errors/index.js"
-import { extractOkResult } from "../src/utils/helper.js"
 
 /**
  * The display codec renders a variant as `{ _type: key, [key]: payload }` and
@@ -25,17 +24,21 @@ interface TestActor {
   unitErr: ActorMethod<[], { Ok: bigint } | { Err: null }>
   /** Motoko spelling of Result<(), ()> */
   motoko: ActorMethod<[], { ok: null } | { err: null }>
+  /** Not a Result: a record that happens to carry a text field named _type */
+  tagged: ActorMethod<[], { _type: string; value: bigint }>
 }
 
 const UnitOk = IDL.Variant({ Ok: IDL.Null, Err: IDL.Text })
 const UnitErr = IDL.Variant({ Ok: IDL.Nat, Err: IDL.Null })
 const Motoko = IDL.Variant({ ok: IDL.Null, err: IDL.Null })
+const Tagged = IDL.Record({ _type: IDL.Text, value: IDL.Nat })
 
 const idlFactory: IDL.InterfaceFactory = ({ IDL }) =>
   IDL.Service({
     unitOk: IDL.Func([], [UnitOk], ["query"]),
     unitErr: IDL.Func([], [UnitErr], ["query"]),
     motoko: IDL.Func([], [Motoko], ["query"]),
+    tagged: IDL.Func([], [Tagged], ["query"]),
   })
 
 const CANISTER_ID = "ryjl3-tyaaa-aaaaa-aaaba-cai"
@@ -126,19 +129,33 @@ describe("DisplayReactor unwraps Result arms that carry no payload", () => {
       )
     expect(error?.err).toBe("boom")
   })
-})
 
-describe("extractOkResult on the display variant shape", () => {
-  it("treats a tag with no payload key as an empty arm", () => {
-    expect(extractOkResult({ _type: "Ok" })).toBeNull()
-    expect(extractOkResult({ _type: "ok" })).toBeNull()
-    expect(() => extractOkResult({ _type: "Err" })).toThrow(CanisterError)
-    expect(() => extractOkResult({ _type: "err" })).toThrow(CanisterError)
+  it("leaves a record with a text field named _type alone", async () => {
+    // Guards against over-reach: only the codec's `{ _type: key }` shape, with
+    // no other key, is an empty arm. A record keeps its other fields.
+    const display = makeDisplay()
+    replyWith(display, Tagged, { _type: "Ok", value: 7n })
+
+    await expect(
+      display.callMethod({ functionName: "tagged" })
+    ).resolves.toEqual({ _type: "Ok", value: "7" })
+
+    const errLike = makeDisplay()
+    replyWith(errLike, Tagged, { _type: "Err", value: 7n })
+    await expect(
+      errLike.callMethod({ functionName: "tagged" })
+    ).resolves.toEqual({ _type: "Err", value: "7" })
   })
 
-  it("leaves other display variants alone", () => {
-    // A plain variant that is not a Result is still returned as-is.
-    const active = { _type: "Active" }
-    expect(extractOkResult(active)).toBe(active)
+  it("leaves the raw Reactor path untouched", async () => {
+    // The base Reactor never display-transforms, so a raw record with a
+    // `_type` field is returned exactly as decoded.
+    const raw = makeRaw()
+    replyWith(raw, Tagged, { _type: "Err", value: 7n })
+
+    await expect(raw.callMethod({ functionName: "tagged" })).resolves.toEqual({
+      _type: "Err",
+      value: 7n,
+    })
   })
 })

--- a/packages/core/tests/display-reactor-null-result.test.ts
+++ b/packages/core/tests/display-reactor-null-result.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi } from "vitest"
+import { QueryClient } from "@tanstack/query-core"
+import { IDL } from "@icp-sdk/core/candid"
+import type { ActorMethod } from "@icp-sdk/core/agent"
+import { ClientManager } from "../src/client.js"
+import { DisplayReactor } from "../src/display-reactor.js"
+import { Reactor } from "../src/reactor.js"
+import { CanisterError } from "../src/errors/index.js"
+import { extractOkResult } from "../src/utils/helper.js"
+
+/**
+ * The display codec renders a variant as `{ _type: key, [key]: payload }` and
+ * drops the payload key for a `null` arm. A Result whose Ok or Err arm carries
+ * no payload — Rust's `Result<(), E>` and `Result<T, ()>` — therefore reaches
+ * the unwrapping step as `{ _type: "Ok" }` or `{ _type: "Err" }`, which the
+ * raw-shape checks did not recognise: an empty Err came back as a success
+ * value, and an empty Ok came back as `{ _type: "Ok" }` where the declared
+ * display type is `null`. Both must unwrap exactly as the raw path does.
+ */
+
+interface TestActor {
+  /** Result<(), text> */
+  unitOk: ActorMethod<[], { Ok: null } | { Err: string }>
+  /** Result<nat, ()> */
+  unitErr: ActorMethod<[], { Ok: bigint } | { Err: null }>
+  /** Motoko spelling of Result<(), ()> */
+  motoko: ActorMethod<[], { ok: null } | { err: null }>
+}
+
+const UnitOk = IDL.Variant({ Ok: IDL.Null, Err: IDL.Text })
+const UnitErr = IDL.Variant({ Ok: IDL.Nat, Err: IDL.Null })
+const Motoko = IDL.Variant({ ok: IDL.Null, err: IDL.Null })
+
+const idlFactory: IDL.InterfaceFactory = ({ IDL }) =>
+  IDL.Service({
+    unitOk: IDL.Func([], [UnitOk], ["query"]),
+    unitErr: IDL.Func([], [UnitErr], ["query"]),
+    motoko: IDL.Func([], [Motoko], ["query"]),
+  })
+
+const CANISTER_ID = "ryjl3-tyaaa-aaaaa-aaaba-cai"
+
+const params = () => ({
+  clientManager: new ClientManager({ queryClient: new QueryClient() }),
+  name: "test",
+  canisterId: CANISTER_ID,
+  idlFactory,
+})
+const makeDisplay = () => new DisplayReactor<TestActor>(params())
+const makeRaw = () => new Reactor<TestActor>(params())
+
+const replyWith = (reactor: object, type: IDL.Type, value: unknown) =>
+  vi
+    .spyOn(reactor as any, "executeQuery")
+    .mockResolvedValue(IDL.encode([type], [value]))
+
+describe("DisplayReactor unwraps Result arms that carry no payload", () => {
+  it("throws CanisterError for an empty Err arm, as the raw path does", async () => {
+    const display = makeDisplay()
+    replyWith(display, UnitErr, { Err: null })
+
+    await expect(
+      display.callMethod({ functionName: "unitErr" })
+    ).rejects.toBeInstanceOf(CanisterError)
+  })
+
+  it("carries the same err as the raw path for an empty Err arm", async () => {
+    const display = makeDisplay()
+    const raw = makeRaw()
+    replyWith(display, UnitErr, { Err: null })
+    replyWith(raw, UnitErr, { Err: null })
+
+    const fromDisplay = await display
+      .callMethod({ functionName: "unitErr" })
+      .then(
+        () => undefined,
+        (e: CanisterError) => e
+      )
+    const fromRaw = await raw.callMethod({ functionName: "unitErr" }).then(
+      () => undefined,
+      (e: CanisterError) => e
+    )
+
+    expect(fromDisplay?.err).toBeNull()
+    expect(fromDisplay?.err).toEqual(fromRaw?.err)
+    expect(fromDisplay?.message).toBe(fromRaw?.message)
+  })
+
+  it("returns null for an empty Ok arm, as the raw path does", async () => {
+    const display = makeDisplay()
+    replyWith(display, UnitOk, { Ok: null })
+
+    await expect(display.callMethod({ functionName: "unitOk" })).resolves.toBe(
+      null
+    )
+  })
+
+  it("handles the Motoko spelling of both arms", async () => {
+    const ok = makeDisplay()
+    replyWith(ok, Motoko, { ok: null })
+    await expect(ok.callMethod({ functionName: "motoko" })).resolves.toBe(null)
+
+    const err = makeDisplay()
+    replyWith(err, Motoko, { err: null })
+    await expect(
+      err.callMethod({ functionName: "motoko" })
+    ).rejects.toBeInstanceOf(CanisterError)
+  })
+
+  it("still unwraps arms that carry a payload, in display form", async () => {
+    // Guards against over-reach: with a payload the key survives the
+    // transform and the raw-shape checks handle it.
+    const okWithPayload = makeDisplay()
+    replyWith(okWithPayload, UnitErr, { Ok: 42n })
+    await expect(
+      okWithPayload.callMethod({ functionName: "unitErr" })
+    ).resolves.toBe("42")
+
+    const errWithPayload = makeDisplay()
+    replyWith(errWithPayload, UnitOk, { Err: "boom" })
+    const error = await errWithPayload
+      .callMethod({ functionName: "unitOk" })
+      .then(
+        () => undefined,
+        (e: CanisterError) => e
+      )
+    expect(error?.err).toBe("boom")
+  })
+})
+
+describe("extractOkResult on the display variant shape", () => {
+  it("treats a tag with no payload key as an empty arm", () => {
+    expect(extractOkResult({ _type: "Ok" })).toBeNull()
+    expect(extractOkResult({ _type: "ok" })).toBeNull()
+    expect(() => extractOkResult({ _type: "Err" })).toThrow(CanisterError)
+    expect(() => extractOkResult({ _type: "err" })).toThrow(CanisterError)
+  })
+
+  it("leaves other display variants alone", () => {
+    // A plain variant that is not a Result is still returned as-is.
+    const active = { _type: "Active" }
+    expect(extractOkResult(active)).toBe(active)
+  })
+})


### PR DESCRIPTION
Closes #353.

## The bug

`DisplayReactor.transformResult` display-transforms the result first and unwraps it second. The display codec renders a variant as `{ _type: key, [key]: payload }` and **drops the payload key for a `null` arm**. So a top-level `Result<T, ()>` Err reached `extractOkResult` as `{ _type: "Err" }` and a `Result<(), E>` Ok as `{ _type: "Ok" }`. Neither matched the `Ok`/`ok`/`Err`/`err` key checks:

- an empty Err was **returned as the success value**, so hooks fired `onSuccess` with `{ _type: "Err" }` while a raw `Reactor` on the same bytes threw `CanisterError`;
- an empty Ok came back as a truthy `{ _type: "Ok" }` where the declared display type is `null`.

Arms with a payload were unaffected because the key survives the transform.

## The fix

`DisplayReactor.transformResult` now unwraps the two empty display shapes itself, right after the codec runs: exactly `{ _type: "Ok" | "ok" }` becomes `null`, exactly `{ _type: "Err" | "err" }` throws `CanisterError(null)`. That is the same error the raw path throws for `{ Err: null }`, same `err`, same message, so the two reactors agree on every Result shape.

"Exactly" means one key, and it is `_type`. Codex pointed out that a first cut put this in `extractOkResult`, which also serves the base `Reactor`, where a raw record with a text field named `_type` would have been misread. It is now confined to the display path, and a record keeps its other fields and is left alone on both paths. `extractOkResult` is unchanged.

Unwrapping before the transform, the other option the issue offers, would have handed `CanisterError.err` the raw payload (bigint, Principal) instead of the display form that consumers of `DisplayReactor` see everywhere else.

## Verification

| gate | result |
| --- | --- |
| `@ic-reactor/core` tests | 305 passed, 2 skipped |
| `pnpm typecheck` (core) | clean |
| `pnpm format:check` | clean |
| `pnpm verify:test-fails tests/display-reactor-null-result.test.ts --package core` | 4 of 7 fail on `main`, pass here |

The three that pass either way guard against over-reach: arms with a payload still unwrap in display form; a record with a `_type` text field is returned intact through `DisplayReactor`; and the same record through the base `Reactor` is returned exactly as decoded. One of the four compares the display and raw reactors on the same bytes and asserts the same `err` and message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)