### PR TITLE
fix(parser): resolve aliased services and report composite_query in parseDid

### DIFF
--- a/packages/parser/scripts/append-types.js
+++ b/packages/parser/scripts/append-types.js
@@ -96,7 +96,7 @@ export interface CandidServiceDeclaration {
 
 export interface CandidMethodDeclaration {
   name: string;
-  mode: "query" | "update" | "oneway";
+  mode: "query" | "composite_query" | "update" | "oneway";
   args: CandidType[];
   returns: CandidType[];
   metadata?: CandidMetadata;

--- a/packages/parser/src/lib.rs
+++ b/packages/parser/src/lib.rs
@@ -265,22 +265,10 @@ fn validation_from_docs(docs: &[String]) -> Option<CandidValidationMetadata> {
 }
 
 fn apply_default_validation_messages(validation: &mut CandidValidationMetadata) {
-    validation.minimum = with_default_bound_message(
-        validation.minimum.take(),
-        "minimum",
-    );
-    validation.maximum = with_default_bound_message(
-        validation.maximum.take(),
-        "maximum",
-    );
-    validation.min_length = with_default_bound_message(
-        validation.min_length.take(),
-        "minLength",
-    );
-    validation.max_length = with_default_bound_message(
-        validation.max_length.take(),
-        "maxLength",
-    );
+    validation.minimum = with_default_bound_message(validation.minimum.take(), "minimum");
+    validation.maximum = with_default_bound_message(validation.maximum.take(), "maximum");
+    validation.min_length = with_default_bound_message(validation.min_length.take(), "minLength");
+    validation.max_length = with_default_bound_message(validation.max_length.take(), "maxLength");
     validation.format = with_default_format_message(validation.format.take());
 }
 
@@ -578,6 +566,22 @@ pub fn parse_did(prog: String) -> Result<JsValue, String> {
     let type_bindings = type_bindings_by_name(&ast);
     let method_bindings = service_method_bindings_from_actor(ast.actor.as_ref(), &type_bindings);
 
+    // `check_prog` validates the actor but hands back its *declared* type: for
+    // `service : S` that is `Var("S")`, for `service : (args) -> S` it is
+    // `Class(args, Var("S"))`. Both are how real ledgers spell their service
+    // (ICRC ledgers declare `service : (ledger_arg) -> Service`). Unwrap the
+    // class and chase aliases through the environment until the service body
+    // itself is in hand; anything else is not a service.
+    let service_ty = actor.and_then(|mut ty| loop {
+        ty = match ty.as_ref() {
+            candid_parser::candid::types::TypeInner::Class(_, inner) => inner.clone(),
+            candid_parser::candid::types::TypeInner::Var(_)
+            | candid_parser::candid::types::TypeInner::Knot(_) => env.trace_type(&ty).ok()?,
+            candid_parser::candid::types::TypeInner::Service(_) => break Some(ty),
+            _ => break None,
+        };
+    });
+
     let types = env
         .0
         .into_iter()
@@ -591,12 +595,7 @@ pub fn parse_did(prog: String) -> Result<JsValue, String> {
         })
         .collect();
 
-    let service = actor.and_then(|actor_ty| {
-        let service_ty = match actor_ty.as_ref() {
-            candid_parser::candid::types::TypeInner::Class(_, inner) => inner.clone(),
-            _ => actor_ty,
-        };
-
+    let service = service_ty.and_then(|service_ty| {
         if let candid_parser::candid::types::TypeInner::Service(methods) = service_ty.as_ref() {
             let methods = methods
                 .iter()
@@ -607,11 +606,19 @@ pub fn parse_did(prog: String) -> Result<JsValue, String> {
                             .find(|binding| binding.id == *name)
                             .copied();
                         let syntax_func = syntax_func_for_method(binding);
+                        // `composite_query` is its own mode, not an update: the IC
+                        // rejects a replicated call to one. `didToJs` already emits
+                        // the `composite_query` annotation for the same method.
                         let mode = if func
                             .modes
                             .contains(&candid_parser::candid::types::FuncMode::Oneway)
                         {
                             "oneway"
+                        } else if func
+                            .modes
+                            .contains(&candid_parser::candid::types::FuncMode::CompositeQuery)
+                        {
+                            "composite_query"
                         } else if func
                             .modes
                             .contains(&candid_parser::candid::types::FuncMode::Query)

--- a/packages/parser/tests/parser-schema.test.ts
+++ b/packages/parser/tests/parser-schema.test.ts
@@ -36,6 +36,77 @@ describe("Candid Schema Parser (parseDid)", () => {
     })
   })
 
+  it("reports composite_query as its own mode", () => {
+    // ICRC-3 and index canisters use it. It used to fall through to "update",
+    // while didToJs on the same source emitted the composite_query annotation.
+    const candid = `
+      service : {
+        get_blocks : (nat) -> (vec nat) composite_query;
+        get_tip : () -> (nat) query;
+        append : (nat) -> ();
+        notify : (nat) -> () oneway;
+      }
+    `
+    const parsed = parser.parseDid(candid)
+
+    // Methods come back in Candid's canonical (sorted) order.
+    expect(
+      parsed.service?.methods.map(({ name, mode }) => [name, mode])
+    ).toEqual([
+      ["append", "update"],
+      ["get_blocks", "composite_query"],
+      ["get_tip", "query"],
+      ["notify", "oneway"],
+    ])
+  })
+
+  it("resolves a service declared through a type alias", () => {
+    // `check_prog` hands back the declared type, Var("S"), not the service
+    // body; the alias has to be chased through the type environment.
+    const candid = `
+      type S = service { greet : (text) -> (text) query; };
+      service : S;
+    `
+    const parsed = parser.parseDid(candid)
+
+    expect(parsed.service?.methods.map((m) => m.name)).toEqual(["greet"])
+    expect(parsed.service?.methods[0].mode).toBe("query")
+  })
+
+  it("resolves a service class whose body is a type alias", () => {
+    // The shape of real ledger files: `service : (ledger_arg) -> Service`.
+    const candid = `
+      type Account = record { owner : principal };
+      type Service = service {
+        icrc1_balance_of : (Account) -> (nat) query;
+        icrc1_transfer : (Account, nat) -> (variant { Ok : nat; Err : text });
+      };
+      service : (opt nat) -> Service;
+    `
+    const parsed = parser.parseDid(candid)
+
+    expect(parsed.service?.methods.map((m) => m.name)).toEqual([
+      "icrc1_balance_of",
+      "icrc1_transfer",
+    ])
+    // Argument metadata still resolves through the alias to the declared type.
+    expect(parsed.service?.methods[0].args[0]).toEqual({
+      kind: "reference",
+      name: "Account",
+    })
+  })
+
+  it("chases an alias of an alias", () => {
+    const candid = `
+      type Inner = service { ping : () -> () query; };
+      type Outer = Inner;
+      service : Outer;
+    `
+    const parsed = parser.parseDid(candid)
+
+    expect(parsed.service?.methods.map((m) => m.name)).toEqual(["ping"])
+  })
+
   it("should parse custom type declarations", () => {
     const candid = `
       type Profile = record {


### PR DESCRIPTION
Closes #360. Closes #361.

## Aliased services (#360)

`check_prog` validates the actor but hands back its **declared** type: for `service : S` that is `Var("S")`, and for `service : (args) -> S` it is `Class(args, Var("S"))`. `parse_did` unwrapped the class and then required a literal `Service`, so both alias forms came back with `service` absent, while `didToJs` compiled the same file without complaint. That is the shape of every ICRC ledger file (`service : (ledger_arg) -> Service`). Codegen already knew and works around it by testing the generated JS instead of `parseDid().service`.

The declared type is now unwrapped and chased through the type environment (`TypeEnv::trace_type`, which follows `Var` and `Knot`) until the service body is in hand. Anything that resolves to something other than a service is still reported as none.

## composite_query (#361)

The mode derivation checked only `Oneway` and `Query` and fell through to `"update"` for `composite_query`, which the IC rejects as a replicated call. It is now its own mode, `"composite_query"`, matching the annotation `didToJs` already emits for the same method, and the generated `CandidMethodDeclaration.mode` union carries it. Nothing in this repo branches on that field, and call routing everywhere uses the IDL annotations, which were already right.

## Tests

Four new cases in `tests/parser-schema.test.ts`: composite_query alongside the other three modes, `service : S`, `service : (opt nat) -> Service` with an argument that still resolves to its declared type through the alias, and an alias of an alias.

`verify:test-fails` cannot prove these, since the parser tests run against the built wasm and the script only reverts sources. Done by hand instead: against the previous build all four fail (`service` is `undefined`; `get_blocks` is `"update"`), and after `pnpm --filter @ic-reactor/parser build` the suite passes, 14 of 14.

Not touched: codegen's regex workaround in `generators/declarations.ts` still works and is now redundant for alias-form files. Worth removing once this parser version is the one codegen pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)