### PR TITLE
fix(packaging): zod is a dependency only, and candid depends on the parser it imports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,20 @@ jobs:
             fi
           done
 
+      # @ic-reactor/candid depends on @ic-reactor/parser at `workspace:^`, which
+      # pnpm pack rewrites to a caret on the parser's *local* version. A parser
+      # bumped in the tree but not yet published as parser-v* would leave the
+      # published candid unresolvable for every consumer.
+      - name: Candid's parser dependency must exist on npm
+        run: |
+          set -euo pipefail
+          PARSER="$(node -p "require('./packages/parser/package.json').version")"
+          if ! npm view "@ic-reactor/parser@${PARSER}" version >/dev/null 2>&1; then
+            echo "::error::@ic-reactor/candid depends on @ic-reactor/parser@^${PARSER}, which is not on npm. Publish parser-v${PARSER} first."
+            exit 1
+          fi
+          echo "@ic-reactor/parser@${PARSER} is on npm"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter '!./examples/**'
 

--- a/docs/src/content/docs/packages/candid/candidadapter.mdx
+++ b/docs/src/content/docs/packages/candid/candidadapter.mdx
@@ -136,11 +136,12 @@ Load the local WASM parser for offline compilation.
 
 ```typescript
 import { CandidAdapter } from "@ic-reactor/candid"
-import "@ic-reactor/parser" // Required peer dependency
 
 const adapter = new CandidAdapter({ clientManager })
 
-// Load the parser (only needed once)
+// Load the parser (only needed once). It imports @ic-reactor/parser itself:
+// the package is a dependency of @ic-reactor/candid, so do not import it
+// from your app unless you also install it directly.
 await adapter.loadParser()
 
 // Now compileLocal works
@@ -241,7 +242,6 @@ for (const [name, func] of service._fields) {
 
 ```typescript
 import { CandidAdapter } from "@ic-reactor/candid"
-import "@ic-reactor/parser"
 
 const adapter = new CandidAdapter({ clientManager })
 

--- a/docs/src/content/docs/packages/candid/candidadapter.mdx
+++ b/docs/src/content/docs/packages/candid/candidadapter.mdx
@@ -19,7 +19,7 @@ Fetching the Candid source and compiling it to JavaScript are two separate steps
 
 **Compiling to JavaScript:**
 
-1. **Local parser** (preferred) — the optional [`@ic-reactor/parser`](/v3/packages/parser) WASM module, auto-loaded when installed
+1. **Local parser** (preferred) — the [`@ic-reactor/parser`](/v3/packages/parser) WASM module, a dependency of this package, loaded on first use
 2. **didjs canister** (fallback) — remote `did_to_js` call
 
 ```typescript
@@ -100,8 +100,8 @@ console.log(candidSource)
 
 <Aside type="note">
   This method queries the canister's `candid` metadata first, then falls back to
-  the `__get_candid_interface_tmp_hack` query method. It doesn't parse or compile
-  the Candid.
+  the `__get_candid_interface_tmp_hack` query method. It doesn't parse or
+  compile the Candid.
 </Aside>
 
 ---
@@ -122,7 +122,7 @@ const { idlFactory } = await adapter.parseCandidSource(candidSource)
 
 This method:
 
-1. Tries the local parser first, auto-loading `@ic-reactor/parser` if it is installed
+1. Tries the local parser first, loading `@ic-reactor/parser` on first use
 2. Falls back to remote compilation via the didjs canister
 
 It is the only method that returns a `CandidDefinition` — `compileLocal` and

--- a/docs/src/content/docs/packages/candid/index.mdx
+++ b/docs/src/content/docs/packages/candid/index.mdx
@@ -39,24 +39,25 @@ Most IC applications know which canisters they'll interact with at build time. B
     display
   </Card>
   <Card title="CandidFormVisitor" icon="list-format">
-    Generate form metadata from Candid IDL with schema, component, and render hints
+    Generate form metadata from Candid IDL with schema, component, and render
+    hints
   </Card>
   <Card title="Local Parsing" icon="seti:config">
-    Optional WASM parser for fast, offline Candid compilation
+    Bundled WASM parser for fast, offline Candid compilation, loaded on first
+    use
   </Card>
 </CardGrid>
 
 ## Installation
 
 ```bash
