### PR TITLE
ci: add dependency review and a workspace audit gate (#342)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,68 @@
+name: Dependency Review
+
+# PR-only. dependency-review-action diffs the dependency graph between a base
+# ref and a head ref, so it has nothing to compare against on a push to main --
+# which is also why this cannot live in ci.yml, which runs on both.
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
+        with:
+          fail-on-severity: high
+          # The lockfile entries GitHub reports carry scope "runtime" regardless
+          # of whether the importer is a devDependency, so the default scope
+          # filter would not hide them. Manifest entries for devDependencies do
+          # come through as "development" and would be filtered, so both scopes
+          # are named explicitly rather than relying on that asymmetry.
+          fail-on-scopes: runtime, development
+
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Deliberately install-free: `pnpm audit` resolves the whole workspace from
+    # pnpm-lock.yaml and never reads node_modules, so this job needs no pnpm
+    # store cache and no Rust toolchain, unlike every other job in this repo.
+    #
+    # dependency-review-action alone would not have caught what motivated this
+    # gate. It diffs base against head, so it only reports dependencies a PR
+    # introduces or upgrades into a vulnerable version -- it is blind to a
+    # dependency that was already on main and became vulnerable later, when a new
+    # advisory was published against a version the lockfile had pinned all along.
+    # That is exactly how four high-severity fast-uri advisories went unnoticed.
+    # This job re-audits the whole tree on every PR, so decay surfaces.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.3 --activate
+          pnpm --version
+
+      - name: Audit the workspace
+        run: pnpm verify:audit

--- a/.github/workflows/release-tools.yml
+++ b/.github/workflows/release-tools.yml
@@ -125,10 +125,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter '!./examples/**'
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          targets: wasm32-unknown-unknown
+      - name: Setup Rust for the parser wasm build
+        uses: ./.github/actions/setup-rust-wasm
 
       - name: Build, type check and test
         run: |
@@ -215,7 +213,13 @@ jobs:
         run: pnpm install --frozen-lockfile --filter "./packages/**..."
 
       # Build the selected package and its dependency graph.
-      - name: Build packages
+      # Every workspace in this matrix reaches the parser: the shortest leg,
+      # `{./packages/parser}...`, is core + parser + candid, and the others add
+      # codegen / cli / vite-plugin on top. So all four run the wasm-pack build.
+      - name: Setup Rust for the parser wasm build
+        uses: ./.github/actions/setup-rust-wasm
+
+      - name: Build package dependency graph
         run: pnpm -r --filter "{./${{ matrix.workspace }}}..." build
 
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter '!./examples/**'
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          targets: wasm32-unknown-unknown
+      - name: Setup Rust for the parser wasm build
+        uses: ./.github/actions/setup-rust-wasm
 
       - name: Build, type check and test
         run: |
@@ -176,19 +174,14 @@ jobs:
         # unreleased workspaces out of v3 tags.
         run: pnpm install --frozen-lockfile --filter "{./${{ matrix.workspace }}}..."
 
-      - name: Cache Rust dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            packages/parser/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/parser/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      # parser is released separately via the release-tools workflow, so we don't need to
-      # build it here. keeping this step slows down the job.
+      # Only the candid leg reaches the parser: `{./packages/candid}...` expands
+      # to core + candid + parser, so that leg runs the wasm-pack build and needs
+      # the toolchain and the cargo cache. The core and react legs expand to
+      # core and core + react, so they skip this entirely. (The comment this
+      # replaces claimed the parser was never built here, which was false.)
+      - name: Setup Rust for the parser wasm build
+        if: matrix.workspace == 'packages/candid'
+        uses: ./.github/actions/setup-rust-wasm
 
       # Build this publishable package and the workspace packages it depends on.
       - name: Build package dependency graph

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Use this map before editing so you can start in the package that owns the behavi
 - Example type checks: `pnpm typecheck:examples`
 - Example builds (CI gate): `pnpm build:examples` — `tsc` never loads a bundler, so a broken Vite/Next config type-checks clean. Both Next.js examples were unbuildable while the type-check job stayed green.
 - Docs build: `pnpm docs:build`
-- Dependency audit: `corepack pnpm audit --audit-level moderate`
+- Dependency audit (CI gate on every PR): `pnpm verify:audit`
 
 Generated outputs under `dist`, `.dfx`, `.icp`, `.mops`, `target`, `.next`, `.astro`, and `*.tsbuildinfo` are normally build artifacts. Do not hand-edit generated hook files; change the generator, wrapper, or source `.did` instead.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ pnpm format:check       # Verify formatting without writing (CI gate, whole repo
 pnpm check:ai-context   # Verify llms.txt versions match package.json (CI gate)
 pnpm size               # size-limit gate for core/react/candid/parser (CI gate)
 pnpm verify:packages    # Pack + publint + attw + real-Node import of published artifacts
+pnpm verify:audit       # pnpm audit --audit-level=high over the workspace (CI gate)
 pnpm verify:test-fails <file> --package <pkg>  # Check a new test actually fails without the fix
 pnpm docs:build         # Build docs site
 ```

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "format:check": "prettier --check .",
     "prepare": "husky",
     "typecheck": "pnpm -r --filter \"./packages/**\" typecheck",
-    "verify:packages": "node scripts/verify-package-artifacts.mjs"
+    "verify:packages": "node scripts/verify-package-artifacts.mjs",
+    "verify:audit": "pnpm audit --audit-level=high"
   },
   "lint-staged": {
     "*": [
@@ -58,7 +59,7 @@
       "axios": "^1.16.0",
       "brace-expansion": "^5.0.9",
       "devalue": "^5.8.1",
-      "fast-uri": "^3.1.5",
+      "fast-uri": "^3.1.6",
       "h3": "^1.15.9",
       "picomatch": "^4.0.4",
       "postcss": "^8.5.26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   axios: ^1.16.0
   brace-expansion: ^5.0.9
   devalue: ^5.8.1
-  fast-uri: ^3.1.5
+  fast-uri: ^3.1.6
   h3: ^1.15.9
   picomatch: ^4.0.4
   postcss: ^8.5.26
@@ -5549,8 +5549,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -11884,7 +11884,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12837,7 +12837,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/skill-packages/ic-reactor-packages/SKILL.md
+++ b/skill-packages/ic-reactor-packages/SKILL.md
@@ -80,7 +80,7 @@ Use CI-aligned commands:
 - Example type checks: `pnpm typecheck:examples`
 - Example builds (CI gate — `tsc` never loads a bundler, so a broken Vite or Next config type-checks clean): `pnpm build:examples`
 - Docs build: `pnpm docs:build`
-- Dependency audit: `corepack pnpm audit --audit-level moderate`
+- Dependency audit (CI gate on every PR): `pnpm verify:audit`
 
 Run `pnpm verify:packages` after any change to a package's `exports`, `files`,
 build output, or module format — in-repo consumers resolve through workspace

--- a/skill-packages/ic-reactor-packages/references/package-map.md
+++ b/skill-packages/ic-reactor-packages/references/package-map.md
@@ -51,7 +51,7 @@ For each package touched:
 | CLI                            | `pnpm --filter @ic-reactor/cli test`, `pnpm --filter @ic-reactor/cli build`; add a focused manual run for behaviour the suite does not cover |
 | Vite plugin                    | `pnpm --filter @ic-reactor/vite-plugin test`, affected Vite example build/run                                                                |
 | Package metadata or references | `pnpm typecheck`, `pnpm exec tsc -b`, `pnpm build`, `pnpm verify:packages`                                                                   |
-| Dependency/security work       | `corepack pnpm audit --audit-level moderate`, affected package builds/tests                                                                  |
+| Dependency/security work       | `pnpm verify:audit`, affected package builds/tests                                                                                           |
 
 Before finishing broad PR work, prefer:
 


### PR DESCRIPTION
Closes #342

> **Stacked on #397.** Base is `ci/dedupe-345-release`; merge #395 → #396 → #397 first.

Two jobs on `pull_request`, plus the fix for what they immediately caught.

## ⚠️ The advisories were already live on `main`

`pnpm audit --audit-level=high` exits 1 today with four high-severity advisories, all `fast-uri@3.1.5` reached by one path, `docs > serve > ajv > fast-uri`:

| Advisory | Issue |
|---|---|
| GHSA-5jgf-p345-68v8 | host confusion via skipped IDN canonicalization |
| GHSA-f65p-4m7j-42xc | SSRF via malformed IPv6 normalization |
| GHSA-fph4-wmhf-6fwf | SSRF via repeated hostname percent-decoding |
| GHSA-jqff-g426-hqxp | host confusion via percent-encoded scheme normalization |

All four are patched in `>=3.1.6`, and GitHub reports the same four as open Dependabot alerts.

This is the `pnpm.overrides` block decaying in real time — and note the range `^3.1.5` **already admitted** 3.1.7. No edit was ever needed to become vulnerable; time alone did it, and only the frozen lockfile held it at the vulnerable version. The override moves to `^3.1.6`; the relock is 10 lines, every one of them fast-uri (3.1.5 → 3.1.7).

## Why two jobs and not one

`dependency-review-action` diffs base against head, so it only reports dependencies a PR *introduces or upgrades* into a vulnerable version. It is structurally blind to a dependency that was already on main and became vulnerable later, when a new advisory was published against a version the lockfile had pinned all along — **which is exactly what happened here.** So the `audit` job re-audits the whole tree on every PR.

That job is deliberately install-free: `pnpm audit` resolves the workspace from `pnpm-lock.yaml` and never reads node_modules, so it needs no store cache and no Rust toolchain.

## Known ongoing cost, stated plainly

`pnpm audit` cannot be workspace-scoped (`--filter` is rejected; pnpm 10 offers only `--dev`/`--prod`/`--no-optional`), and `pnpm-workspace.yaml` includes `examples/*` — so **all 20 example apps are audited importers.** One high advisory against a Next.js or Vite dependency will block every PR until someone bumps an example manifest and relocks.

The job stays blocking anyway: a full-tree audit under `continue-on-error` is precisely the "gate that cannot fail" pattern this set of issues exists to eliminate. The escape hatch is the `pnpm.overrides` block, the mechanism already in use. Note `pnpm audit --ignore` is **not** a CI flag — it writes a `pnpm.auditConfig.ignoreCves` entry into package.json and matches CVE ids only, so advisories with no CVE cannot be suppressed that way.

Both checks are advisory-red rather than merge-blocking: `main` carries no branch protection and no active branch ruleset. Making them required is a repo-settings change outside this PR.

## Verification

- audit exits 1 before the override bump, 0 after (leaving only the below-threshold esbuild low)
- `pnpm install --lockfile-only --frozen-lockfile` still exits 0 — CI's install mode unaffected
- **gate proven non-vacuous:** adding `lodash@4.17.20` (GHSA-35jh-r3h4-6jhm, confirmed high via the API) fails it with `Paths: packages__core>lodash`; removing it passes
- the action pin `a1d282b` is the real v5.0.0 tag, confirmed via `git ls-remote`

🤖 Generated with [Claude Code](https://claude.com/claude-code)