### PR TITLE
ci: widen format:check to the whole repo (#343)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -102,7 +102,7 @@ Follow these repository-specific patterns when suggesting code:
 
 ## Verification
 
-- Format check (CI gate; covers `packages/**` only): `pnpm format:check`
+- Format check (CI gate; covers the whole repo): `pnpm format:check`
 - AI context check (CI gate): `pnpm check:ai-context`
 - Type check used by CI: `pnpm typecheck` (every package, `src` and tests; the root `tsconfig.json` is references-only, so `pnpm exec tsc --noEmit` at the root checks nothing)
 - Package builds: `pnpm build`

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,7 +9,7 @@ coverage/
 **/target
 docs/dist
 .e2e/
-public/
+docs/public/
 .husky/
 .pnpm-debug.log
 .env
@@ -19,3 +19,51 @@ public/
 # strips the semicolons Next writes, so formatting it means a one-line diff
 # after every build.
 **/next-env.d.ts
+
+# `pnpm format:check` now walks the whole repo, and Prettier reads only the root
+# .gitignore plus this file -- never a nested .gitignore. Every build directory
+# that only a nested .gitignore covers has to be repeated here, or the check
+# fails in any working tree that has been built: `.next/` and `examples/*/out/`
+# alone accounted for 205 of the 249 files a repo-wide check flagged.
+.next/
+examples/*/out/
+dist-ssr/
+.tanstack/
+.nitro/
+.wrangler/
+.yarn/
+canister_ids.json
+
+# Editor state. Listed in several nested .gitignore files, which Prettier does
+# not read, so an untracked settings file would otherwise be rewritten in place.
+.vscode/
+.idea/
+
+# Claude Code worktrees and machine-local settings. Not covered by the root
+# .gitignore, so a repo-wide walk would format files on other agents' branches.
+.claude/
+
+# Written by `dfx generate` / the vite plugin into the e2e project.
+e2e/src/declarations/
+
+# TypeDoc output, rewritten by `pnpm docs:build`. Also in the root .gitignore;
+# repeated here so the Prettier set does not silently depend on it.
+docs/src/content/docs/libs/
+
+# Rewritten by the TanStack Router plugin on every dev/build run; its own header
+# tells you to exclude it from linters and formatters.
+examples/tanstack-router/src/routeTree.gen.ts
+
+# pnpm rewrites the lockfile on every install.
+pnpm-lock.yaml
+
+# Rewritten by @ic-reactor/vite-plugin's codegen on every `pnpm build:examples`.
+# These are tracked but generator-owned: the committed copies are Prettier-
+# formatted while the generator emits its own style, so a repo-wide check goes
+# red in any tree that has been built. Same reasoning as **/next-env.d.ts above.
+# (The generator emitting unformatted output is tracked separately.)
+examples/all-in-one-demo/src/declarations/backend/declarations/backend.*
+examples/codegen-in-action/src/canisters-vite/backend/declarations/backend.*
+examples/suspense-infinite-query-demo/src/declarations/backend/declarations/backend.*
+examples/vite-environment-variables/frontend/src/lib/canisters/backend/declarations/backend.*
+examples/vite-plugin-demo/frontend/lib/canisters/backend/declarations/backend.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Use this map before editing so you can start in the package that owns the behavi
 
 ## Verification commands
 
-- Format check (CI gate; globs `packages/**` only, so root markdown, `docs/`, `examples/`, and `skill-packages/` are not covered): `pnpm format:check`
+- Format check (CI gate; covers the whole repo, with exclusions declared in `.prettierignore`): `pnpm format:check`
 - AI context check (CI gate; asserts `llms.txt` versions match every `package.json` and each `packages/*/llms.txt` exists): `pnpm check:ai-context`
 - Type check used by CI: `pnpm typecheck` — runs each package's own `typecheck` script, covering `src` and tests. The root `tsconfig.json` is references-only, so `pnpm exec tsc --noEmit` at the root checks nothing.
 - Package builds: `pnpm build`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,8 @@ pnpm test               # Run all tests
 pnpm typecheck          # Type-check every package incl. tests (CI gate)
 pnpm typecheck:examples # Type-check example apps
 pnpm build:examples     # Build every example app (CI gate)
-pnpm format             # Format code with Prettier (packages/** only)
-pnpm format:check       # Verify formatting without writing (CI gate, packages/** only)
+pnpm format             # Format the whole repo with Prettier
+pnpm format:check       # Verify formatting without writing (CI gate, whole repo)
 pnpm check:ai-context   # Verify llms.txt versions match package.json (CI gate)
 pnpm verify:packages    # Pack + publint + attw + real-Node import of published artifacts
 pnpm verify:test-fails <file> --package <pkg>  # Check a new test actually fails without the fix

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,9 @@ You can check formatting without modifying files:
 pnpm format:check
 ```
 
-Both scripts glob `packages/**` only, so root markdown, `docs/`, `examples/`,
-and `skill-packages/` are not formatted or checked by them.
+Both scripts cover the whole repo. Exclusions live in one place,
+`.prettierignore`, which the pre-commit hook honours too, so the hook and the
+CI gate operate on exactly the same set of files.
 
 5. Run the remaining CI gates before opening a PR:
 

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ pnpm test
 # Type-check every package, including its tests (CI gate)
 pnpm typecheck
 
-# Check formatting (CI gate; globs packages/** only)
+# Check formatting (CI gate; covers the whole repo)
 pnpm format:check
 
 # Check llms.txt versions against every package.json (CI gate)

--- a/docs/src/content/docs/examples/nextjs.mdx
+++ b/docs/src/content/docs/examples/nextjs.mdx
@@ -154,7 +154,8 @@ const App: React.FC<AppProps> = (props) => (
   `createAuthHooks`' `useSyncExternalStore` server snapshot reads whatever
   identity that shared manager happens to hold at the moment of the render.
 
-  Constructing inside a `useState` initializer gives each render tree its own
-  set. See [Server-Side
-  Rendering](/v3/framework/react-setup#server-side-rendering).
+Constructing inside a `useState` initializer gives each render tree its own
+set. See [Server-Side
+Rendering](/v3/framework/react-setup#server-side-rendering).
+
 </Aside>

--- a/docs/src/content/docs/framework/mutations.mdx
+++ b/docs/src/content/docs/framework/mutations.mdx
@@ -64,8 +64,8 @@ mutate([Principal.fromText("aaaaa-aa"), BigInt(1000000)])
 <Aside type="note">
   Argument types follow the reactor the hooks were built from. A plain `Reactor`
   expects Candid values (`Principal`, `bigint`), while a `DisplayReactor`
-  expects their display forms — the same call becomes
-  `mutate(["aaaaa-aa", "1000000"])`.
+  expects their display forms — the same call becomes `mutate(["aaaaa-aa",
+  "1000000"])`.
 </Aside>
 
 ## Side Effects
@@ -341,9 +341,7 @@ import { backend } from "../reactor"
 // Define mutation once
 const createPostMutation = createMutation(backend, {
   functionName: "createPost",
-  invalidateQueries: [
-    backend.generateQueryKey({ functionName: "getPosts" }),
-  ],
+  invalidateQueries: [backend.generateQueryKey({ functionName: "getPosts" })],
 })
 
 // Use in components

--- a/docs/src/content/docs/framework/query-caching.mdx
+++ b/docs/src/content/docs/framework/query-caching.mdx
@@ -64,13 +64,16 @@ Use `generateQueryKey` to get the cache key for any query:
 ```typescript
 import { backend } from "./reactor"
 
-const queryKey = backend.generateQueryKey({
-  functionName: "getUser",
-  args: ["user-123"],
-}, {
-  canisterId: otherCanisterId,
-  effectiveCanisterId: managementCanisterId,
-})
+const queryKey = backend.generateQueryKey(
+  {
+    functionName: "getUser",
+    args: ["user-123"],
+  },
+  {
+    canisterId: otherCanisterId,
+    effectiveCanisterId: managementCanisterId,
+  }
+)
 // [otherCanisterId, 'getUser', { effectiveTarget: { canisterId: 'aaaaa-aa' } }, '["user-123"]']
 ```
 
@@ -230,12 +233,15 @@ backend.invalidateQueries(
 
 ```typescript
 // Invalidate getUser query for specific user
-backend.invalidateQueries({
-  functionName: "getUser",
-  args: ["user-123"],
-}, {
-  canisterId: otherCanisterId,
-})
+backend.invalidateQueries(
+  {
+    functionName: "getUser",
+    args: ["user-123"],
+  },
+  {
+    canisterId: otherCanisterId,
+  }
+)
 ```
 
 ### Invalidate by Custom Query Key

--- a/docs/src/content/docs/framework/react-setup.mdx
+++ b/docs/src/content/docs/framework/react-setup.mdx
@@ -69,11 +69,8 @@ This guide covers the complete setup of IC Reactor in a React application, inclu
    // Auth hooks are bound to an AuthenticationManager, not the ClientManager
    export const authentication = new AuthenticationManager({ clientManager })
 
-   export const {
-     useAuth,
-     useUserPrincipal,
-     useAgentState,
-   } = createAuthHooks(authentication)
+   export const { useAuth, useUserPrincipal, useAgentState } =
+     createAuthHooks(authentication)
    ```
 
 3. ### Setup Provider (Optional)

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -51,8 +51,8 @@ Most users will want the React package, which includes everything you need:
 
 <Aside type="note">
   `react` is the only required React peer. `react-dom` is declared as an
-  **optional** peer — the package never imports it — so renderers without a
-  DOM (React Native, custom hosts) work without installing it.
+  **optional** peer — the package never imports it — so renderers without a DOM
+  (React Native, custom hosts) work without installing it.
 </Aside>
 
 ### Non-React Projects (Node.js, Svelte, Vue, etc.)
@@ -136,34 +136,35 @@ pnpm add @icp-sdk/auth@^8
   `@ic-reactor/react` needs `@icp-sdk/core@^6`. A strict `npm install` of the
   advertised set therefore fails:
 
-  ```
-  npm error ERESOLVE unable to resolve dependency tree
-  npm error Found: @icp-sdk/core@5.4.0
-  npm error   peer @icp-sdk/core@"^5" from @icp-sdk/auth@8.0.3
-  npm error Could not resolve dependency:
-  npm error   peer @icp-sdk/core@"^6.0.0" from @ic-reactor/react
-  ```
+```
+npm error ERESOLVE unable to resolve dependency tree
+npm error Found: @icp-sdk/core@5.4.0
+npm error   peer @icp-sdk/core@"^5" from @icp-sdk/auth@8.0.3
+npm error Could not resolve dependency:
+npm error   peer @icp-sdk/core@"^6.0.0" from @ic-reactor/react
+```
 
-  This is stale metadata upstream, not an actual incompatibility: auth v8 works
-  against core v6, and IC Reactor's own suite runs that combination. `pnpm` and
-  `yarn` install it without complaint. For npm, tell it to use your `core` for
-  auth as well:
+This is stale metadata upstream, not an actual incompatibility: auth v8 works
+against core v6, and IC Reactor's own suite runs that combination. `pnpm` and
+`yarn` install it without complaint. For npm, tell it to use your `core` for
+auth as well:
 
-  ```json
-  // package.json
-  {
-    "overrides": {
-      "@icp-sdk/auth": {
-        "@icp-sdk/core": "$@icp-sdk/core"
-      }
+```json
+// package.json
+{
+  "overrides": {
+    "@icp-sdk/auth": {
+      "@icp-sdk/core": "$@icp-sdk/core"
     }
   }
-  ```
+}
+```
 
-  That resolves to a single `@icp-sdk/core` with no duplication.
-  `legacy-peer-deps=true` in `.npmrc` also works but disables peer checking
-  everywhere, so prefer the scoped override. This note goes away once
-  `@icp-sdk/auth` publishes a `core@^6` peer.
+That resolves to a single `@icp-sdk/core` with no duplication.
+`legacy-peer-deps=true` in `.npmrc` also works but disables peer checking
+everywhere, so prefer the scoped override. This note goes away once
+`@icp-sdk/auth` publishes a `core@^6` peer.
+
 </Aside>
 
 Bundlers still **resolve** that specifier while building the module graph,

--- a/docs/src/content/docs/getting-started/why-ic-reactor.mdx
+++ b/docs/src/content/docs/getting-started/why-ic-reactor.mdx
@@ -28,10 +28,10 @@ In the rapidly evolving landscape of Internet Computer development, choosing the
 
 ### Our Packages Are Tiny
 
-| Package               | Minified + Gzipped | What's Included                                     |
-| --------------------- | ------------------ | --------------------------------------------------- |
-| **@ic-reactor/core**  | **~8 KB**          | Reactor, caching, transformations, validation       |
-| **@ic-reactor/react** | **~8 KB**          | React hooks (excludes core, React, TanStack Query)  |
+| Package               | Minified + Gzipped | What's Included                                    |
+| --------------------- | ------------------ | -------------------------------------------------- |
+| **@ic-reactor/core**  | **~8 KB**          | Reactor, caching, transformations, validation      |
+| **@ic-reactor/react** | **~8 KB**          | React hooks (excludes core, React, TanStack Query) |
 
 That's it. **~16 KB total** for a complete, production-ready data layer.
 
@@ -206,6 +206,7 @@ One of IC Reactor's most elegant features:
 
 <Tabs>
   <TabItem label="With IC Reactor">
+
 ```typescript
 // Your Candid method returns: variant { Ok: nat; Err: text }
 
@@ -221,8 +222,10 @@ const { mutate } = useActorMutation({
   },
 })
 ```
+
   </TabItem>
   <TabItem label="Without IC Reactor">
+
 ```typescript
 // Manual approach - tedious and error-prone
 const result = await actor.transfer({ to: recipient, amount })
@@ -236,6 +239,7 @@ if ("Ok" in result) {
   throw new Error("Unexpected result shape")
 }
 ```
+
   </TabItem>
 </Tabs>
 

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -122,13 +122,14 @@ constructor, or per call to `login()` — the per-call value wins.
   before 2026 serve the SPA at `/` behind a `#authorize` fragment instead of at
   `/authorize`.
 
-  **`release-2026-03-16` is the newest `internet_identity_dev.wasm` that works.**
+**`release-2026-03-16` is the newest `internet_identity_dev.wasm` that works.**
 
-  `AuthenticationManager` probes the canister during `prepareClient()` and adapts:
-  it uses `/authorize` when that is served, falls back to the legacy
-  `#authorize` flow with a warning for pre-2026 builds, and rejects `login()`
-  with an explanation naming this release when the build serves neither — rather
-  than opening a popup the app cannot see into.
+`AuthenticationManager` probes the canister during `prepareClient()` and adapts:
+it uses `/authorize` when that is served, falls back to the legacy
+`#authorize` flow with a warning for pre-2026 builds, and rejects `login()`
+with an explanation naming this release when the build serves neither — rather
+than opening a popup the app cannot see into.
+
 </Aside>
 
 <Aside type="caution">

--- a/docs/src/content/docs/guides/type-safety.mdx
+++ b/docs/src/content/docs/guides/type-safety.mdx
@@ -194,8 +194,8 @@ With `DisplayReactor`, types are automatically transformed:
 <Aside type="note">
   The hex string a blob decodes to is a plain `string` with no `0x` prefix,
   regardless of the blob's size. (Releases up to and including v3.10.0 left
-  blobs longer than 512 bytes as `Uint8Array`; every release after v3.10.0
-  no longer switches representation with payload size. Use the exported
+  blobs longer than 512 bytes as `Uint8Array`; every release after v3.10.0 no
+  longer switches representation with payload size. Use the exported
   `hexToUint8Array` to get bytes back.)
 </Aside>
 

--- a/docs/src/content/docs/packages/candid/candiddisplayreactor.mdx
+++ b/docs/src/content/docs/packages/candid/candiddisplayreactor.mdx
@@ -51,17 +51,17 @@ new CandidDisplayReactor<A = BaseActor, T extends TransformKey = "display">(
 
 ### Parameters
 
-| Parameter        | Type                                                    | Required | Description                                          |
-| ---------------- | ------------------------------------------------------- | -------- | ---------------------------------------------------- |
-| `clientManager`  | `ClientManager`                                          | Yes      | Client manager from `@ic-reactor/core`               |
-| `name`           | `string`                                                 | Yes      | Required for logging & environment lookup            |
-| `canisterId`     | `CanisterId`                                             | No       | Resolved from the `ic_env` cookie when omitted, on a trusted host only |
-| `candid`         | `string`                                                 | No       | Candid service definition (avoids network fetch)     |
-| `idlFactory`     | `InterfaceFactory`                                       | No       | IDL factory (if already available)                   |
-| `adapter`        | `CandidAdapter`                                          | No       | Reuse an existing `CandidAdapter` instance           |
-| `funcClass`      | `{ methodName: string; func: IDL.FuncClass }`             | No       | Register a single `IDL.FuncClass` (no `initialize()`) |
-| `pollingOptions` | `PollingOptions`                                         | No       | Update-call polling configuration                    |
-| `validators`     | `Partial<Record<FunctionName<A>, DisplayValidator<A, M>>>` | No       | Initial validators for method arguments              |
+| Parameter        | Type                                                       | Required | Description                                                            |
+| ---------------- | ---------------------------------------------------------- | -------- | ---------------------------------------------------------------------- |
+| `clientManager`  | `ClientManager`                                            | Yes      | Client manager from `@ic-reactor/core`                                 |
+| `name`           | `string`                                                   | Yes      | Required for logging & environment lookup                              |
+| `canisterId`     | `CanisterId`                                               | No       | Resolved from the `ic_env` cookie when omitted, on a trusted host only |
+| `candid`         | `string`                                                   | No       | Candid service definition (avoids network fetch)                       |
+| `idlFactory`     | `InterfaceFactory`                                         | No       | IDL factory (if already available)                                     |
+| `adapter`        | `CandidAdapter`                                            | No       | Reuse an existing `CandidAdapter` instance                             |
+| `funcClass`      | `{ methodName: string; func: IDL.FuncClass }`              | No       | Register a single `IDL.FuncClass` (no `initialize()`)                  |
+| `pollingOptions` | `PollingOptions`                                           | No       | Update-call polling configuration                                      |
+| `validators`     | `Partial<Record<FunctionName<A>, DisplayValidator<A, M>>>` | No       | Initial validators for method arguments                                |
 
 ### Initialization Options
 

--- a/docs/src/content/docs/packages/candid/candidreactor.mdx
+++ b/docs/src/content/docs/packages/candid/candidreactor.mdx
@@ -44,15 +44,15 @@ new CandidReactor(config: CandidReactorParameters)
 
 ### Parameters
 
-| Parameter        | Type               | Required | Description                                      |
-| ---------------- | ------------------ | -------- | ------------------------------------------------ |
-| `clientManager`  | `ClientManager`    | Yes      | Client manager from `@ic-reactor/core`           |
-| `name`           | `string`           | Yes      | Required for logging & environment lookup        |
+| Parameter        | Type               | Required | Description                                                            |
+| ---------------- | ------------------ | -------- | ---------------------------------------------------------------------- |
+| `clientManager`  | `ClientManager`    | Yes      | Client manager from `@ic-reactor/core`                                 |
+| `name`           | `string`           | Yes      | Required for logging & environment lookup                              |
 | `canisterId`     | `CanisterId`       | No       | Resolved from the `ic_env` cookie when omitted, on a trusted host only |
-| `candid`         | `string`           | No       | Candid service definition (avoids network fetch) |
-| `idlFactory`     | `InterfaceFactory` | No       | IDL factory (if already available)               |
-| `adapter`        | `CandidAdapter`    | No       | Reuse an existing `CandidAdapter` instance       |
-| `pollingOptions` | `PollingOptions`   | No       | Update-call polling configuration                |
+| `candid`         | `string`           | No       | Candid service definition (avoids network fetch)                       |
+| `idlFactory`     | `InterfaceFactory` | No       | IDL factory (if already available)                                     |
+| `adapter`        | `CandidAdapter`    | No       | Reuse an existing `CandidAdapter` instance                             |
+| `pollingOptions` | `PollingOptions`   | No       | Update-call polling configuration                                      |
 
 ### Initialization Options
 

--- a/docs/src/content/docs/packages/candid/fieldvisitor.mdx
+++ b/docs/src/content/docs/packages/candid/fieldvisitor.mdx
@@ -52,17 +52,17 @@ type FormArgumentsMeta = {
 
 Every `FormFieldNode` includes:
 
-| Property       | Type                 | Description                             |
-| -------------- | -------------------- | --------------------------------------- |
-| `type`         | `FormFieldType`      | Candid field category                   |
-| `label`        | `string`             | Raw field label                         |
-| `displayLabel` | `string`             | Human-readable label                    |
-| `name`         | `string`             | Form path                               |
-| `schema`       | `z.ZodTypeAny`       | Field-level validation schema           |
-| `component`    | `FormFieldComponentType` | Suggested renderer component        |
-| `renderHint`   | `FormRenderHint`     | Primitive/compound and input type hints |
-| `defaultValue` | `unknown`            | Default value for initialization        |
-| `candidType`   | `string`             | Original Candid type text               |
+| Property       | Type                     | Description                             |
+| -------------- | ------------------------ | --------------------------------------- |
+| `type`         | `FormFieldType`          | Candid field category                   |
+| `label`        | `string`                 | Raw field label                         |
+| `displayLabel` | `string`                 | Human-readable label                    |
+| `name`         | `string`                 | Form path                               |
+| `schema`       | `z.ZodTypeAny`           | Field-level validation schema           |
+| `component`    | `FormFieldComponentType` | Suggested renderer component            |
+| `renderHint`   | `FormRenderHint`         | Primitive/compound and input type hints |
+| `defaultValue` | `unknown`                | Default value for initialization        |
+| `candidType`   | `string`                 | Original Candid type text               |
 
 ## UI Hints
 

--- a/docs/src/content/docs/packages/candid/metadatareactor.mdx
+++ b/docs/src/content/docs/packages/candid/metadatareactor.mdx
@@ -35,7 +35,8 @@ Use [`MetadataDisplayReactor`](/v3/packages/candid/metadatadisplayreactor) if yo
 
 <CardGrid>
   <Card title="Form Schema Generation" icon="list-format">
-    Generate field trees, defaults, component hints, and zod schemas directly from Candid.
+    Generate field trees, defaults, component hints, and zod schemas directly
+    from Candid.
   </Card>
   <Card title="Output Resolution" icon="document">
     Resolve canister return values with method-aware output metadata.
@@ -113,6 +114,7 @@ const resolved = transferOutput?.resolve(raw)
 - hydration decoding for initial form values
 
 Hydration status can be:
+
 - `empty`
 - `hydrated`
 - `skipped`
@@ -170,11 +172,13 @@ const meta = reactor.getInputMeta("get_metadata")
 ```
 
 <Steps>
-  1. Create and initialize `MetadataReactor`.
-  2. Read method metadata with `getInputMeta` / `getOutputMeta`.
-  3. Build UI state from `defaults` + `schema`.
-  4. Optionally hydrate from `candidArgsHex` for replay/edit flows.
-  5. Call the method and resolve output through `MethodMeta.resolve`.
+
+1. Create and initialize `MetadataReactor`.
+2. Read method metadata with `getInputMeta` / `getOutputMeta`.
+3. Build UI state from `defaults` + `schema`.
+4. Optionally hydrate from `candidArgsHex` for replay/edit flows.
+5. Call the method and resolve output through `MethodMeta.resolve`.
+
 </Steps>
 
 ## Practical Pattern: Dynamic Form + Result Viewer
@@ -227,5 +231,6 @@ const rendered = outputMeta?.resolve(raw)
 
 <Aside type="tip">
   `MetadataReactor` is usually the right default for runtime metadata tooling.
-  Reach for `MetadataDisplayReactor` when your app explicitly depends on display-type argument transforms.
+  Reach for `MetadataDisplayReactor` when your app explicitly depends on
+  display-type argument transforms.
 </Aside>

--- a/docs/src/content/docs/packages/cli.mdx
+++ b/docs/src/content/docs/packages/cli.mdx
@@ -126,19 +126,19 @@ The `ic-reactor.json` file controls the CLI behavior.
 | `outDir`            | `string`                         | Base output directory for generated files (required). |
 | `canisters`         | `Record<string, CanisterConfig>` | Map of canister names to configurations (required).   |
 | `clientManagerPath` | `string`                         | Path to a custom `ClientManager` instance (optional). |
-| `target`            | `"react" \| "core"`             | Default generated runtime target (optional).          |
+| `target`            | `"react" \| "core"`              | Default generated runtime target (optional).          |
 
 ### Canister Config
 
-| Key                 | Type     | Description                                                                                                                                          |
-| :------------------ | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`              | `string` | Canister name (required). Must match the key in `canisters`.                                                                                         |
-| `didFile`           | `string` | Path to the `.did` file (required).                                                                                                                  |
-| `mode`              | `string` | Reactor class to generate: `Reactor`, `DisplayReactor` (default), `CandidReactor`, `CandidDisplayReactor`, `MetadataDisplayReactor`.                 |
-| `outDir`            | `string` | Override output directory for this canister.                                                                                                         |
-| `clientManagerPath` | `string` | Override client manager path.                                                                                                                        |
-| `target`            | `string` | Override generated runtime target.                                                                                                                   |
-| `canisterId`        | `string` | Optional fixed canister ID.                                                                                                                          |
+| Key                 | Type     | Description                                                                                                                          |
+| :------------------ | :------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| `name`              | `string` | Canister name (required). Must match the key in `canisters`.                                                                         |
+| `didFile`           | `string` | Path to the `.did` file (required).                                                                                                  |
+| `mode`              | `string` | Reactor class to generate: `Reactor`, `DisplayReactor` (default), `CandidReactor`, `CandidDisplayReactor`, `MetadataDisplayReactor`. |
+| `outDir`            | `string` | Override output directory for this canister.                                                                                         |
+| `clientManagerPath` | `string` | Override client manager path.                                                                                                        |
+| `target`            | `string` | Override generated runtime target.                                                                                                   |
+| `canisterId`        | `string` | Optional fixed canister ID.                                                                                                          |
 
 ## Examples
 

--- a/docs/src/content/docs/packages/parser/reference.mdx
+++ b/docs/src/content/docs/packages/parser/reference.mdx
@@ -135,8 +135,8 @@ await init()
 
 The package builds for multiple targets to ensure compatibility across environments.
 
-| Folder         | Format     | Resolved by                                     |
-| :------------- | :--------- | :---------------------------------------------- |
+| Folder         | Format     | Resolved by                                      |
+| :------------- | :--------- | :----------------------------------------------- |
 | `dist/web`     | ES Modules | `browser`, `workerd` and `default` conditions    |
 | `dist/nodejs`  | CommonJS   | `node` condition                                 |
 | `dist/bundler` | ES Modules | Built and shipped, but not reachable via exports |

--- a/docs/src/content/docs/packages/vite-plugin.mdx
+++ b/docs/src/content/docs/packages/vite-plugin.mdx
@@ -63,26 +63,26 @@ plus hooks named after the canister — for a canister named `backend`:
 
 ## Plugin Options
 
-| Option                | Type             | Default              | Description                                                 |
-| :-------------------- | :--------------- | :------------------- | :---------------------------------------------------------- |
-| `canisters`           | `CanisterConfig[]` | —                  | Canister configurations (required).                         |
-| `outDir`              | `string`         | `"src/declarations"` | Base output directory for generated files.                  |
-| `clientManagerPath`   | `string`         | `"../../clients"`    | Default client manager import path (relative from generated files). |
-| `target`              | `"react" \| "core"` | `"react"`         | Default generated runtime target.                           |
-| `injectEnvironment`   | `boolean`        | `true`               | Inject `ic_env` cookie and proxy during `vite dev`.         |
-| `failOnError`         | `boolean`        | `true` on `vite build`, `false` on `vite dev` | Abort the Vite run when a canister fails to generate. |
+| Option              | Type                | Default                                       | Description                                                         |
+| :------------------ | :------------------ | :-------------------------------------------- | :------------------------------------------------------------------ |
+| `canisters`         | `CanisterConfig[]`  | —                                             | Canister configurations (required).                                 |
+| `outDir`            | `string`            | `"src/declarations"`                          | Base output directory for generated files.                          |
+| `clientManagerPath` | `string`            | `"../../clients"`                             | Default client manager import path (relative from generated files). |
+| `target`            | `"react" \| "core"` | `"react"`                                     | Default generated runtime target.                                   |
+| `injectEnvironment` | `boolean`           | `true`                                        | Inject `ic_env` cookie and proxy during `vite dev`.                 |
+| `failOnError`       | `boolean`           | `true` on `vite build`, `false` on `vite dev` | Abort the Vite run when a canister fails to generate.               |
 
 ### Per-canister options
 
-| Option              | Type     | Description                                                                                                       |
-| :------------------ | :------- | :---------------------------------------------------------------------------------------------------------------- |
-| `name`              | `string` | Canister name (required).                                                                                         |
-| `didFile`           | `string` | Path to the `.did` file (required).                                                                               |
+| Option              | Type     | Description                                                                                                              |
+| :------------------ | :------- | :----------------------------------------------------------------------------------------------------------------------- |
+| `name`              | `string` | Canister name (required).                                                                                                |
+| `didFile`           | `string` | Path to the `.did` file (required).                                                                                      |
 | `mode`              | `string` | Reactor class: `Reactor`, `DisplayReactor` (default), `CandidReactor`, `CandidDisplayReactor`, `MetadataDisplayReactor`. |
-| `outDir`            | `string` | Override output directory for this canister.                                                                      |
-| `clientManagerPath` | `string` | Override client manager path for this canister.                                                                   |
-| `target`            | `string` | Override runtime target for this canister.                                                                        |
-| `canisterId`        | `string` | Fixed canister ID (overrides auto-detected value during local dev).                                               |
+| `outDir`            | `string` | Override output directory for this canister.                                                                             |
+| `clientManagerPath` | `string` | Override client manager path for this canister.                                                                          |
+| `target`            | `string` | Override runtime target for this canister.                                                                               |
+| `canisterId`        | `string` | Fixed canister ID (overrides auto-detected value during local dev).                                                      |
 
 ## Reactor Mode
 

--- a/docs/src/content/docs/reference/ClientManager.mdx
+++ b/docs/src/content/docs/reference/ClientManager.mdx
@@ -80,26 +80,26 @@ const clientManager = new ClientManager({
 
 ## Constructor Options
 
-| Option         | Type               | Default  | Description                                                                    |
-| -------------- | ------------------ | -------- | ------------------------------------------------------------------------------ |
-| `queryClient`  | `QueryClient`      | Required | TanStack Query client instance                                                 |
-| `agentOptions` | `HttpAgentOptions` | `{}`     | Options forwarded to the `HttpAgent` (`host`, `identity`, `rootKey`, `retryTimes`, `verifyQuerySignatures`, …) |
-| `allowEnvConfig` | `boolean` | host-dependent | Whether to trust the `ic_env` cookie: its root key, its Internet Identity provider, and the canister IDs a reactor resolves by name. Defaults to `true` only for hosts that are unambiguously a local replica (loopback, `localhost` and its subdomains, dev-container tunnel domains); every other host must opt in. |
-| `allowEnvRootKey` | `boolean` | — | **Deprecated.** The former name of `allowEnvConfig`. Still honoured, and still scoped to what it always granted: the root key alone, not the identity provider or the canister ID. |
+| Option            | Type               | Default        | Description                                                                                                                                                                                                                                                                                                           |
+| ----------------- | ------------------ | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `queryClient`     | `QueryClient`      | Required       | TanStack Query client instance                                                                                                                                                                                                                                                                                        |
+| `agentOptions`    | `HttpAgentOptions` | `{}`           | Options forwarded to the `HttpAgent` (`host`, `identity`, `rootKey`, `retryTimes`, `verifyQuerySignatures`, …)                                                                                                                                                                                                        |
+| `allowEnvConfig`  | `boolean`          | host-dependent | Whether to trust the `ic_env` cookie: its root key, its Internet Identity provider, and the canister IDs a reactor resolves by name. Defaults to `true` only for hosts that are unambiguously a local replica (loopback, `localhost` and its subdomains, dev-container tunnel domains); every other host must opt in. |
+| `allowEnvRootKey` | `boolean`          | —              | **Deprecated.** The former name of `allowEnvConfig`. Still honoured, and still scoped to what it always granted: the root key alone, not the identity provider or the canister ID.                                                                                                                                    |
 
 Network detection needs no flag — see [Network Configuration](#network-configuration).
 
 ## Properties
 
-| Property      | Type                          | Description                        |
-| ------------- | ----------------------------- | ---------------------------------- |
-| `agent`       | `HttpAgent`                   | The IC HTTP agent (getter)         |
-| `queryClient` | `QueryClient`                 | TanStack Query client              |
-| `agentState`  | `AgentState`                  | Current agent initialization state |
-| `agentHost`   | `URL \| undefined`            | The host URL of the agent          |
-| `network`     | `"ic" \| "local" \| "remote"` | Current network type               |
-| `isLocal`     | `boolean`                     | Whether connected to local replica |
-| `trustsEnvConfig` | `boolean`                 | Whether the `ic_env` cookie is trusted for this host (getter) |
+| Property          | Type                          | Description                                                   |
+| ----------------- | ----------------------------- | ------------------------------------------------------------- |
+| `agent`           | `HttpAgent`                   | The IC HTTP agent (getter)                                    |
+| `queryClient`     | `QueryClient`                 | TanStack Query client                                         |
+| `agentState`      | `AgentState`                  | Current agent initialization state                            |
+| `agentHost`       | `URL \| undefined`            | The host URL of the agent                                     |
+| `network`         | `"ic" \| "local" \| "remote"` | Current network type                                          |
+| `isLocal`         | `boolean`                     | Whether connected to local replica                            |
+| `trustsEnvConfig` | `boolean`                     | Whether the `ic_env` cookie is trusted for this host (getter) |
 
 ### AgentState Type
 
@@ -272,7 +272,7 @@ const clientManager = new ClientManager({
 
 ### Canister Environment
 
-When your app is served by the `@icp-sdk` toolchain (e.g., `icp-cli`) or by [`@ic-reactor/vite-plugin`](/v3/packages/vite-plugin), the dev server injects an `ic_env` cookie carrying the local canister IDs and root key. `ClientManager` reads that cookie **automatically** in the browser. Host detection needs no option to enable; everything the cookie *carries* is gated on one decision, exposed as the `trustsEnvConfig` getter and controlled by `allowEnvConfig`:
+When your app is served by the `@icp-sdk` toolchain (e.g., `icp-cli`) or by [`@ic-reactor/vite-plugin`](/v3/packages/vite-plugin), the dev server injects an `ic_env` cookie carrying the local canister IDs and root key. `ClientManager` reads that cookie **automatically** in the browser. Host detection needs no option to enable; everything the cookie _carries_ is gated on one decision, exposed as the `trustsEnvConfig` getter and controlled by `allowEnvConfig`:
 
 - Agent host taken from `window.location.origin` when the page is served from a local or IC boundary host
 - Query signature verification disabled in development for performance
@@ -317,7 +317,10 @@ await clientManager.initialize()
 await authentication.authenticate()
 
 if (authentication.authState.isAuthenticated) {
-  console.log("Welcome back!", (await clientManager.getUserPrincipal()).toText())
+  console.log(
+    "Welcome back!",
+    (await clientManager.getUserPrincipal()).toText()
+  )
 }
 
 // Login handler

--- a/docs/src/content/docs/reference/DisplayReactor.mdx
+++ b/docs/src/content/docs/reference/DisplayReactor.mdx
@@ -174,10 +174,10 @@ const { useActorQuery, useActorMutation } = createActorHooks(backend)
 
 #### Identity & Binary Types
 
-| Candid      | TypeScript   | Display  | Notes                        |
-| ----------- | ------------ | -------- | ---------------------------- |
-| `principal` | `Principal`  | `string` | e.g., `"rrkah-fqaaa..."`     |
-| `blob`      | `Uint8Array` | `string` | Hex, no `0x`: `"89504e..."`  |
+| Candid      | TypeScript   | Display  | Notes                       |
+| ----------- | ------------ | -------- | --------------------------- |
+| `principal` | `Principal`  | `string` | e.g., `"rrkah-fqaaa..."`    |
+| `blob`      | `Uint8Array` | `string` | Hex, no `0x`: `"89504e..."` |
 
 #### Container Types
 
@@ -384,15 +384,14 @@ value is always JSON-safe, so persisting or serialising it never corrupts
 binary fields.
 
 <Aside type="caution" title="Changed behavior — was size-dependent">
-  Releases up to and including v3.10.0 decode only blobs of 512 bytes or
-  fewer to hex; anything larger stays a `Uint8Array`, so one field could
-  change JS type with payload size and JSON-serialising a result silently
-  corrupted large blobs. Every release after v3.10.0 decodes all blobs to
-  hex. If you branched on `typeof blob === "string"`, the `Uint8Array`
-  branch is now dead — delete it, or convert back with the exported
-  `hexToUint8Array(value)`. If you were relying on raw bytes for large
-  payloads (hex doubles the in-memory size), read them through a plain
-  `Reactor`, which leaves blobs untransformed.
+  Releases up to and including v3.10.0 decode only blobs of 512 bytes or fewer
+  to hex; anything larger stays a `Uint8Array`, so one field could change JS
+  type with payload size and JSON-serialising a result silently corrupted large
+  blobs. Every release after v3.10.0 decodes all blobs to hex. If you branched
+  on `typeof blob === "string"`, the `Uint8Array` branch is now dead — delete
+  it, or convert back with the exported `hexToUint8Array(value)`. If you were
+  relying on raw bytes for large payloads (hex doubles the in-memory size), read
+  them through a plain `Reactor`, which leaves blobs untransformed.
 </Aside>
 
 ```typescript

--- a/docs/src/content/docs/reference/Reactor.mdx
+++ b/docs/src/content/docs/reference/Reactor.mdx
@@ -169,13 +169,16 @@ const result = await backend.callMethod({
 Generate a TanStack Query cache key for a method call:
 
 ```typescript
-const queryKey = backend.generateQueryKey({
-  functionName: "getUser",
-  args: ["user-123"],
-}, {
-  canisterId: otherCanisterId,
-  effectiveCanisterId: managementCanisterId,
-})
+const queryKey = backend.generateQueryKey(
+  {
+    functionName: "getUser",
+    args: ["user-123"],
+  },
+  {
+    canisterId: otherCanisterId,
+    effectiveCanisterId: managementCanisterId,
+  }
+)
 // Returns:
 // [otherCanisterId, "getUser", { effectiveTarget: { canisterId: managementCanisterId } }, '["user-123"]']
 ```
@@ -282,16 +285,15 @@ ledgerReactor.setCanisterId(Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai"))
 | `canisterId` | `string \| Principal` | The new canister ID |
 
 <Aside type="note">
-  No cache cleanup is needed after switching. Query keys start with the
-  canister ID, so the two canisters never share a cache entry: mounted hooks —
-  including the infinite-query variants — recompute their key and fetch the new
-  canister's data **on their next render**, while the previous canister's
-  entries stay cached under their own keys (until normal `gcTime` eviction)
-  and are reused if you switch back.
-  `setCanisterId` does not itself trigger a render, so pair it with something
-  that does — a route navigation (as in the loader example below) or a state
-  update. A hook that renders before then still reads the previous canister's
-  key.
+  No cache cleanup is needed after switching. Query keys start with the canister
+  ID, so the two canisters never share a cache entry: mounted hooks — including
+  the infinite-query variants — recompute their key and fetch the new canister's
+  data **on their next render**, while the previous canister's entries stay
+  cached under their own keys (until normal `gcTime` eviction) and are reused if
+  you switch back. `setCanisterId` does not itself trigger a render, so pair it
+  with something that does — a route navigation (as in the loader example below)
+  or a state update. A hook that renders before then still reads the previous
+  canister's key.
 </Aside>
 
 ---
@@ -470,10 +472,13 @@ This method ensures the data is in the cache (fetching it if necessary) and retu
 Get the current data from the cache without fetching:
 
 ```typescript
-const user = backend.getQueryData({
-  functionName: "getUser",
-  args: ["user-123"],
-}, { canisterId: otherCanisterId })
+const user = backend.getQueryData(
+  {
+    functionName: "getUser",
+    args: ["user-123"],
+  },
+  { canisterId: otherCanisterId }
+)
 
 if (user) {
   console.log("User in cache:", user.name)

--- a/docs/src/content/docs/reference/ReactorHooks.mdx
+++ b/docs/src/content/docs/reference/ReactorHooks.mdx
@@ -145,8 +145,8 @@ import type {
 
 <Aside type="note">
   All parameter types extend TanStack Query's base types. This means you get
-  access to standard options like `gcTime`, `retry`,
-  `refetchOnWindowFocus`, `networkMode`, and `placeholderData`.
+  access to standard options like `gcTime`, `retry`, `refetchOnWindowFocus`,
+  `networkMode`, and `placeholderData`.
 </Aside>
 
 <Aside type="tip">

--- a/docs/src/content/docs/reference/createActorHooks/useActorMutation.mdx
+++ b/docs/src/content/docs/reference/createActorHooks/useActorMutation.mdx
@@ -56,17 +56,17 @@ function CreatePost() {
 
 ### Optional Options
 
-| Option              | Type                 | Default | Description                                                     |
-| ------------------- | -------------------- | ------- | --------------------------------------------------------------- |
-| `callConfig`        | `CallConfig`         | -       | IC agent call configuration                                     |
-| `invalidateQueries` | `QueryKey[]`         | -       | Query keys to invalidate on success                             |
+| Option              | Type                 | Default | Description                                                       |
+| ------------------- | -------------------- | ------- | ----------------------------------------------------------------- |
+| `callConfig`        | `CallConfig`         | -       | IC agent call configuration                                       |
+| `invalidateQueries` | `QueryKey[]`         | -       | Query keys to invalidate on success                               |
 | `onCanisterError`   | `function`           | -       | Called only for `Result { Err }` variants (canister logic errors) |
-| `retry`             | `number \| boolean`  | `0`     | Number of retry attempts                                        |
-| `retryDelay`        | `number \| function` | -       | Delay between retries                                           |
-| `onMutate`          | `function`           | -       | Called before mutation                                          |
-| `onSuccess`         | `function`           | -       | Called on successful mutation                                   |
-| `onError`           | `function`           | -       | Called on ALL errors (canister, network, agent)                 |
-| `onSettled`         | `function`           | -       | Called after success or error                                   |
+| `retry`             | `number \| boolean`  | `0`     | Number of retry attempts                                          |
+| `retryDelay`        | `number \| function` | -       | Delay between retries                                             |
+| `onMutate`          | `function`           | -       | Called before mutation                                            |
+| `onSuccess`         | `function`           | -       | Called on successful mutation                                     |
+| `onError`           | `function`           | -       | Called on ALL errors (canister, network, agent)                   |
+| `onSettled`         | `function`           | -       | Called after success or error                                     |
 
 ### Callback Signatures
 

--- a/docs/src/content/docs/reference/createActorHooks/useActorQuery.mdx
+++ b/docs/src/content/docs/reference/createActorHooks/useActorQuery.mdx
@@ -252,10 +252,10 @@ The types are automatically inferred from your actor interface, so you typically
 
 <Aside type="note">
   The query key is automatically generated as `[canisterId, functionName,
-  JSON.stringify(args), ...queryKey]`, with an extra `{ effectiveTarget }`
-  segment inserted after `functionName` when `callConfig` targets a different
-  canister or subnet. Arguments are one single serialized segment, so queries
-  with different arguments are cached separately.
+  JSON.stringify(args), ...queryKey]`, with an extra `{effectiveTarget}` segment
+  inserted after `functionName` when `callConfig` targets a different canister
+  or subnet. Arguments are one single serialized segment, so queries with
+  different arguments are cached separately.
 </Aside>
 
 <Aside type="tip">

--- a/docs/src/content/docs/reference/createActorHooks/useactormethod.mdx
+++ b/docs/src/content/docs/reference/createActorHooks/useactormethod.mdx
@@ -98,21 +98,21 @@ All react-query options are available:
 
 ## Return Value
 
-| Property         | Type                                    | Description                                                        |
-| :--------------- | :-------------------------------------- | :----------------------------------------------------------------- |
-| `data`           | `ReactorReturnOk<A, M, T> \| undefined` | The returned data from the method call.                            |
-| `call`           | `(args?) => Promise<data>`              | Function to trigger the method call manually.                      |
-| `isLoading`      | `boolean`                               | Whether the method is currently executing (alias for `isPending`). |
-| `isPending`      | `boolean`                               | Whether the method is currently executing.                         |
-| `isError`        | `boolean`                               | Whether the last call resulted in an error.                        |
-| `isSuccess`      | `boolean`                               | Whether the method has completed successfully.                     |
-| `error`          | `ReactorReturnErr<A, M, T> \| null`     | The error object if one occurred.                                  |
-| `isQuery`        | `boolean`                               | `true` if it's a query method, `false` otherwise.                  |
+| Property         | Type                                    | Description                                                                 |
+| :--------------- | :-------------------------------------- | :-------------------------------------------------------------------------- |
+| `data`           | `ReactorReturnOk<A, M, T> \| undefined` | The returned data from the method call.                                     |
+| `call`           | `(args?) => Promise<data>`              | Function to trigger the method call manually.                               |
+| `isLoading`      | `boolean`                               | Whether the method is currently executing (alias for `isPending`).          |
+| `isPending`      | `boolean`                               | Whether the method is currently executing.                                  |
+| `isError`        | `boolean`                               | Whether the last call resulted in an error.                                 |
+| `isSuccess`      | `boolean`                               | Whether the method has completed successfully.                              |
+| `error`          | `ReactorReturnErr<A, M, T> \| null`     | The error object if one occurred.                                           |
+| `isQuery`        | `boolean`                               | `true` if it's a query method, `false` otherwise.                           |
 | `functionType`   | `FunctionType`                          | `"query"` or `"update"`. Candid `composite_query` methods report `"query"`. |
-| `reset`          | `() => void`                            | Clears the state (data and error).                                 |
-| `refetch`        | `() => Promise`                         | For queries: manually refetches the data.                          |
-| `queryResult`    | `UseQueryResult`                        | The raw result if it's a query.                                    |
-| `mutationResult` | `UseMutationResult`                     | The raw result if it's a mutation.                                 |
+| `reset`          | `() => void`                            | Clears the state (data and error).                                          |
+| `refetch`        | `() => Promise`                         | For queries: manually refetches the data.                                   |
+| `queryResult`    | `UseQueryResult`                        | The raw result if it's a query.                                             |
+| `mutationResult` | `UseMutationResult`                     | The raw result if it's a mutation.                                          |
 
 ## See Also
 

--- a/docs/src/content/docs/reference/createAuthHooks/overview.mdx
+++ b/docs/src/content/docs/reference/createAuthHooks/overview.mdx
@@ -26,8 +26,8 @@ const { useAuth, useUserPrincipal, useAgentState } =
 
 ## Parameters
 
-| Parameter        | Type                    | Description                                  |
-| ---------------- | ----------------------- | -------------------------------------------- |
+| Parameter        | Type                    | Description                                   |
+| ---------------- | ----------------------- | --------------------------------------------- |
 | `authentication` | `AuthenticationManager` | The AuthenticationManager instance to bind to |
 
 `AuthenticationManager` is constructed from a `ClientManager`:

--- a/docs/src/content/docs/reference/createAuthHooks/useAgentState.mdx
+++ b/docs/src/content/docs/reference/createAuthHooks/useAgentState.mdx
@@ -27,13 +27,13 @@ function AgentStatus() {
 
 ## Return Value
 
-| Property         | Type                 | Description                                                   |
-| ---------------- | -------------------- | ------------------------------------------------------------- |
-| `isInitialized`  | `boolean`            | Whether the agent has finished initializing                   |
-| `isInitializing` | `boolean`            | Whether the agent is currently initializing                   |
-| `isLocalhost`    | `boolean`            | Whether the agent is connected to a local development network |
+| Property         | Type                  | Description                                                                                  |
+| ---------------- | --------------------- | -------------------------------------------------------------------------------------------- |
+| `isInitialized`  | `boolean`             | Whether the agent has finished initializing                                                  |
+| `isInitializing` | `boolean`             | Whether the agent is currently initializing                                                  |
+| `isLocalhost`    | `boolean`             | Whether the agent is connected to a local development network                                |
 | `network`        | `string \| undefined` | The network the agent is connected to — `"ic"`, `"local"`, or `"remote"` (Codespaces/Gitpod) |
-| `error`          | `Error \| undefined` | Any error that occurred during initialization                 |
+| `error`          | `Error \| undefined`  | Any error that occurred during initialization                                                |
 
 ## Examples
 

--- a/docs/src/content/docs/reference/createAuthHooks/useAuth.mdx
+++ b/docs/src/content/docs/reference/createAuthHooks/useAuth.mdx
@@ -73,16 +73,16 @@ const identity = await authenticate()
 
 ## Return Value
 
-| Property           | Type                          | Description                                            |
-| ------------------ | ----------------------------- | ------------------------------------------------------ |
-| `login`            | `(options?) => Promise<void>` | Triggers the login flow                                |
-| `logout`           | `(options?: { returnTo?: string }) => Promise<void>` | Logs the user out               |
-| `authenticate`     | `() => Promise<Identity \| undefined>` | Restores an existing session without a popup  |
-| `isAuthenticated`  | `boolean`                     | Whether the user is currently authenticated            |
-| `isAuthenticating` | `boolean`                     | Whether an authentication process is in progress       |
-| `identity`         | `Identity \| null`            | The current user's `@icp-sdk/core/agent` Identity      |
-| `principal`        | `Principal \| null`           | The current user's `@icp-sdk/core/principal` Principal |
-| `error`            | `Error \| undefined`          | Last authentication error                              |
+| Property           | Type                                                 | Description                                            |
+| ------------------ | ---------------------------------------------------- | ------------------------------------------------------ |
+| `login`            | `(options?) => Promise<void>`                        | Triggers the login flow                                |
+| `logout`           | `(options?: { returnTo?: string }) => Promise<void>` | Logs the user out                                      |
+| `authenticate`     | `() => Promise<Identity \| undefined>`               | Restores an existing session without a popup           |
+| `isAuthenticated`  | `boolean`                                            | Whether the user is currently authenticated            |
+| `isAuthenticating` | `boolean`                                            | Whether an authentication process is in progress       |
+| `identity`         | `Identity \| null`                                   | The current user's `@icp-sdk/core/agent` Identity      |
+| `principal`        | `Principal \| null`                                  | The current user's `@icp-sdk/core/principal` Principal |
+| `error`            | `Error \| undefined`                                 | Last authentication error                              |
 
 ## Protected Routes Pattern
 

--- a/docs/src/content/docs/reference/factories/createInfiniteQuery.mdx
+++ b/docs/src/content/docs/reference/factories/createInfiniteQuery.mdx
@@ -73,13 +73,13 @@ getPreviousPageParam: (
 
 ## Return Value
 
-| Property           | Type                                   | Description                                 |
-| ------------------ | -------------------------------------- | ------------------------------------------- |
-| `fetch`            | `() => Promise<T>`                     | Fetch first page (for loaders)              |
-| `useInfiniteQuery` | `(options?) => UseInfiniteQueryResult` | React hook                                  |
-| `invalidate`       | `() => Promise<void>`                  | Invalidate the cache (refetches if active)  |
-| `getQueryKey`      | `() => QueryKey`                       | Get the query key                           |
-| `getCacheData`     | `(select?) => T \| undefined`          | Read from cache without fetching            |
+| Property           | Type                                   | Description                                |
+| ------------------ | -------------------------------------- | ------------------------------------------ |
+| `fetch`            | `() => Promise<T>`                     | Fetch first page (for loaders)             |
+| `useInfiniteQuery` | `(options?) => UseInfiniteQueryResult` | React hook                                 |
+| `invalidate`       | `() => Promise<void>`                  | Invalidate the cache (refetches if active) |
+| `getQueryKey`      | `() => QueryKey`                       | Get the query key                          |
+| `getCacheData`     | `(select?) => T \| undefined`          | Read from cache without fetching           |
 
 These five keys are the whole object. To force a refetch from a component, use
 the `refetch` returned by `useInfiniteQuery()`; outside React, call

--- a/docs/src/content/docs/reference/factories/createMutation.mdx
+++ b/docs/src/content/docs/reference/factories/createMutation.mdx
@@ -75,10 +75,10 @@ const transferMutation = createMutation(backend, {
 
 ## Return Value
 
-| Property      | Type                              | Description                                                 |
-| ------------- | --------------------------------- | ----------------------------------------------------------- |
-| `useMutation` | `(options?) => UseMutationResult` | React hook for components                                   |
-| `execute`     | `(args) => Promise<T>`            | Imperative call that runs the factory-level callback chain  |
+| Property      | Type                              | Description                                                |
+| ------------- | --------------------------------- | ---------------------------------------------------------- |
+| `useMutation` | `(options?) => UseMutationResult` | React hook for components                                  |
+| `execute`     | `(args) => Promise<T>`            | Imperative call that runs the factory-level callback chain |
 
 ---
 

--- a/docs/src/content/docs/reference/factories/createQuery.mdx
+++ b/docs/src/content/docs/reference/factories/createQuery.mdx
@@ -41,15 +41,15 @@ const userProfileQuery = createQuery(backend, {
 
 The factory returns an object with these utilities:
 
-| Property       | Type                                     | Description                              |
-| -------------- | ---------------------------------------- | ---------------------------------------- |
-| `fetch`        | `() => Promise<T>`                       | Cache-first fetch — use in route loaders |
-| `prefetch`     | `() => Promise<void>`                    | Fire-and-forget cache warm-up            |
-| `useQuery`     | `(options?) => UseQueryResult`           | React hook for components                |
-| `invalidate`   | `() => Promise<void>`                    | Invalidate cache (refetches if active)   |
-| `getQueryKey`  | `() => QueryKey`                         | Get the TanStack Query key               |
-| `getCacheData` | `(select?) => T`                         | Read from cache without fetching         |
-| `setData`      | `(updater) => T \| undefined`            | Write raw data into cache                |
+| Property       | Type                           | Description                              |
+| -------------- | ------------------------------ | ---------------------------------------- |
+| `fetch`        | `() => Promise<T>`             | Cache-first fetch — use in route loaders |
+| `prefetch`     | `() => Promise<void>`          | Fire-and-forget cache warm-up            |
+| `useQuery`     | `(options?) => UseQueryResult` | React hook for components                |
+| `invalidate`   | `() => Promise<void>`          | Invalidate cache (refetches if active)   |
+| `getQueryKey`  | `() => QueryKey`               | Get the TanStack Query key               |
+| `getCacheData` | `(select?) => T`               | Read from cache without fetching         |
+| `setData`      | `(updater) => T \| undefined`  | Write raw data into cache                |
 
 ---
 
@@ -335,7 +335,7 @@ oldest entries rather than grow without bound.
 Eviction costs memoization, not correctness: a query object is a closure over
 the reactor and its config, so one rebuilt after eviction behaves identically
 and only its reference identity differs. It matters only if you compare
-instances or put one in a dependency array *and* cycle through more than 256
+instances or put one in a dependency array _and_ cycle through more than 256
 distinct argument sets.
 
 ---

--- a/docs/src/content/docs/reference/reactorHooks/usereactormethod.mdx
+++ b/docs/src/content/docs/reference/reactorHooks/usereactormethod.mdx
@@ -105,21 +105,21 @@ All react-query options are available:
 
 ## Return Value
 
-| Property         | Type                                    | Description                                                        |
-| :--------------- | :-------------------------------------- | :----------------------------------------------------------------- |
-| `data`           | `ReactorReturnOk<A, M, T> \| undefined` | The returned data from the method call.                            |
-| `call`           | `(args?) => Promise<data>`              | Function to trigger the method call manually.                      |
-| `isLoading`      | `boolean`                               | Whether the method is currently executing (alias for `isPending`). |
-| `isPending`      | `boolean`                               | Whether the method is currently executing.                         |
-| `isError`        | `boolean`                               | Whether the last call resulted in an error.                        |
-| `isSuccess`      | `boolean`                               | Whether the method has completed successfully.                     |
-| `error`          | `ReactorReturnErr<A, M, T> \| null`     | The error object if one occurred.                                  |
-| `isQuery`        | `boolean`                               | `true` if it's a query method, `false` otherwise.                  |
+| Property         | Type                                    | Description                                                                 |
+| :--------------- | :-------------------------------------- | :-------------------------------------------------------------------------- |
+| `data`           | `ReactorReturnOk<A, M, T> \| undefined` | The returned data from the method call.                                     |
+| `call`           | `(args?) => Promise<data>`              | Function to trigger the method call manually.                               |
+| `isLoading`      | `boolean`                               | Whether the method is currently executing (alias for `isPending`).          |
+| `isPending`      | `boolean`                               | Whether the method is currently executing.                                  |
+| `isError`        | `boolean`                               | Whether the last call resulted in an error.                                 |
+| `isSuccess`      | `boolean`                               | Whether the method has completed successfully.                              |
+| `error`          | `ReactorReturnErr<A, M, T> \| null`     | The error object if one occurred.                                           |
+| `isQuery`        | `boolean`                               | `true` if it's a query method, `false` otherwise.                           |
 | `functionType`   | `FunctionType`                          | `"query"` or `"update"`. Candid `composite_query` methods report `"query"`. |
-| `reset`          | `() => void`                            | Clears the state (data and error).                                 |
-| `refetch`        | `() => Promise`                         | For queries: manually refetches the data.                          |
-| `queryResult`    | `UseQueryResult`                        | The raw result if it's a query.                                    |
-| `mutationResult` | `UseMutationResult`                     | The raw result if it's a mutation.                                 |
+| `reset`          | `() => void`                            | Clears the state (data and error).                                          |
+| `refetch`        | `() => Promise`                         | For queries: manually refetches the data.                                   |
+| `queryResult`    | `UseQueryResult`                        | The raw result if it's a query.                                             |
+| `mutationResult` | `UseMutationResult`                     | The raw result if it's a mutation.                                          |
 
 ## See Also
 

--- a/examples/ckbtc-wallet/src/declarations/ckbtc.ts
+++ b/examples/ckbtc-wallet/src/declarations/ckbtc.ts
@@ -111,8 +111,7 @@ export interface ConsentInfo {
   consent_message: ConsentMessage
 }
 export type ConsentMessage =
-  | { FieldsDisplayMessage: FieldsDisplay }
-  | { GenericDisplayMessage: string }
+  { FieldsDisplayMessage: FieldsDisplay } | { GenericDisplayMessage: string }
 export interface ConsentMessageMetadata {
   utc_offset_minutes: [] | [number]
   language: string
@@ -131,8 +130,7 @@ export interface DataCertificate {
   hash_tree: Uint8Array | number[]
 }
 export type DisplayMessageType =
-  | { GenericDisplay: null }
-  | { FieldsDisplay: null }
+  { GenericDisplay: null } | { FieldsDisplay: null }
 export interface ErrorInfo {
   description: string
 }
@@ -221,8 +219,7 @@ export interface InitArgs {
   feature_flags: [] | [FeatureFlags]
 }
 export type LedgerArgument =
-  | { Upgrade: [] | [UpgradeArgs] }
-  | { Init: InitArgs }
+  { Upgrade: [] | [UpgradeArgs] } | { Init: InitArgs }
 export type MetadataValue =
   | { Int: bigint }
   | { Nat: bigint }

--- a/examples/ckbtc-wallet/src/declarations/minter.ts
+++ b/examples/ckbtc-wallet/src/declarations/minter.ts
@@ -13,9 +13,7 @@ export type BitcoinAddress =
   | { p2wpkh_v0: Uint8Array | number[] }
   | { p2pkh: Uint8Array | number[] }
 export type BtcNetwork =
-  | { Mainnet: null }
-  | { Regtest: null }
-  | { Testnet: null }
+  { Mainnet: null } | { Regtest: null } | { Testnet: null }
 export interface CanisterStatusResponse {
   status: CanisterStatusType
   memory_size: bigint
@@ -26,9 +24,7 @@ export interface CanisterStatusResponse {
   module_hash: [] | [Uint8Array | number[]]
 }
 export type CanisterStatusType =
-  | { stopped: null }
-  | { stopping: null }
-  | { running: null }
+  { stopped: null } | { stopping: null } | { running: null }
 export interface DefiniteCanisterSettings {
   freezing_threshold: bigint
   controllers: Array<Principal>

--- a/examples/codec-demo/index.html
+++ b/examples/codec-demo/index.html
@@ -285,15 +285,13 @@
                 <div class="result-column">
                   <h5>📱 Display Format (Frontend)</h5>
                   <pre id="display-args" class="code-block">
-Interact with the form to see result</pre
-                  >
+Interact with the form to see result</pre>
                 </div>
                 <div class="result-arrow">→</div>
                 <div class="result-column">
                   <h5>🔧 Candid Format (Backend)</h5>
                   <pre id="candid-args" class="code-block">
-Interact with the form to see result</pre
-                  >
+Interact with the form to see result</pre>
                 </div>
               </div>
             </div>
@@ -301,8 +299,7 @@ Interact with the form to see result</pre
             <div class="codec-result">
               <h5>📋 Transformation Details:</h5>
               <pre id="encoded-result" class="code-block">
-Interact with the form to see the full transformation process</pre
-              >
+Interact with the form to see the full transformation process</pre>
             </div>
           </div>
         </section>
@@ -384,8 +381,7 @@ Interact with the form to see the full transformation process</pre
 { ok: { balance: 12345n } }
 
 // You receive directly:
-{ balance: "12345" } // Processed & Transformed</pre
-                >
+{ balance: "12345" } // Processed & Transformed</pre>
               </div>
 
               <div class="result-card err">
@@ -403,8 +399,7 @@ try {
   await reactor.callMethod({ ... })
 } catch (err) {
   // err.err = { InsufficientFunds: { balance: "0" } }
-} // Error value is also transformed!</pre
-                >
+} // Error value is also transformed!</pre>
               </div>
             </div>
 
@@ -416,8 +411,7 @@ try {
             <div class="codec-result">
               <h5>Simulated Result:</h5>
               <pre id="result-demo-output" class="code-block">
-Click "Simulate Result Unwrapping" to see how Ok/Err are handled</pre
-              >
+Click "Simulate Result Unwrapping" to see how Ok/Err are handled</pre>
             </div>
           </div>
         </section>

--- a/examples/codec-demo/src/declarations/ledger.d.ts
+++ b/examples/codec-demo/src/declarations/ledger.d.ts
@@ -111,8 +111,7 @@ export interface ConsentInfo {
   consent_message: ConsentMessage
 }
 export type ConsentMessage =
-  | { FieldsDisplayMessage: FieldsDisplay }
-  | { GenericDisplayMessage: string }
+  { FieldsDisplayMessage: FieldsDisplay } | { GenericDisplayMessage: string }
 export interface ConsentMessageMetadata {
   utc_offset_minutes: [] | [number]
   language: string
@@ -131,8 +130,7 @@ export interface DataCertificate {
   hash_tree: Uint8Array | number[]
 }
 export type DisplayMessageType =
-  | { GenericDisplay: null }
-  | { FieldsDisplay: null }
+  { GenericDisplay: null } | { FieldsDisplay: null }
 export interface ErrorInfo {
   description: string
 }
@@ -221,8 +219,7 @@ export interface InitArgs {
   feature_flags: [] | [FeatureFlags]
 }
 export type LedgerArgument =
-  | { Upgrade: [] | [UpgradeArgs] }
-  | { Init: InitArgs }
+  { Upgrade: [] | [UpgradeArgs] } | { Init: InitArgs }
 export type MetadataValue =
   | { Int: bigint }
   | { Nat: bigint }

--- a/examples/multiple-canister/src/declarations/icdv.ts
+++ b/examples/multiple-canister/src/declarations/icdv.ts
@@ -40,8 +40,7 @@ export interface AllowanceDetail {
   expires_at: [] | [bigint]
 }
 export type AllowanceResult =
-  | { Ok: Array<AllowanceDetail> }
-  | { Err: GetAllowancesError }
+  { Ok: Array<AllowanceDetail> } | { Err: GetAllowancesError }
 export interface ApprovalInfo {
   from_subaccount: [] | [Uint8Array | number[]]
   amount: bigint
@@ -176,9 +175,7 @@ export type Icrc106Error =
     }
   | { IndexPrincipalNotSet: null }
 export type IndexType =
-  | { Stable: null }
-  | { StableTyped: null }
-  | { Managed: null }
+  { Stable: null } | { StableTyped: null } | { Managed: null }
 export interface InitArgs {
   fee: [] | [Fee]
   advanced_settings: [] | [AdvancedSettings]
@@ -360,9 +357,7 @@ export interface Transfer__1 {
 }
 export type TxIndex = bigint
 export type UpdateLedgerInfoRequest =
-  | { Fee: Fee__1 }
-  | { MaxBalances: bigint }
-  | { MaxTransfers: bigint }
+  { Fee: Fee__1 } | { MaxBalances: bigint } | { MaxTransfers: bigint }
 export type UpdateLedgerInfoRequest__1 =
   | { Fee: Fee__1 }
   | { MaxAllowance: [] | [MaxAllowance] }

--- a/examples/multiple-canister/src/declarations/icrc2.ts
+++ b/examples/multiple-canister/src/declarations/icrc2.ts
@@ -122,8 +122,7 @@ export interface ConsentInfo {
   consent_message: ConsentMessage
 }
 export type ConsentMessage =
-  | { FieldsDisplayMessage: FieldsDisplay }
-  | { GenericDisplayMessage: string }
+  { FieldsDisplayMessage: FieldsDisplay } | { GenericDisplayMessage: string }
 export interface ConsentMessageMetadata {
   utc_offset_minutes: [] | [number]
   language: string
@@ -141,8 +140,7 @@ export interface Decimals {
   decimals: number
 }
 export type DisplayMessageType =
-  | { GenericDisplay: null }
-  | { FieldsDisplay: null }
+  { GenericDisplay: null } | { FieldsDisplay: null }
 export interface Duration {
   secs: bigint
   nanos: number
@@ -195,8 +193,7 @@ export interface InitArgs {
   feature_flags: [] | [FeatureFlags]
 }
 export type LedgerCanisterPayload =
-  | { Upgrade: [] | [UpgradeArgs] }
-  | { Init: InitArgs }
+  { Upgrade: [] | [UpgradeArgs] } | { Init: InitArgs }
 export type MetadataValue =
   | { Int: bigint }
   | { Nat: bigint }
@@ -230,8 +227,7 @@ export type Result_2 = { Ok: bigint } | { Err: ApproveError }
 export type Result_3 = { Ok: bigint } | { Err: TransferFromError }
 export type Result_4 = { Ok: BlockRange } | { Err: GetBlocksError }
 export type Result_5 =
-  | { Ok: Array<Uint8Array | number[]> }
-  | { Err: GetBlocksError }
+  { Ok: Array<Uint8Array | number[]> } | { Err: GetBlocksError }
 export type Result_6 = { Ok: bigint } | { Err: TransferError_1 }
 export interface SendArgs {
   to: string

--- a/examples/query-demo/src/declarations/ledger.type.ts
+++ b/examples/query-demo/src/declarations/ledger.type.ts
@@ -121,8 +121,7 @@ export interface ConsentInfo {
   consent_message: ConsentMessage
 }
 export type ConsentMessage =
-  | { FieldsDisplayMessage: FieldsDisplay }
-  | { GenericDisplayMessage: string }
+  { FieldsDisplayMessage: FieldsDisplay } | { GenericDisplayMessage: string }
 export interface ConsentMessageMetadata {
   utc_offset_minutes: [] | [number]
   language: string
@@ -140,8 +139,7 @@ export interface Decimals {
   decimals: number
 }
 export type DisplayMessageType =
-  | { GenericDisplay: null }
-  | { FieldsDisplay: null }
+  { GenericDisplay: null } | { FieldsDisplay: null }
 export interface Duration {
   secs: bigint
   nanos: number
@@ -194,8 +192,7 @@ export interface InitArgs {
   feature_flags: [] | [FeatureFlags]
 }
 export type LedgerCanisterPayload =
-  | { Upgrade: [] | [UpgradeArgs] }
-  | { Init: InitArgs }
+  { Upgrade: [] | [UpgradeArgs] } | { Init: InitArgs }
 export type MetadataValue =
   | { Int: bigint }
   | { Nat: bigint }
@@ -229,8 +226,7 @@ export type Result_2 = { Ok: bigint } | { Err: ApproveError }
 export type Result_3 = { Ok: bigint } | { Err: TransferFromError }
 export type Result_4 = { Ok: BlockRange } | { Err: GetBlocksError }
 export type Result_5 =
-  | { Ok: Array<Uint8Array | number[]> }
-  | { Err: GetBlocksError }
+  { Ok: Array<Uint8Array | number[]> } | { Err: GetBlocksError }
 export type Result_6 = { Ok: bigint } | { Err: TransferError_1 }
 export interface SendArgs {
   to: string

--- a/examples/tanstack-router/src/canisters/ledger/declarations/icrc1.did.d.ts
+++ b/examples/tanstack-router/src/canisters/ledger/declarations/icrc1.did.d.ts
@@ -75,10 +75,7 @@ export interface UpgradeArgs {
  * The value returned from the [icrc1_metadata] endpoint.
  */
 export type Value =
-  | { Int: bigint }
-  | { Nat: bigint }
-  | { Blob: Uint8Array }
-  | { Text: string }
+  { Int: bigint } | { Nat: bigint } | { Blob: Uint8Array } | { Text: string }
 export interface _SERVICE {
   icrc1_balance_of: ActorMethod<[Account], Tokens>
   icrc1_decimals: ActorMethod<[], number>

--- a/examples/typescript-demo/src/declarations/ledger.type.ts
+++ b/examples/typescript-demo/src/declarations/ledger.type.ts
@@ -121,8 +121,7 @@ export interface ConsentInfo {
   consent_message: ConsentMessage
 }
 export type ConsentMessage =
-  | { FieldsDisplayMessage: FieldsDisplay }
-  | { GenericDisplayMessage: string }
+  { FieldsDisplayMessage: FieldsDisplay } | { GenericDisplayMessage: string }
 export interface ConsentMessageMetadata {
   utc_offset_minutes: [] | [number]
   language: string
@@ -140,8 +139,7 @@ export interface Decimals {
   decimals: number
 }
 export type DisplayMessageType =
-  | { GenericDisplay: null }
-  | { FieldsDisplay: null }
+  { GenericDisplay: null } | { FieldsDisplay: null }
 export interface Duration {
   secs: bigint
   nanos: number
@@ -194,8 +192,7 @@ export interface InitArgs {
   feature_flags: [] | [FeatureFlags]
 }
 export type LedgerCanisterPayload =
-  | { Upgrade: [] | [UpgradeArgs] }
-  | { Init: InitArgs }
+  { Upgrade: [] | [UpgradeArgs] } | { Init: InitArgs }
 export type MetadataValue =
   | { Int: bigint }
   | { Nat: bigint }
@@ -229,8 +226,7 @@ export type Result_2 = { Ok: bigint } | { Err: ApproveError }
 export type Result_3 = { Ok: bigint } | { Err: TransferFromError }
 export type Result_4 = { Ok: BlockRange } | { Err: GetBlocksError }
 export type Result_5 =
-  | { Ok: Array<Uint8Array | number[]> }
-  | { Err: GetBlocksError }
+  { Ok: Array<Uint8Array | number[]> } | { Err: GetBlocksError }
 export type Result_6 = { Ok: bigint } | { Err: TransferError_1 }
 export interface SendArgs {
   to: string

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -456,8 +456,8 @@ depend on parser `dist`; parser builds remove and recreate `dist`.
 
 Script notes:
 
-- `pnpm format:check` globs `packages/**` only; root markdown, `docs/`,
-  `examples/`, and `skill-packages/` are not covered by Prettier.
+- `pnpm format:check` covers the whole repo; exclusions are declared in one
+  place, `.prettierignore`, which the pre-commit hook honours too.
 - `pnpm check:ai-context` is a CI gate asserting `llms.txt` package versions
   match each `package.json` and that every `packages/*/llms.txt` exists.
 - `pnpm typecheck` runs each package's own `typecheck` script and covers tests

--- a/llms.txt
+++ b/llms.txt
@@ -100,8 +100,8 @@ declarations, and generated hook files. For codegen behavior, edit
 
 Notes:
 
-- `pnpm format:check` globs `packages/**` only. Root markdown, `docs/`,
-  `examples/`, and `skill-packages/` are outside Prettier's reach.
+- `pnpm format:check` covers the whole repo. Exclusions are declared in one
+  place, `.prettierignore`, which the pre-commit hook honours too.
 - `pnpm check:ai-context` is a CI gate: it asserts the package versions listed
   above match each `package.json` and that every `packages/*/llms.txt` exists.
 - `pnpm typecheck` runs each package's own `typecheck` script, so `src` **and**

--- a/package.json
+++ b/package.json
@@ -22,16 +22,15 @@
     "release": "node scripts/release.js",
     "release:tools": "node scripts/release-tools.js",
     "clean": "node scripts/clean-node-modules.js",
-    "format": "prettier --write \"packages/**/*.{ts,tsx,js,jsx,json,md,mdx,css,scss,html}\"",
-    "format:check": "prettier --check \"packages/**/*.{ts,tsx,js,jsx,json,md,mdx,css,scss,html}\"",
-    "format:staged": "pnpm -r --filter './packages/**' exec prettier --write",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "prepare": "husky",
     "typecheck": "pnpm -r --filter \"./packages/**\" typecheck",
     "verify:packages": "node scripts/verify-package-artifacts.mjs"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,json,md,css,scss,html}": [
-      "prettier --write"
+    "*": [
+      "prettier --write --ignore-unknown"
     ]
   },
   "keywords": [

--- a/packages/parser/.travis.yml
+++ b/packages/parser/.travis.yml
@@ -5,65 +5,64 @@ cache: cargo
 
 matrix:
   include:
+    # Builds with wasm-pack.
+    - rust: beta
+      env: RUST_BACKTRACE=1
+      addons:
+        firefox: latest
+        chrome: stable
+      before_script:
+        - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+        - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+        - cargo install-update -a
+        - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
+      script:
+        - cargo generate --git . --name testing
+        # Having a broken Cargo.toml (in that it has curlies in fields) anywhere
+        # in any of our parent dirs is problematic.
+        - mv Cargo.toml Cargo.toml.tmpl
+        - cd testing
+        - wasm-pack build
+        - wasm-pack test --chrome --firefox --headless
 
-  # Builds with wasm-pack.
-  - rust: beta
-    env: RUST_BACKTRACE=1
-    addons:
-      firefox: latest
-      chrome: stable
-    before_script:
-      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
-      - cargo install-update -a
-      - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
-    script:
-      - cargo generate --git . --name testing
-      # Having a broken Cargo.toml (in that it has curlies in fields) anywhere
-      # in any of our parent dirs is problematic.
-      - mv Cargo.toml Cargo.toml.tmpl
-      - cd testing
-      - wasm-pack build
-      - wasm-pack test --chrome --firefox --headless
+    # Builds on nightly.
+    - rust: nightly
+      env: RUST_BACKTRACE=1
+      before_script:
+        - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+        - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+        - cargo install-update -a
+        - rustup target add wasm32-unknown-unknown
+      script:
+        - cargo generate --git . --name testing
+        - mv Cargo.toml Cargo.toml.tmpl
+        - cd testing
+        - cargo check
+        - cargo check --target wasm32-unknown-unknown
+        - cargo check                                 --no-default-features
+        - cargo check --target wasm32-unknown-unknown --no-default-features
+        - cargo check                                 --no-default-features --features console_error_panic_hook
+        - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
+        - cargo check                                 --no-default-features --features "console_error_panic_hook wee_alloc"
+        - cargo check --target wasm32-unknown-unknown --no-default-features --features "console_error_panic_hook wee_alloc"
 
-  # Builds on nightly.
-  - rust: nightly
-    env: RUST_BACKTRACE=1
-    before_script:
-      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
-      - cargo install-update -a
-      - rustup target add wasm32-unknown-unknown
-    script:
-      - cargo generate --git . --name testing
-      - mv Cargo.toml Cargo.toml.tmpl
-      - cd testing
-      - cargo check
-      - cargo check --target wasm32-unknown-unknown
-      - cargo check                                 --no-default-features
-      - cargo check --target wasm32-unknown-unknown --no-default-features
-      - cargo check                                 --no-default-features --features console_error_panic_hook
-      - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
-      - cargo check                                 --no-default-features --features "console_error_panic_hook wee_alloc"
-      - cargo check --target wasm32-unknown-unknown --no-default-features --features "console_error_panic_hook wee_alloc"
-
-  # Builds on beta.
-  - rust: beta
-    env: RUST_BACKTRACE=1
-    before_script:
-      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
-      - cargo install-update -a
-      - rustup target add wasm32-unknown-unknown
-    script:
-      - cargo generate --git . --name testing
-      - mv Cargo.toml Cargo.toml.tmpl
-      - cd testing
-      - cargo check
-      - cargo check --target wasm32-unknown-unknown
-      - cargo check                                 --no-default-features
-      - cargo check --target wasm32-unknown-unknown --no-default-features
-      - cargo check                                 --no-default-features --features console_error_panic_hook
-      - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
-      # Note: no enabling the `wee_alloc` feature here because it requires
-      # nightly for now.
+    # Builds on beta.
+    - rust: beta
+      env: RUST_BACKTRACE=1
+      before_script:
+        - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+        - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+        - cargo install-update -a
+        - rustup target add wasm32-unknown-unknown
+      script:
+        - cargo generate --git . --name testing
+        - mv Cargo.toml Cargo.toml.tmpl
+        - cd testing
+        - cargo check
+        - cargo check --target wasm32-unknown-unknown
+        - cargo check                                 --no-default-features
+        - cargo check --target wasm32-unknown-unknown --no-default-features
+        - cargo check                                 --no-default-features --features console_error_panic_hook
+        - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
+        # Note: no enabling the `wee_alloc` feature here because it requires
+        # nightly for now.

--- a/scripts/verify-package-artifacts.mjs
+++ b/scripts/verify-package-artifacts.mjs
@@ -18,7 +18,13 @@
  * Usage: node scripts/verify-package-artifacts.mjs [--skip-attw] [--keep]
  */
 import { execFileSync } from "node:child_process"
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync } from "node:fs"
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+} from "node:fs"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 
@@ -61,7 +67,13 @@ const isBinOnly = (m) =>
 const failures = []
 function fail(pkg, what, detail) {
   failures.push({ pkg, what, detail })
-  console.error(`  ✗ ${what}\n${String(detail).split("\n").slice(0, 12).map((l) => `      ${l}`).join("\n")}`)
+  console.error(
+    `  ✗ ${what}\n${String(detail)
+      .split("\n")
+      .slice(0, 12)
+      .map((l) => `      ${l}`)
+      .join("\n")}`
+  )
 }
 function ok(what) {
   console.log(`  ✓ ${what}`)
@@ -99,18 +111,41 @@ try {
   // ── 2. Install them into a scratch project outside the workspace ─────────────
   writeFileSync(
     join(scratch, "package.json"),
-    JSON.stringify({ name: "verify-esm", private: true, version: "1.0.0", type: "module" }, null, 2)
+    JSON.stringify(
+      { name: "verify-esm", private: true, version: "1.0.0", type: "module" },
+      null,
+      2
+    )
   )
-  console.log(`\ninstalling ${tarballs.length} tarballs + peers into scratch project...`)
+  console.log(
+    `\ninstalling ${tarballs.length} tarballs + peers into scratch project...`
+  )
   try {
     // --legacy-peer-deps: @icp-sdk/auth@8 still declares a peer of @icp-sdk/core@^5,
     // which npm refuses to resolve against the v6 we use. That is an upstream
     // manifest bug and is not what this script is checking.
-    run("npm", ["install", "--no-audit", "--no-fund", "--legacy-peer-deps",
-      "--loglevel", "error", ...tarballs.map((t) => `./${t.file}`), ...PEERS], { cwd: scratch })
+    run(
+      "npm",
+      [
+        "install",
+        "--no-audit",
+        "--no-fund",
+        "--legacy-peer-deps",
+        "--loglevel",
+        "error",
+        ...tarballs.map((t) => `./${t.file}`),
+        ...PEERS,
+      ],
+      { cwd: scratch }
+    )
   } catch (e) {
     console.error("install into scratch project failed:")
-    console.error(String(e.stderr || e.stdout || e.message).split("\n").slice(0, 25).join("\n"))
+    console.error(
+      String(e.stderr || e.stdout || e.message)
+        .split("\n")
+        .slice(0, 25)
+        .join("\n")
+    )
     process.exit(1)
   }
   console.log("installed\n")
@@ -120,7 +155,9 @@ try {
     console.log(`${name}`)
 
     if (isBinOnly(manifest)) {
-      ok(`skip import ${name} (bin-only package — the executable is the whole surface)`)
+      ok(
+        `skip import ${name} (bin-only package — the executable is the whole surface)`
+      )
     }
 
     // Derive the public subpaths from the exports map (skip ./package.json).
@@ -134,7 +171,9 @@ try {
     // rather than exposing a module surface. Only its declarations are checked.
     const binTargets = new Set(
       Object.values(
-        typeof manifest.bin === "string" ? { [name]: manifest.bin } : manifest.bin || {}
+        typeof manifest.bin === "string"
+          ? { [name]: manifest.bin }
+          : manifest.bin || {}
       ).map((p) => String(p).replace(/^\.\//, ""))
     )
     const isBinEntry = (target) =>
@@ -145,10 +184,10 @@ try {
 
       const entryTarget =
         sub === "."
-          ? manifest.exports?.["."]?.import?.default ??
+          ? (manifest.exports?.["."]?.import?.default ??
             manifest.exports?.["."]?.import ??
             manifest.exports?.["."]?.default ??
-            manifest.main
+            manifest.main)
           : undefined
       if (isBinEntry(entryTarget)) {
         ok(`skip import ${spec} (bin entry — importing would run the CLI)`)
@@ -157,13 +196,18 @@ try {
 
       // ESM import
       try {
-        const out = run(process.execPath, ["-e",
-          `import(${JSON.stringify(spec)}).then(m=>{
+        const out = run(
+          process.execPath,
+          [
+            "-e",
+            `import(${JSON.stringify(spec)}).then(m=>{
              const n=Object.keys(m).length;
              if(n===0) { console.error("no exports"); process.exit(1) }
              console.log("exports:"+n)
            }).catch(e=>{ console.error(e.code||"", e.message); process.exit(1) })`,
-        ], { cwd: scratch })
+          ],
+          { cwd: scratch }
+        )
         ok(`import ${spec} (${out.trim()})`)
       } catch (e) {
         fail(name, `import ${spec}`, e.stderr || e.stdout || e.message)
@@ -174,10 +218,15 @@ try {
       const hasRequire = cond && typeof cond === "object" && "require" in cond
       if (hasRequire) {
         try {
-          run(process.execPath, ["-e",
-            `const m=require(${JSON.stringify(spec)});
+          run(
+            process.execPath,
+            [
+              "-e",
+              `const m=require(${JSON.stringify(spec)});
              if(!m||Object.keys(m).length===0){console.error("no exports");process.exit(1)}`,
-          ], { cwd: scratch, env: { ...process.env } })
+            ],
+            { cwd: scratch, env: { ...process.env } }
+          )
           ok(`require ${spec}`)
         } catch (e) {
           fail(name, `require ${spec}`, e.stderr || e.stdout || e.message)
@@ -189,15 +238,23 @@ try {
     if (manifest.types || manifest.typings) {
       const declared = manifest.types || manifest.typings
       try {
-        run(process.execPath, ["-e",
-          `require("node:fs").accessSync(require("node:path").join(
+        run(
+          process.execPath,
+          [
+            "-e",
+            `require("node:fs").accessSync(require("node:path").join(
              require("node:path").dirname(require.resolve(${JSON.stringify(name + "/package.json")})),
              ${JSON.stringify(declared)}))`,
-        ], { cwd: scratch })
+          ],
+          { cwd: scratch }
+        )
         ok(`ships declared types (${declared})`)
       } catch {
-        fail(name, `declared types missing: ${declared}`,
-          "package.json advertises this file but the tarball does not contain it")
+        fail(
+          name,
+          `declared types missing: ${declared}`,
+          "package.json advertises this file but the tarball does not contain it"
+        )
       }
     }
   }
@@ -206,7 +263,9 @@ try {
   console.log("\npublint")
   for (const { name, file } of tarballs) {
     try {
-      run("npx", ["--yes", "publint@latest", join(scratch, file)], { cwd: ROOT })
+      run("npx", ["--yes", "publint@latest", join(scratch, file)], {
+        cwd: ROOT,
+      })
       ok(`publint ${name}`)
     } catch (e) {
       fail(name, `publint ${name}`, e.stdout || e.stderr || e.message)
@@ -228,8 +287,20 @@ try {
         // root-level shim files.
         // cjs-resolves-to-esm: core/react/candid/cli are deliberately ESM-only
         //   ("type": "module", no require condition); CJS consumers use dynamic import.
-        run("npx", ["--yes", "@arethetypeswrong/cli@latest", "--pack", join(scratch, file),
-          "--profile", "node16", "--ignore-rules", "cjs-resolves-to-esm"], { cwd: ROOT })
+        run(
+          "npx",
+          [
+            "--yes",
+            "@arethetypeswrong/cli@latest",
+            "--pack",
+            join(scratch, file),
+            "--profile",
+            "node16",
+            "--ignore-rules",
+            "cjs-resolves-to-esm",
+          ],
+          { cwd: ROOT }
+        )
         ok(`attw ${name}`)
       } catch (e) {
         fail(name, `attw ${name}`, e.stdout || e.stderr || e.message)

--- a/skill-packages/ic-reactor-packages/SKILL.md
+++ b/skill-packages/ic-reactor-packages/SKILL.md
@@ -70,7 +70,7 @@ dapp on a custom domain falls through it.
 
 Use CI-aligned commands:
 
-- Format check (CI gate, covers `packages/**` only): `pnpm format:check`
+- Format check (CI gate, covers the whole repo): `pnpm format:check`
 - AI context check (CI gate): `pnpm check:ai-context`
 - Type check every package including tests (CI gate): `pnpm typecheck`
 - Strict project-reference sanity: `pnpm exec tsc -b`

--- a/skill-packages/ic-reactor-packages/references/package-map.md
+++ b/skill-packages/ic-reactor-packages/references/package-map.md
@@ -70,8 +70,8 @@ re-runs the tests against a base revision, and a test that passes with and
 without the fix proves nothing about it.
 
 `pnpm typecheck` runs each package's own `typecheck` script, so it covers tests
-as well as `src`. `pnpm format:check` only globs `packages/**`, so Prettier
-never sees root markdown, `docs/`, `examples/`, or `skill-packages/`.
+as well as `src`. `pnpm format:check` covers the whole repo, with
+exclusions declared in one place, `.prettierignore`.
 
 Add `pnpm typecheck:examples` **and `pnpm build:examples`** when example
 compatibility may be affected — the type check never loads a bundler, so a


### PR DESCRIPTION
Closes #343

`format:check` globbed `packages/**` while `.husky/pre-commit` ran lint-staged with an unrestricted basename glob. Files were therefore formatted on commit locally, but CI accepted unformatted files that landed any other way — a web-UI edit, a bot PR, a merge resolution — and the next local commit touching the same file reformatted it as unrelated noise.

Both sides now run over the whole repo, with exclusions declared in exactly one place, `.prettierignore`, which Prettier and lint-staged both honour. The gate set and the hook set are now identical by construction rather than by coincidence.

## Review notes

- **Prettier reads only the *root* `.gitignore` plus `.prettierignore`, never a nested `.gitignore`**, so every build directory covered only by a nested one had to be repeated. `.next/` and `examples/*/out/` alone accounted for most of the files a repo-wide check flagged in a built tree.
- **`public/` → `docs/public/`.** The bare form was inert under the old glob; repo-wide it matches at any depth and would have permanently excluded three hand-written example files.
- **Two MDX files were hand-fixed before the reformat**, because Prettier's MDX printer would otherwise change what they render: a `<Steps>` list collapsing into one reflowed paragraph, and ``` fences escalating to ```` with the embedded TypeScript dedented.
- **`format:staged` is deleted** — grep finds no consumer; the hook goes through lint-staged.

## A pre-existing bug this surfaced

The vite-plugin `declarations/backend.*` outputs are tracked but generator-owned: committed Prettier-formatted, regenerated in the generator's own style. So `pnpm build:examples` left the tree unformatted. They're ignored here for the same reason `**/next-env.d.ts` already is; the generator emitting unformatted output is worth a separate fix.

## Verification

- `format:check` green on a clean tree **and on a fully built one** (packages + examples + docs) — the built-tree case is what exposed the gap above
- tracked-file set and gate set agree: `git ls-files -z | xargs -0 prettier --check --ignore-unknown` → 0
- **gate proven non-vacuous:** unformatted probes under `scripts/`, `docs/` and `.github/` fail the new gate and pass the old one
- `lint:mdx`, `docs:build` (180 pages, `<Steps>` still renders) and `check:ai-context` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)