-npm install @ic-reactor/candid @ic-reactor/core @icp-sdk/core @tanstack/query-core zod
+npm install @ic-reactor/candid @ic-reactor/core @icp-sdk/core @tanstack/query-core
 ```
 
-For local parsing (recommended for production):
-
-```bash
-npm install @ic-reactor/parser
-```
+`@ic-reactor/parser` is a dependency, so local parsing works out of the box.
+The adapter imports it on the first parse and bundlers emit it as its own
+chunk; if it cannot be loaded at runtime, the adapter falls back to the didjs
+canister.
 
 Unlike `@ic-reactor/core` and `@ic-reactor/react` (Node.js 18+), this package
 requires **Node.js 20.19.0 or later** — the floor of its `@noble/hashes`

--- a/docs/src/content/docs/packages/core.mdx
+++ b/docs/src/content/docs/packages/core.mdx
@@ -27,7 +27,7 @@ React.
 ## Installation
 
 ```bash
-pnpm add @ic-reactor/core @icp-sdk/core @tanstack/query-core zod
+pnpm add @ic-reactor/core @icp-sdk/core @tanstack/query-core
 ```
 
 <Aside type="note">

--- a/packages/candid/README.md
+++ b/packages/candid/README.md
@@ -6,7 +6,7 @@ Lightweight adapter for fetching and parsing Candid definitions from Internet Co
 
 - **Fetch Candid Definitions**: Retrieve Candid interface definitions from any canister
 - **Multiple Retrieval Methods**: Supports both canister metadata and the temporary hack method
-- **Local Parsing**: Use the optional WASM-based parser for fast, offline Candid compilation
+- **Local Parsing**: Ships with the WASM-based `@ic-reactor/parser` for fast, offline Candid compilation, loaded on first use
 - **Remote Fallback**: Falls back to the didjs canister for Candid-to-JavaScript compilation
 - **Dynamic Reactor**: Includes `CandidReactor` for dynamic IDL fetching and interaction
 - **Dynamic Forms**: Generate rich form metadata with validation schemas using `MetadataReactor` and `CandidFormVisitor`
@@ -16,19 +16,19 @@ Lightweight adapter for fetching and parsing Candid definitions from Internet Co
 ## Installation
 
 ```bash
-npm install @ic-reactor/candid @ic-reactor/core @icp-sdk/core @tanstack/query-core zod
+npm install @ic-reactor/candid @ic-reactor/core @icp-sdk/core @tanstack/query-core
 ```
 
 `ClientManager` requires a TanStack `QueryClient`, so `@tanstack/query-core` is
 needed even when you only use the adapter.
 
-### Optional: Local Parser
+### Local parser
 
-For faster Candid parsing without network requests:
-
-```bash
-npm install @ic-reactor/parser
-```
+`@ic-reactor/parser` is a dependency of this package, so nothing extra is
+installed for local, offline Candid parsing. The adapter imports it on the
+first parse, and bundlers emit it as its own chunk, so an app that never
+parses Candid never loads the WASM. If it cannot be loaded at runtime, the
+adapter falls back to remote compilation through the didjs canister.
 
 ## Usage
 

--- a/packages/candid/llms.txt
+++ b/packages/candid/llms.txt
@@ -7,7 +7,7 @@ interaction, and metadata-driven form generation.
 
 ```bash
 pnpm add @ic-reactor/candid @icp-sdk/core
