### PR TITLE
fix(react): reset the agent to anonymous when a delegation lapses mid-session

### DIFF
--- a/packages/react/src/auth/authentication-manager.ts
+++ b/packages/react/src/auth/authentication-manager.ts
@@ -1,4 +1,5 @@
 import type { Identity } from "@icp-sdk/core/agent"
+import { AnonymousIdentity } from "@icp-sdk/core/agent"
 import type {
   AuthClientLike,
   AuthClientSignInOptions,
@@ -228,9 +229,13 @@ export class AuthenticationManager {
       if (stillValid) {
         return this.authState.identity || undefined
       }
-      // Expired — drop the stale flag and fall through to re-derive state,
-      // which resets the agent to the anonymous identity.
-      this.updateState({ isAuthenticated: false })
+      // Expired. Re-deriving state from the client will not help: the v8
+      // client keeps handing out the lapsed delegation from getIdentity()
+      // until signOut() runs (only a fresh page load purges it), so the
+      // expired identity would go straight back on the agent and every
+      // refetch would be signed with it. End the session explicitly.
+      await this.expireSession()
+      return undefined
     }
     if (this.authPromise) {
       return this.authPromise
@@ -267,17 +272,29 @@ export class AuthenticationManager {
             return undefined
           }
         }
-        const identity = await this.authClient!.getIdentity()
+        const clientIdentity = await this.authClient!.getIdentity()
         const isAuthenticated = await this.authClient!.isAuthenticated()
 
         if (revision !== this.authStateRevision) {
           // Superseded — leave whatever ran in the meantime in place.
           return this.authState.identity || undefined
         }
+        // A client that says it is not authenticated but still hands out a
+        // non-anonymous identity is holding a delegation it will no longer
+        // vouch for (expired, mid-session). Nothing may be signed with it.
+        const identity =
+          isAuthenticated || clientIdentity.getPrincipal().isAnonymous()
+            ? clientIdentity
+            : new AnonymousIdentity()
         // Restoring an anonymous session is the common first-load case; pushing
         // it through updateAgent would invalidate the whole query cache on
-        // every mount for nothing.
-        if (isAuthenticated || !identity.getPrincipal().isAnonymous()) {
+        // every mount for nothing. It is only skipped while the agent is
+        // anonymous too, so a lapsed delegation still gets replaced.
+        if (
+          isAuthenticated ||
+          !identity.getPrincipal().isAnonymous() ||
+          !this.agentIsAnonymous()
+        ) {
           this.clientManager.updateAgent(identity)
         }
         this.updateState({
@@ -471,6 +488,35 @@ export class AuthenticationManager {
       identityProvider:
         merged?.identityProvider ?? this.getDefaultIdentityProvider(),
     }
+  }
+
+  /** Whether the shared agent currently signs as the anonymous principal. */
+  private agentIsAnonymous(): boolean {
+    const installed = this.clientManager.identity
+    return installed === undefined || installed.getPrincipal().isAnonymous()
+  }
+
+  /**
+   * End a session whose delegation has lapsed: ask the client to forget it,
+   * put the anonymous identity on the agent -- which also sweeps the previous
+   * user's caller-scoped cache entries and refetches the rest anonymously --
+   * and publish the signed-out state. `signOut` failing changes nothing here:
+   * the delegation is already unusable, and the agent must not keep it.
+   */
+  private async expireSession() {
+    try {
+      await this.authClient?.signOut()
+    } catch {
+      // Nothing to keep; fall through to anonymous either way.
+    }
+    const identity = new AnonymousIdentity()
+    this.clientManager.updateAgent(identity)
+    this.updateState({
+      identity,
+      isAuthenticated: false,
+      isAuthenticating: false,
+      error: undefined,
+    })
   }
 
   private async syncStateFromClient(revision = this.authStateRevision) {

--- a/packages/react/tests/auth/authentication-manager.test.ts
+++ b/packages/react/tests/auth/authentication-manager.test.ts
@@ -536,6 +536,83 @@ describe("AuthenticationManager session hygiene", () => {
     expect(authentication.authState.isAuthenticated).toBe(false)
   })
 
+  it("resets the agent to anonymous when a delegation lapses mid-session", async () => {
+    // The v8 client keeps returning the lapsed delegation from getIdentity()
+    // until signOut() runs; only a fresh page load purges it. Re-deriving
+    // state from the client therefore put the expired identity straight back
+    // on the agent, every refetch was signed with it and failed, and
+    // getUserPrincipal() kept naming the signed-out user.
+    const authClient = createAuthClient()
+    const authentication = new AuthenticationManager({
+      clientManager,
+      authClient,
+    })
+    await authentication.login()
+    const updateAgent = vi.spyOn(clientManager, "updateAgent")
+
+    // The delegation lapses. The client says so, but still hands it out.
+    authClient.isAuthenticated.mockResolvedValue(false)
+    const lapsed = identity("aaaaa-aa")
+    authClient.getIdentity.mockReturnValue(lapsed)
+
+    const result = await authentication.authenticate()
+
+    expect(result).toBeUndefined()
+    expect(authClient.signOut).toHaveBeenCalledTimes(1)
+    expect(updateAgent).toHaveBeenCalledTimes(1)
+    expect(updateAgent.mock.calls[0][0].getPrincipal().isAnonymous()).toBe(true)
+    expect(clientManager.identity?.getPrincipal().isAnonymous()).toBe(true)
+    expect(authentication.authState.isAuthenticated).toBe(false)
+    expect(
+      authentication.authState.identity?.getPrincipal().isAnonymous()
+    ).toBe(true)
+  })
+
+  it("still drops the lapsed delegation when signOut fails", async () => {
+    // The delegation is already unusable; a storage error while forgetting it
+    // is no reason to keep signing with it.
+    const authClient = createAuthClient()
+    const authentication = new AuthenticationManager({
+      clientManager,
+      authClient,
+    })
+    await authentication.login()
+
+    authClient.isAuthenticated.mockResolvedValue(false)
+    authClient.signOut.mockRejectedValue(new Error("storage unavailable"))
+
+    await expect(authentication.authenticate()).resolves.toBeUndefined()
+
+    expect(clientManager.identity?.getPrincipal().isAnonymous()).toBe(true)
+    expect(authentication.authState.isAuthenticated).toBe(false)
+    expect(authentication.authState.error).toBeUndefined()
+  })
+
+  it("does not install an identity the client will not vouch for", async () => {
+    // Same shape on the main path: a client that reports not authenticated
+    // while still handing out a non-anonymous identity is holding a
+    // delegation it no longer stands behind.
+    const authClient = createAuthClient()
+    authClient.getIdentity.mockReturnValue(identity("aaaaa-aa"))
+    authClient.isAuthenticated.mockResolvedValue(false)
+    const authentication = new AuthenticationManager({
+      clientManager,
+      authClient,
+    })
+    const updateAgent = vi.spyOn(clientManager, "updateAgent")
+
+    const result = await authentication.authenticate()
+
+    expect(result?.getPrincipal().isAnonymous()).toBe(true)
+    for (const [installed] of updateAgent.mock.calls) {
+      expect(installed.getPrincipal().isAnonymous()).toBe(true)
+    }
+    expect(authentication.authState.isAuthenticated).toBe(false)
+    expect(
+      authentication.authState.identity?.getPrincipal().isAnonymous()
+    ).toBe(true)
+  })
+
   it("keeps the session when the expiry check itself fails", async () => {
     // A transient failure must not sign anyone out.
     const authClient = createAuthClient()


### PR DESCRIPTION
Closes #354.

## The bug

`authenticate()`'s expiry re-check dropped the `isAuthenticated` flag and fell through to re-derive state from the client, with a comment saying that "resets the agent to the anonymous identity". It never did with the real `@icp-sdk/auth` v8 client. Once the delegation lapses, `isAuthenticated()` turns false but `getIdentity()` keeps returning the stored `DelegationIdentity` until `signOut()` runs; only a fresh page load purges it. So the re-derived identity was the expired one, the `isAuthenticated || !anonymous` condition installed it on the agent again, every refetch triggered by `updateAgent`'s invalidation was signed with it and hard-failed instead of degrading to anonymous, and `getUserPrincipal()` / `useUserPrincipal()` kept naming the signed-out user. Each later `authenticate()` repeated the cycle.

The existing test mocked `getIdentity()` to return anonymous, a shape the real client never produces mid-session, and asserted only the state flag.

## The fix

On expiry the manager ends the session explicitly instead of trusting the client to have done it:

- ask the client to forget the delegation (`signOut`); a failure there changes nothing, since the delegation is already unusable and the agent must not keep it;
- install `AnonymousIdentity` through `updateAgent`, which also sweeps the previous user's caller-scoped cache entries and refetches the rest anonymously;
- publish `{ identity: anonymous, isAuthenticated: false }` and return `undefined`.

The main path gets the same rule: a client that reports not authenticated while handing out a non-anonymous identity is holding a delegation it no longer stands behind, so the anonymous identity is used instead. The first-load optimisation (skip `updateAgent` for an anonymous session) is kept, but now only while the agent is anonymous too, so a lapsed delegation is replaced rather than skipped.

## Not changed, for you to weigh

`useUserPrincipal` returns the principal of whatever identity is in state, and its doc comment says it returns `null` when not authenticated. After this fix it returns the **anonymous** principal after an expiry, which is the same thing it has always returned on first load before sign-in, so nothing regresses. Making it honour its own comment (`null` unless `isAuthenticated`) is a one-line change, but it would also stop returning the anonymous principal for signed-out users on every app, which some may use as a cache-key input. Separate decision.

## Verification

| gate | result |
| --- | --- |
| `@ic-reactor/react` tests | 489 passed |
| `pnpm typecheck` (react) | clean |
| `pnpm format:check` | clean |
| `pnpm verify:test-fails tests/auth/authentication-manager.test.ts --package react` | 3 new cases fail on `main`, pass here |

The three new cases model the real v8 client shape: `isAuthenticated()` false with `getIdentity()` still returning the delegation. They cover the mid-session expiry, the same with `signOut` failing, and the main-path variant. Each asserts the agent's installed identity and the published state, not just the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)