### PR TITLE
ci(release): ask for one approval per release, not one per package

### DIFF
--- a/.github/workflows/release-tools.yml
+++ b/.github/workflows/release-tools.yml
@@ -140,20 +140,33 @@ jobs:
       - name: Verify published artifacts
         run: pnpm verify:packages
 
-  release:
-    name: Release to npm
+  # One approval for the whole release. The `npm-publish` environment carries a
+  # required reviewer and a deployment tag policy (v*, tools-v*, parser-v*) in
+  # repo settings. Preflight gates correctness and the `Release tags` ruleset
+  # gates who can create the tag; this is the only gate on the publish itself.
+  # npm versions are immutable, so a wrong publish can only be superseded.
+  # Self-approval is allowed, so for a solo maintainer it is a confirmation
+  # step, not a second-person requirement. Like preflight, it is read from the
+  # tagged revision: the tag policy is the part that holds regardless.
+  #
+  # It is its own job rather than a key on `release` because the publish
+  # matrix runs with max-parallel: 1, and an environment on a matrix job asks
+  # for approval once per leg as each one starts -- three prompts for v*.
+  approve:
+    name: Approve publish
     needs: [setup, preflight]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    # Every publish leg deploys to the `npm-publish` environment, which carries a
-    # required reviewer and a deployment tag policy (v*, tools-v*, parser-v*) in
-    # repo settings. Preflight gates correctness and the `Release tags` ruleset
-    # gates who can create the tag; this is the only gate on the publish itself.
-    # npm versions are immutable, so a wrong publish can only be superseded.
-    # Self-approval is allowed, so for a solo maintainer it is a confirmation
-    # step, not a second-person requirement. Like preflight, it is read from the
-    # tagged revision: the tag policy is the part that holds regardless.
+    timeout-minutes: 5
     environment: npm-publish
+    steps:
+      - name: Approved
+        run: echo "Publishing ${GITHUB_REF_NAME} was approved."
+
+  release:
+    name: Release to npm
+    needs: [setup, preflight, approve]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,20 +86,33 @@ jobs:
       - name: Verify published artifacts
         run: pnpm verify:packages
 
-  release:
+  # One approval for the whole release. The `npm-publish` environment carries a
+  # required reviewer and a deployment tag policy (v*, tools-v*, parser-v*) in
+  # repo settings. Preflight gates correctness and the `Release tags` ruleset
+  # gates who can create the tag; this is the only gate on the publish itself.
+  # npm versions are immutable, so a wrong publish can only be superseded.
+  # Self-approval is allowed, so for a solo maintainer it is a confirmation
+  # step, not a second-person requirement. Like preflight, it is read from the
+  # tagged revision: the tag policy is the part that holds regardless.
+  #
+  # It is its own job rather than a key on `release` because the publish
+  # matrix runs with max-parallel: 1, and an environment on a matrix job asks
+  # for approval once per leg as each one starts -- three prompts for v*.
+  approve:
+    name: Approve publish
     needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: npm-publish
+    steps:
+      - name: Approved
+        run: echo "Publishing ${GITHUB_REF_NAME} was approved."
+
+  release:
+    needs: [preflight, approve]
     name: Release to npm
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Every publish leg deploys to the `npm-publish` environment, which carries a
-    # required reviewer and a deployment tag policy (v*, tools-v*, parser-v*) in
-    # repo settings. Preflight gates correctness and the `Release tags` ruleset
-    # gates who can create the tag; this is the only gate on the publish itself.
-    # npm versions are immutable, so a wrong publish can only be superseded.
-    # Self-approval is allowed, so for a solo maintainer it is a confirmation
-    # step, not a second-person requirement. Like preflight, it is read from the
-    # tagged revision: the tag policy is the part that holds regardless.
-    environment: npm-publish
     permissions:
       contents: write
       id-token: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ The release workflow also auto-selects a publish tag from the git tag name: prer
 
 ### Approving a release
 
-Pushing a release tag no longer publishes unattended. Both publish jobs (`release.yml` for `v*`, `release-tools.yml` for `tools-v*` and `parser-v*`) deploy to the `npm-publish` environment, which requires a reviewer to approve the run before any package is published. Preflight still runs first, so by the time the run pauses the tag has been checked against `main`, the manifests, the build, the tests and `verify:packages`. Approve it from the run's page under Actions, or from the pending-deployments prompt on the workflow run. Approving completes the release unchanged; rejecting it publishes nothing. npm versions are immutable, so this is the last point at which a wrong release can be stopped rather than superseded.
+Pushing a release tag no longer publishes unattended. Both release workflows (`release.yml` for `v*`, `release-tools.yml` for `tools-v*` and `parser-v*`) run an `Approve publish` job against the `npm-publish` environment, which requires a reviewer to approve the run once before any package is published; every package in the release then publishes on that single approval. Preflight still runs first, so by the time the run pauses the tag has been checked against `main`, the manifests, the build, the tests and `verify:packages`. Approve it from the run's page under Actions, or from the pending-deployments prompt on the workflow run. Approving completes the release unchanged; rejecting it publishes nothing. npm versions are immutable, so this is the last point at which a wrong release can be stopped rather than superseded.
 
 The environment lives in repository settings (Settings → Environments → `npm-publish`) and carries:
 


### PR DESCRIPTION
Follow-up to #378, from the first live run.

## What happened on v3.12.2

The `npm-publish` environment sat directly on the publish matrix, which runs with `max-parallel: 1`. An environment on a matrix job asks for approval as each leg starts, so the release prompted three times: core, then react, then candid.

## Change

The gate moves to its own `Approve publish` job between preflight and the matrix, in both `release.yml` and `release-tools.yml`. The publish jobs `need` it and no longer carry `environment:`. One approval, then every package in the release publishes in order as before. The required reviewer and the deployment tag policy on the environment are unchanged, and the tag policy still applies since the approve job is what deploys to it.

CONTRIBUTING.md's "Approving a release" section is adjusted to say once.

## Note on OIDC

npm trusted publishing was configured against the workflow filename, not an environment name, so removing `environment:` from the publish jobs restores exactly the token claims 3.12.1 published with. 3.12.2 published with the environment claim present, which npm accepted as well.

Only exercisable by a tag; the next release is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)