### PR TITLE
ci: use the setup-rust-wasm composite on the release paths (#345)

### DIFF
--- a/.github/workflows/release-tools.yml
+++ b/.github/workflows/release-tools.yml
@@ -125,10 +125,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter '!./examples/**'
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          targets: wasm32-unknown-unknown
+      - name: Setup Rust for the parser wasm build
+        uses: ./.github/actions/setup-rust-wasm
 
       - name: Build, type check and test
         run: |
@@ -215,7 +213,13 @@ jobs:
         run: pnpm install --frozen-lockfile --filter "./packages/**..."
 
       # Build the selected package and its dependency graph.
-      - name: Build packages
+      # Every workspace in this matrix reaches the parser: the shortest leg,
+      # `{./packages/parser}...`, is core + parser + candid, and the others add
+      # codegen / cli / vite-plugin on top. So all four run the wasm-pack build.
+      - name: Setup Rust for the parser wasm build
+        uses: ./.github/actions/setup-rust-wasm
+
+      - name: Build package dependency graph
         run: pnpm -r --filter "{./${{ matrix.workspace }}}..." build
 
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter '!./examples/**'
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          targets: wasm32-unknown-unknown
+      - name: Setup Rust for the parser wasm build
+        uses: ./.github/actions/setup-rust-wasm
 
       - name: Build, type check and test
         run: |
@@ -176,19 +174,14 @@ jobs:
         # unreleased workspaces out of v3 tags.
         run: pnpm install --frozen-lockfile --filter "{./${{ matrix.workspace }}}..."
 
-      - name: Cache Rust dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            packages/parser/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/parser/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      # parser is released separately via the release-tools workflow, so we don't need to
-      # build it here. keeping this step slows down the job.
+      # Only the candid leg reaches the parser: `{./packages/candid}...` expands
+      # to core + candid + parser, so that leg runs the wasm-pack build and needs
+      # the toolchain and the cargo cache. The core and react legs expand to
+      # core and core + react, so they skip this entirely. (The comment this
+      # replaces claimed the parser was never built here, which was false.)
+      - name: Setup Rust for the parser wasm build
+        if: matrix.workspace == 'packages/candid'
+        uses: ./.github/actions/setup-rust-wasm
 
       # Build this publishable package and the workspace packages it depends on.
       - name: Build package dependency graph


### PR DESCRIPTION
Closes #345 — the release half, split from #396 because these two workflows publish to npm. npm versions are immutable and these paths cannot be dry-run, so this is worth reviewing and reverting on its own.

> **Stacked on #396.** Base is `ci/dedupe-345`; merge #395 then #396 first.

Both preflight jobs installed the Rust toolchain with **no cargo cache at all**; they now use the composite, which carries both halves.

## A comment that was actively wrong

`release.yml`'s release matrix carried a `Cache Rust dependencies` block for all three legs, guarded by a comment claiming *"parser is released separately via the release-tools workflow, so we don't need to build it here."* Measured:

```
packages/core   -> core
packages/react  -> core react
packages/candid -> core candid parser
```

`{./packages/candid}...` expands to include the parser, so the candid leg **does** run the wasm-pack build — with a cache but no Rust setup. The block is replaced by the composite guarded on `matrix.workspace == 'packages/candid'`, so the leg that builds the parser gets both halves and the two that don't skip the step entirely.

`release-tools.yml`'s release matrix had neither a toolchain step nor a cargo cache, yet every one of its four legs reaches the parser:

```
packages/parser      -> core parser candid
packages/codegen     -> core parser candid codegen
packages/vite-plugin -> core parser candid codegen vite-plugin
packages/cli         -> core parser candid codegen cli
```

so the composite goes on unconditionally there. Its `Build packages` step is renamed `Build package dependency graph`, which is what `pnpm -r --filter "{./<ws>}..." build` actually does.

## Risk

The changes are additive — one composite step per job, one step rename, one corrected comment. **No build, pack, or publish command changes.** Actions resolves a local composite from the commit the tag points at, so tagging a pre-merge commit degrades safely: that commit's workflow has no composite reference.

## Verification

The machine check over every workflow is now **9 ok / 0 failures** (from 10 failures on main). No bare `rust-toolchain` or cargo-cache step remains anywhere; all workflows parse and `format:check` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)