### PR TITLE
fix(react): type useActorMutation variables from the service in createActorHooks

### DIFF
--- a/packages/react/src/createActorHooks.ts
+++ b/packages/react/src/createActorHooks.ts
@@ -24,6 +24,7 @@ import {
   ReactorQueryData,
   BaseActor,
   FunctionName,
+  ReactorArgs,
   TransformKey,
 } from "@ic-reactor/core"
 import {
@@ -115,7 +116,10 @@ export type ActorHooks<Service, Transform extends TransformKey> = {
     config: MutationConfig<Service, Method, Transform>
   ) => UseMutationResult<
     ReactorReturnOk<Service, Method, Transform>,
-    ReactorReturnErr<Service, Method, Transform>
+    ReactorReturnErr<Service, Method, Transform>,
+    // Without this TVariables defaults to `unknown` and mutate/mutateAsync
+    // accept anything; the standalone hook and createMutation both pass it.
+    ReactorArgs<Service, Method, Transform>
   >
 
   useActorMethod: <Method extends FunctionName<Service>>(

--- a/packages/react/src/defineReactor.ts
+++ b/packages/react/src/defineReactor.ts
@@ -276,7 +276,9 @@ export function defineReactor<Service = BaseActor>(
       })
     : new Reactor<Service>(reactorConfig)
 
-  const hooks = createActorHooks(reactor)
+  // `reactor` is `any` above, which would let the overloads infer `Service`
+  // as `unknown` and type every hook's arguments as `never`.
+  const hooks = createActorHooks<Service, any>(reactor)
 
   // Auth is built on first use. `AuthenticationManager` dynamically imports the
   // optional `@icp-sdk/auth` peer as soon as it is constructed, and reactors

--- a/packages/react/tests/actor-hooks-mutation-variables.test-d.ts
+++ b/packages/react/tests/actor-hooks-mutation-variables.test-d.ts
@@ -1,0 +1,71 @@
+/**
+ * `createActorHooks(...).useActorMutation` must type its variables from the
+ * service, the way the standalone hook and `createMutation` already do. It
+ * used to omit `TVariables` from `UseMutationResult`, which defaults to
+ * `unknown`, so `mutate` / `mutateAsync` accepted any argument and a wrong
+ * shape surfaced only as an IDL encode failure at runtime. Every consumer of
+ * `createActorHooks` inherited the hole: `defineReactor` and generated hooks.
+ *
+ * Checked by `pnpm typecheck` (tests are in the typecheck project), not by
+ * vitest: each `@ts-expect-error` below is an unused directive, and therefore
+ * a compile error, if the wrong shape is accepted.
+ */
+import { describe, it, expectTypeOf } from "vitest"
+import type { ActorMethod } from "@icp-sdk/core/agent"
+import type { ActorHooks } from "../src/createActorHooks.js"
+import type { Reactor } from "@ic-reactor/core"
+import type { DefineReactorResult } from "../src/defineReactor.js"
+
+interface Service {
+  updateGreet: ActorMethod<[string], string>
+  transfer: ActorMethod<[{ to: string; amount: bigint }], { Ok: bigint }>
+}
+
+declare const hooks: ActorHooks<Service, "candid">
+declare const defined: DefineReactorResult<
+  Service,
+  "candid",
+  Reactor<Service, "candid">
+>
+
+describe("createActorHooks useActorMutation variables", () => {
+  it("types mutate and mutateAsync from the method's arguments", () => {
+    const { mutate, mutateAsync, variables } = hooks.useActorMutation({
+      functionName: "updateGreet",
+    })
+
+    expectTypeOf(mutate).parameter(0).toEqualTypeOf<[string]>()
+    expectTypeOf(mutateAsync).parameter(0).toEqualTypeOf<[string]>()
+    expectTypeOf(variables).toEqualTypeOf<[string] | undefined>()
+
+    mutate(["hello"])
+    // @ts-expect-error a number is not a string
+    mutate([123])
+    // @ts-expect-error an object is not the argument tuple
+    mutateAsync({ nope: true })
+    // @ts-expect-error a bare string is not the argument tuple
+    mutateAsync("hello")
+  })
+
+  it("carries record arguments through", () => {
+    const { mutateAsync } = hooks.useActorMutation({
+      functionName: "transfer",
+    })
+
+    mutateAsync([{ to: "aaaaa-aa", amount: 1n }])
+    // @ts-expect-error amount must be a bigint
+    mutateAsync([{ to: "aaaaa-aa", amount: 1 }])
+    // @ts-expect-error missing field
+    mutateAsync([{ to: "aaaaa-aa" }])
+  })
+
+  it("applies through defineReactor, which exposes the same hooks", () => {
+    const { mutateAsync } = defined.useActorMutation({
+      functionName: "updateGreet",
+    })
+
+    expectTypeOf(mutateAsync).parameter(0).toEqualTypeOf<[string]>()
+    // @ts-expect-error a number is not a string
+    mutateAsync([123])
+  })
+})


### PR DESCRIPTION
Closes #355.

## The bug

`ActorHooks.useActorMutation` returned `UseMutationResult<Ok, Err>` with the third type parameter omitted. `TVariables` defaults to `unknown`, so `mutate` / `mutateAsync` / `variables` accepted any argument and a wrong shape surfaced only as an IDL encode failure at runtime. The standalone hook (`UseActorMutationResult`) and `createMutation().useMutation()` both pass `ReactorArgs`, so this was an inconsistency, not a design choice. Every consumer inherited it: `defineReactor`'s returned hooks and all codegen-generated hooks.

## The fix

One line: pass `ReactorArgs<Service, Method, Transform>` as the third parameter, matching the siblings.

Tightening it surfaced a second gap. `defineReactor` builds its hooks from a `reactor` typed `any`, which let `createActorHooks` infer `Service` as `unknown` and type every method name as `never`; the loose mutation type had been hiding that from the compiler. It now calls `createActorHooks<Service, any>(reactor)`.

## Test

`tests/actor-hooks-mutation-variables.test-d.ts` pins the contract through both `ActorHooks` and `DefineReactorResult`: `expectTypeOf` on the `mutate` / `mutateAsync` parameter and `variables`, plus `@ts-expect-error` on a number for a string, an object for the tuple, a bare string, a `number` for a `bigint` field, and a missing field.

It is enforced by `pnpm typecheck` (the tests directory is in the typecheck project), not by vitest, so `verify:test-fails` does not apply. Checked by hand instead: with the two source files reverted to `main`, `tsc` reports **6 unused `@ts-expect-error` directives**; with them, the package type-checks clean.

## Verification

| gate | result |
| --- | --- |
| `pnpm typecheck` (react) | clean |
| `pnpm typecheck:examples` | 20 of 20 clean, so no example was relying on the hole |
| `@ic-reactor/react` tests | 489 passed |
| `pnpm format:check` | clean |

No runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)