### PR TITLE
fix(candid): rebuild every display codec when initialize() replaces the service

### DIFF
--- a/packages/candid/src/display-reactor.ts
+++ b/packages/candid/src/display-reactor.ts
@@ -140,15 +140,24 @@ export class CandidDisplayReactor<
 
     this.service = idlFactory({ IDL })
 
-    // Re-initialize codecs after service is updated
-    this.reinitializeCodecs()
+    // The service was replaced wholesale, and a codec is a snapshot of one
+    // signature: it has to be rebuilt for every method, or a method that
+    // changed shape — a `funcClass` that disagrees with the fetched interface,
+    // a `registerMethod` guess corrected here, a canister upgraded between two
+    // calls to initialize() — keeps transforming args and results against the
+    // old signature while getServiceInterface() reports the new one.
+    this.reinitializeCodecs({ rebuild: true })
   }
 
   /**
    * Re-initialize the display codecs after the service has been updated.
    * This is called automatically after initialize() or registerMethod().
+   *
+   * By default only methods without a codec get one, which is what the
+   * additive `registerMethod` path needs. `rebuild` drops every existing codec
+   * first, for when the whole service has been replaced.
    */
-  private reinitializeCodecs(): void {
+  private reinitializeCodecs({ rebuild = false } = {}): void {
     const fields = this.getServiceInterface()?._fields
     if (!fields) return
 
@@ -157,6 +166,8 @@ export class CandidDisplayReactor<
       string,
       { args: any; result: any }
     >
+
+    if (rebuild) codecs.clear()
 
     for (const [methodName, funcType] of fields) {
       // Skip if already exists

--- a/packages/candid/tests/unit/display-reactor-reinitialize.test.ts
+++ b/packages/candid/tests/unit/display-reactor-reinitialize.test.ts
@@ -1,0 +1,103 @@
+import { ClientManager } from "@ic-reactor/core"
+import { HttpAgent } from "@icp-sdk/core/agent"
+import { IDL } from "@icp-sdk/core/candid"
+import { describe, expect, it, vi } from "vitest"
+import { CandidDisplayReactor } from "../../src/display-reactor.js"
+
+/**
+ * A display codec is a snapshot of one method signature, built when the codec
+ * map is (re)initialised. `initialize()` replaces the whole service, so every
+ * codec has to be rebuilt with it; skipping the ones that already existed left
+ * a method that changed shape transforming against the old signature while
+ * `getServiceInterface()` reported the new one.
+ */
+
+function createMockClientManager(): ClientManager {
+  const agent = HttpAgent.createSync({ host: "https://ic0.app" })
+  return {
+    agent,
+    registerCanisterId: () => {},
+    subscribe: () => () => {},
+    queryClient: {
+      invalidateQueries: () => Promise.resolve(),
+      ensureQueryData: () => Promise.resolve(undefined),
+      getQueryData: () => undefined,
+    },
+  } as unknown as ClientManager
+}
+
+const V1 = `service : { balance : () -> (nat) query; }`
+const V2 = `service : { balance : () -> (record { amount : nat }) query; }`
+const V2_RESULT = IDL.Record({ amount: IDL.Nat })
+
+const replyWith = (reactor: object, type: IDL.Type, value: unknown) =>
+  vi
+    .spyOn(reactor as any, "executeQuery")
+    .mockResolvedValue(IDL.encode([type], [value]))
+
+const codecsOf = (reactor: object) =>
+  (reactor as any).codecs as Map<string, { args: unknown; result: unknown }>
+
+describe("CandidDisplayReactor rebuilds codecs when the service is replaced", () => {
+  it("transforms with the new signature after a second initialize()", async () => {
+    // A canister upgraded between two calls: balance() now returns a record.
+    const reactor = new CandidDisplayReactor({
+      name: "ledger",
+      canisterId: "aaaaa-aa",
+      clientManager: createMockClientManager(),
+      candid: V1,
+    })
+    await reactor.initialize()
+    const before = codecsOf(reactor).get("balance")
+
+    ;(reactor as any).candidSource = V2
+    await reactor.initialize()
+    replyWith(reactor, V2_RESULT, { amount: 5n })
+
+    expect(codecsOf(reactor).get("balance")).not.toBe(before)
+    await expect(
+      reactor.callMethod({ functionName: "balance" as never })
+    ).resolves.toEqual({ amount: "5" })
+  })
+
+  it("replaces a codec built from funcClass once the real interface arrives", async () => {
+    // Usable immediately from a func-record guess, then corrected by the
+    // fetched interface, which disagrees.
+    const reactor = new CandidDisplayReactor({
+      name: "ledger",
+      canisterId: "aaaaa-aa",
+      clientManager: createMockClientManager(),
+      funcClass: {
+        methodName: "balance",
+        func: IDL.Func([], [IDL.Nat], ["query"]),
+      },
+      candid: V2,
+    })
+    await reactor.initialize()
+    replyWith(reactor, V2_RESULT, { amount: 5n })
+
+    await expect(
+      reactor.callMethod({ functionName: "balance" as never })
+    ).resolves.toEqual({ amount: "5" })
+  })
+
+  it("keeps existing codecs when registerMethod adds one", async () => {
+    // Guards against over-reach: the additive path stays additive.
+    const reactor = new CandidDisplayReactor({
+      name: "ledger",
+      canisterId: "aaaaa-aa",
+      clientManager: createMockClientManager(),
+      candid: V1,
+    })
+    await reactor.initialize()
+    const before = codecsOf(reactor).get("balance")
+
+    await reactor.registerMethod({
+      functionName: "name",
+      candid: "() -> (text) query",
+    })
+
+    expect(codecsOf(reactor).get("balance")).toBe(before)
+    expect(codecsOf(reactor).has("name")).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #356.

## The bug

`CandidDisplayReactor.initialize()` replaced `this.service` wholesale and then called `reinitializeCodecs()`, which skipped any method that already had a codec. A codec is a snapshot of one signature, keyed by method name only, so a method whose shape changed kept transforming args and results against the old signature while `getServiceInterface()` reported the new one. Three ways to get there: a `funcClass` that disagrees with the fetched interface, a `registerMethod` guess later corrected by `initialize()`, or a canister upgraded between two calls to `initialize()`. The symptom is silently wrong display data (bigints not stringified, optionals not unwrapped) or an IDL encode error. `MetadataDisplayReactor` inherited the args-path half.

## The fix

`reinitializeCodecs` gains a `rebuild` option that clears the map first. `initialize()` passes it, since the whole service was replaced. `registerMethod` keeps the default skip-if-present, which is what the additive path needs.

## Verification

| gate | result |
| --- | --- |
| `@ic-reactor/candid` tests | 411 passed |
| `pnpm typecheck` (candid) | clean |
| `pnpm format:check` | clean |
| `pnpm verify:test-fails tests/unit/display-reactor-reinitialize.test.ts --package candid` | 2 of 3 fail on `main`, pass here |

The two that catch it: a second `initialize()` after the method's return type changed from `nat` to a record, and a `funcClass` guess corrected by the fetched interface, both asserting the display-transformed call result. The third guards that `registerMethod` still leaves existing codecs untouched (same object before and after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)