-pnpm add @ic-reactor/parser # optional local parser
+# @ic-reactor/parser comes with it: local WASM parsing, loaded on first parse
 ```
 
 ## When To Use
@@ -24,8 +24,8 @@ pnpm add @ic-reactor/parser # optional local parser
 
 ## Parser Strategy
 
-- Prefer local parser (`@ic-reactor/parser`) for speed and offline usage
-- Fallback uses remote didjs compilation when parser is unavailable
+- The local parser (`@ic-reactor/parser`) is a dependency, loaded on first parse; bundlers emit it as its own chunk
+- Fallback uses remote didjs compilation when the parser cannot be loaded at runtime
 
 ## Best Practices
 

--- a/packages/candid/package.json
+++ b/packages/candid/package.json
@@ -61,17 +61,16 @@
   "license": "MIT",
   "dependencies": {
     "@ic-reactor/core": "workspace:^",
+    "@ic-reactor/parser": "workspace:^",
     "@noble/hashes": "^2.4.0",
     "zod": "^4.4.3"
   },
   "peerDependencies": {
     "@icp-sdk/core": "^6.1.0",
-    "@noble/hashes": "^2.0.0",
-    "zod": "^4.3.5"
+    "@noble/hashes": "^2.0.0"
   },
   "peerDependenciesMeta": {},
   "devDependencies": {
-    "@ic-reactor/parser": "workspace:^",
     "@icp-sdk/core": "^6.1.0",
     "@size-limit/preset-small-lib": "^13.0.3",
     "@types/node": "^26.4.0",

--- a/packages/candid/package.json
+++ b/packages/candid/package.json
@@ -84,7 +84,8 @@
       "limit": "30 KB",
       "gzip": true,
       "ignore": [
-        "@ic-reactor/parser"
+        "@ic-reactor/parser",
+        "zod"
       ]
     }
   ]

--- a/packages/candid/src/adapter.ts
+++ b/packages/candid/src/adapter.ts
@@ -152,7 +152,9 @@ export class CandidAdapter {
         await (this.parserModule.default as () => Promise<void>)()
       }
     } catch {
-      // Silently fail - parser is optional
+      // The package is a dependency, so the specifier resolves; what can still
+      // fail is instantiating the WASM in this runtime. Remote compilation
+      // through the didjs canister covers that case.
       this.parserModule = undefined
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,8 +65,7 @@
   },
   "peerDependencies": {
     "@icp-sdk/core": "^6.1.0",
-    "@tanstack/query-core": "^5.0.0",
-    "zod": "^4.3.5"
+    "@tanstack/query-core": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "@tanstack/query-core": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1087,6 +1087,9 @@ importers:
       '@ic-reactor/core':
         specifier: workspace:^
         version: link:../core
+      '@ic-reactor/parser':
+        specifier: workspace:^
+        version: link:../parser
       '@noble/hashes':
         specifier: ^2.4.0
         version: 2.4.0
@@ -1094,9 +1097,6 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
-      '@ic-reactor/parser':
-        specifier: workspace:^
-        version: link:../parser
       '@icp-sdk/core':
         specifier: ^6.1.0
         version: 6.1.0


### PR DESCRIPTION
Closes #359. Closes #362.

## zod (#359)

`@ic-reactor/core` and `@ic-reactor/candid` declared zod twice: as a dependency at `^4.4.3` and as a required peer at `^4.3.5`, after dependabot bumped only the dependency. The two package managers disagree on which one wins. npm ignores the peer when a dependency of the same name exists. pnpm honours the peer and skips the dependency, so a pnpm project on zod 3 linked core against zod 3, where `z.codec` does not exist, with nothing but a warning.

The README never told anyone to install zod, and `fromZodSchema` is deliberately structural so it never needs a shared instance. So: the peer is removed from both packages and zod stays a plain dependency. The docs-site install line for core, the one place that listed zod, is corrected.

`@noble/hashes` in candid has the same dual shape. I left it, since instance identity does not matter for hash functions, but it is the same drift risk and worth a look.

## @ic-reactor/parser (#362)

`adapter.ts` contains a literal `await import("@ic-reactor/parser")`, and candid declared the parser only as a devDependency. Bundlers resolve a literal dynamic import like a static one, so a consumer who followed the README's "Optional: Local Parser" framing and skipped it got a hard build failure ("failed to resolve import") instead of the documented remote fallback. In this repo the workspace link hides it: every example's dist already contains the parser wasm.

The issue suggests an optional peer plus hiding the specifier from bundlers. That second half would break the *installed* case for the same bundler users: a bare specifier left for runtime never resolves in a browser, so the local parser would silently never load. The only shape that works for both is the honest one: **the parser is a dependency of candid** (`workspace:^`, rewritten to `^0.4.8` on pack). The import already lands in its own chunk, so an app that never parses Candid never loads the WASM, and the remote fallback remains for a runtime that cannot instantiate it. README, llms.txt and both docs pages now say so.

Because `pnpm pack` rewrites `workspace:^` to a caret on the parser's **local** version, a parser bumped in the tree but not yet published would leave the published candid unresolvable. `release.yml` preflight now asserts that version exists on npm, the way release-tools already does for codegen's pin.

## Verification

| gate | result |
| --- | --- |
| `pnpm build` then `pnpm verify:packages` | clean: packs, installs into a scratch project outside the workspace, imports every entry in real Node, publint, attw |
| `@ic-reactor/candid` tests | 411 passed |
| `pnpm typecheck` (candid) | clean |
| `pnpm format:check`, `pnpm check:ai-context` | clean |

No runtime code change beyond a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)