### PR TITLE
docs(react): drop the popupCenter() call the README never defined

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -318,7 +318,8 @@ function RegisterWithOpenIdProvider() {
       nonce: () => backend.callMethod({ functionName: "register_begin" }),
       openIdProvider: "microsoft",
       keys: ["email", "name"],
-      windowOpenerFeatures: popupCenter(),
+      // Optional: any window.open() features string, e.g. to size the popup
+      windowOpenerFeatures: "width=500,height=640",
     })
 
     console.log(result.decodedAttributes.email)


### PR DESCRIPTION
Closes #364.

The `RegisterWithOpenIdProvider` example in the react README passed `windowOpenerFeatures: popupCenter()`. That helper exists in no package and nowhere in the snippet, whose only imports are `./auth` and `./reactor`, so a copy-paste failed with "Cannot find name popupCenter". The option is real and takes a plain `window.open()` features string, so the snippet now shows one, with a comment saying it is optional. No other README, docs page or llms file used the name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)