### PR TITLE
fix(candid): build a recursive type's form node per occurrence

### DIFF
--- a/packages/candid/src/visitor/candid/index.ts
+++ b/packages/candid/src/visitor/candid/index.ts
@@ -57,7 +57,6 @@ export class CandidFormVisitor<A = BaseActor> extends IDL.Visitor<
   string,
   FormFieldNode | FormArgumentsMeta | FormServiceMeta<A>
 > {
-  private recCache = new Map<IDL.RecClass<any>, FormFieldNode>()
   private recursiveSchemas: Map<string, z.ZodTypeAny> = new Map()
   private nameStack: string[] = []
 
@@ -458,7 +457,7 @@ export class CandidFormVisitor<A = BaseActor> extends IDL.Visitor<
   }
 
   public visitRec<T>(
-    t: IDL.RecClass<T>,
+    _t: IDL.RecClass<T>,
     ty: IDL.ConstructType<T>,
     label: string
   ): FormFieldNode {
@@ -466,10 +465,11 @@ export class CandidFormVisitor<A = BaseActor> extends IDL.Visitor<
     const typeName = ty.name || "RecursiveType"
     let schema: z.ZodTypeAny
 
-    if (this.recCache.has(t)) {
-      return this.recCache.get(t)!
-    }
-
+    // Only the schema is shared between occurrences. The node itself bakes in
+    // the path and label of the place it was met, so caching it per RecClass
+    // handed every later occurrence — a second argument, another method, and
+    // on the MetadataReactor instance every reactor shares, another service —
+    // the first one's path, and the same object.
     if (this.recursiveSchemas.has(typeName)) {
       schema = this.recursiveSchemas.get(typeName)!
     } else {
@@ -493,7 +493,6 @@ export class CandidFormVisitor<A = BaseActor> extends IDL.Visitor<
         this.atName(name, () => ty.accept(this, label)) as FormFieldNode,
     }
 
-    this.recCache.set(t, node)
     return node
   }
 

--- a/packages/candid/tests/unit/candid-form-visitor.test.ts
+++ b/packages/candid/tests/unit/candid-form-visitor.test.ts
@@ -122,3 +122,80 @@ describe("CandidFormVisitor createItemField", () => {
     expect(item.name).toBe("[0][2]")
   })
 })
+
+/**
+ * A recursive type's node bakes in the path and label of the place it was
+ * met. It used to be cached per RecClass, so every later occurrence — a
+ * second argument, another method, and on the shared MetadataReactor visitor
+ * another service — got the first one's path, and the same object.
+ */
+describe("CandidFormVisitor recursive types", () => {
+  const visitor = new CandidFormVisitor()
+
+  const list = () => {
+    const List = IDL.Rec()
+    List.fill(IDL.Opt(IDL.Record({ head: IDL.Nat, tail: List })))
+    return List
+  }
+
+  const meta = (service: IDL.ServiceClass) =>
+    visitor.visitService(service) as unknown as Record<
+      string,
+      { args: FormFieldNode[] }
+    >
+
+  it("names each occurrence by its own path", () => {
+    const List = list()
+    const m = meta(
+      IDL.Service({
+        a: IDL.Func([List], [], []),
+        b: IDL.Func([IDL.Text, List], [], []),
+      })
+    )
+
+    expect(m.a.args[0].name).toBe("[0]")
+    expect(m.b.args[1].name).toBe("[1]")
+    expect(m.b.args[1]).not.toBe(m.a.args[0])
+  })
+
+  it("extracts the inner type under the occurrence's own path", () => {
+    const List = list()
+    const m = meta(IDL.Service({ b: IDL.Func([IDL.Text, List], [], []) }))
+    const rec = m.b.args[1]
+    if (rec.type !== "recursive") throw new Error("expected a recursive node")
+
+    const inner = rec.extract()
+    expect(inner.name).toBe("[1]")
+    if (inner.type !== "optional") throw new Error("expected an optional")
+    const record = inner.innerField
+    if (record.type !== "record") throw new Error("expected a record")
+    expect(record.fields.map((f) => f.name).sort()).toEqual([
+      "[1].head",
+      "[1].tail",
+    ])
+  })
+
+  it("does not hand a later service the earlier one's node", () => {
+    const List = list()
+    const first = meta(IDL.Service({ a: IDL.Func([List], [], []) }))
+    const second = meta(
+      IDL.Service({ c: IDL.Func([IDL.Text, IDL.Text, List], [], []) })
+    )
+
+    expect(second.c.args[2].name).toBe("[2]")
+    expect(second.c.args[2]).not.toBe(first.a.args[0])
+  })
+
+  it("shares one validation schema per recursive type", () => {
+    // Guards the part that is meant to be shared.
+    const List = list()
+    const m = meta(
+      IDL.Service({
+        a: IDL.Func([List], [], []),
+        b: IDL.Func([IDL.Text, List], [], []),
+      })
+    )
+
+    expect(m.b.args[1].schema).toBe(m.a.args[0].schema)
+  })
+})


### PR DESCRIPTION
Closes #357.

## The bug

`CandidFormVisitor.visitRec` cached the built node per `RecClass`. The node bakes in `name` (the current path) and `label` from the place it was met, so every later occurrence got the first one's path, and the same object. For `service { a: (List) -> (); b: (text, List) -> () }` the second argument of `b` was named `[0]` instead of `[1]`, and `extract()` reproduced the wrong path for everything nested. `MetadataReactor` holds this visitor as a static, so the stale node also crossed services that share the same `RecClass`.

## The fix

Only the validation schema is shared now, per type name, which is exactly what the sibling `FieldVisitor` in `visitor/arguments` already does. The node is rebuilt on every visit with the current path and label. The `recCache` field is gone.

The returns visitor has a similar per-`RecClass` cache, but its nodes carry no form path, only a label, so it is not this bug; left alone.

## Verification

| gate | result |
| --- | --- |
| `@ic-reactor/candid` tests | 411 passed |
| `pnpm typecheck` (candid) | clean |
| `pnpm format:check` | clean |
| `pnpm verify:test-fails tests/unit/candid-form-visitor.test.ts --package candid` | 3 new cases fail on `main`, pass here |

The three: per-occurrence naming within one service, `extract()` placing the inner record's fields under `[1]`, and a later service not receiving the earlier one's node. A fourth guards that the schema is still shared between occurrences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)