### PR TITLE
ci: type-check packages/parser and e2e/ (#340)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -104,7 +104,7 @@ Follow these repository-specific patterns when suggesting code:
 
 - Format check (CI gate; covers the whole repo): `pnpm format:check`
 - AI context check (CI gate): `pnpm check:ai-context`
-- Type check used by CI: `pnpm typecheck` (every package, `src` and tests; the root `tsconfig.json` is references-only, so `pnpm exec tsc --noEmit` at the root checks nothing)
+- Type check used by CI: `pnpm typecheck` (every package plus `e2e/`, `src` and tests; the root `tsconfig.json` is references-only, so `pnpm exec tsc --noEmit` at the root checks nothing)
 - Package builds: `pnpm build`
 - Package tests: `pnpm test`
 - Published-artifact verification: `pnpm verify:packages` (pack + publint + attw + real Node import; run it after `exports`/`files`/build-output changes)

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,68 @@
+name: Dependency Review
+
+# PR-only. dependency-review-action diffs the dependency graph between a base
+# ref and a head ref, so it has nothing to compare against on a push to main --
+# which is also why this cannot live in ci.yml, which runs on both.
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
+        with:
+          fail-on-severity: high
+          # The lockfile entries GitHub reports carry scope "runtime" regardless
+          # of whether the importer is a devDependency, so the default scope
+          # filter would not hide them. Manifest entries for devDependencies do
+          # come through as "development" and would be filtered, so both scopes
+          # are named explicitly rather than relying on that asymmetry.
+          fail-on-scopes: runtime, development
+
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Deliberately install-free: `pnpm audit` resolves the whole workspace from
+    # pnpm-lock.yaml and never reads node_modules, so this job needs no pnpm
+    # store cache and no Rust toolchain, unlike every other job in this repo.
+    #
+    # dependency-review-action alone would not have caught what motivated this
+    # gate. It diffs base against head, so it only reports dependencies a PR
+    # introduces or upgrades into a vulnerable version -- it is blind to a
+    # dependency that was already on main and became vulnerable later, when a new
+    # advisory was published against a version the lockfile had pinned all along.
+    # That is exactly how four high-severity fast-uri advisories went unnoticed.
+    # This job re-audits the whole tree on every PR, so decay surfaces.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.3 --activate
+          pnpm --version
+
+      - name: Audit the workspace
+        run: pnpm verify:audit

--- a/.github/workflows/release-tools.yml
+++ b/.github/workflows/release-tools.yml
@@ -125,10 +125,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter '!./examples/**'
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          targets: wasm32-unknown-unknown
+      - name: Setup Rust for the parser wasm build
+        uses: ./.github/actions/setup-rust-wasm
 
       - name: Build, type check and test
         run: |
@@ -215,7 +213,13 @@ jobs:
         run: pnpm install --frozen-lockfile --filter "./packages/**..."
 
       # Build the selected package and its dependency graph.
-      - name: Build packages
+      # Every workspace in this matrix reaches the parser: the shortest leg,
+      # `{./packages/parser}...`, is core + parser + candid, and the others add
+      # codegen / cli / vite-plugin on top. So all four run the wasm-pack build.
+      - name: Setup Rust for the parser wasm build
+        uses: ./.github/actions/setup-rust-wasm
+
+      - name: Build package dependency graph
         run: pnpm -r --filter "{./${{ matrix.workspace }}}..." build
 
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter '!./examples/**'
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          targets: wasm32-unknown-unknown
+      - name: Setup Rust for the parser wasm build
+        uses: ./.github/actions/setup-rust-wasm
 
       - name: Build, type check and test
         run: |
@@ -176,19 +174,14 @@ jobs:
         # unreleased workspaces out of v3 tags.
         run: pnpm install --frozen-lockfile --filter "{./${{ matrix.workspace }}}..."
 
-      - name: Cache Rust dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            packages/parser/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/parser/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      # parser is released separately via the release-tools workflow, so we don't need to
-      # build it here. keeping this step slows down the job.
+      # Only the candid leg reaches the parser: `{./packages/candid}...` expands
+      # to core + candid + parser, so that leg runs the wasm-pack build and needs
+      # the toolchain and the cargo cache. The core and react legs expand to
+      # core and core + react, so they skip this entirely. (The comment this
+      # replaces claimed the parser was never built here, which was false.)
+      - name: Setup Rust for the parser wasm build
+        if: matrix.workspace == 'packages/candid'
+        uses: ./.github/actions/setup-rust-wasm
 
       # Build this publishable package and the workspace packages it depends on.
       - name: Build package dependency graph

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Use this map before editing so you can start in the package that owns the behavi
 
 - Format check (CI gate; covers the whole repo, with exclusions declared in `.prettierignore`): `pnpm format:check`
 - AI context check (CI gate; asserts `llms.txt` versions match every `package.json` and each `packages/*/llms.txt` exists): `pnpm check:ai-context`
-- Type check used by CI: `pnpm typecheck` — runs each package's own `typecheck` script, covering `src` and tests. The root `tsconfig.json` is references-only, so `pnpm exec tsc --noEmit` at the root checks nothing.
+- Type check used by CI: `pnpm typecheck` — runs each package's own `typecheck` script plus `e2e/`'s, covering `src` and tests. The root `tsconfig.json` is references-only, so `pnpm exec tsc --noEmit` at the root checks nothing.
 - Package builds: `pnpm build`
 - Package tests: `pnpm test`
 - Published-artifact verification: `pnpm verify:packages` — packs every publishable package, installs the tarballs outside the workspace, imports/requires each entry point in real Node, and runs `publint` + `attw`. Run it after any change to `exports`, `files`, build output, or module format; in-repo consumers resolve through workspace symlinks, so nothing else catches a broken published artifact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Use this map before editing so you can start in the package that owns the behavi
 - Example type checks: `pnpm typecheck:examples`
 - Example builds (CI gate): `pnpm build:examples` — `tsc` never loads a bundler, so a broken Vite/Next config type-checks clean. Both Next.js examples were unbuildable while the type-check job stayed green.
 - Docs build: `pnpm docs:build`
-- Dependency audit: `corepack pnpm audit --audit-level moderate`
+- Dependency audit (CI gate on every PR): `pnpm verify:audit`
 
 Generated outputs under `dist`, `.dfx`, `.icp`, `.mops`, `target`, `.next`, `.astro`, and `*.tsbuildinfo` are normally build artifacts. Do not hand-edit generated hook files; change the generator, wrapper, or source `.did` instead.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ Skills are structured instruction sets stored in `skill-packages/`. When a task 
 pnpm install            # Install dependencies
 pnpm build              # Build all packages
 pnpm test               # Run all tests
-pnpm typecheck          # Type-check every package incl. tests (CI gate)
+pnpm typecheck          # Type-check every package + e2e/, incl. tests (CI gate)
 pnpm typecheck:examples # Type-check example apps
 pnpm build:examples     # Build every example app (CI gate)
 pnpm format             # Format the whole repo with Prettier

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ pnpm format:check       # Verify formatting without writing (CI gate, whole repo
 pnpm check:ai-context   # Verify llms.txt versions match package.json (CI gate)
 pnpm size               # size-limit gate for core/react/candid/parser (CI gate)
 pnpm verify:packages    # Pack + publint + attw + real-Node import of published artifacts
+pnpm verify:audit       # pnpm audit --audit-level=high over the workspace (CI gate)
 pnpm verify:test-fails <file> --package <pkg>  # Check a new test actually fails without the fix
 pnpm docs:build         # Build docs site
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ CI gate operate on exactly the same set of files.
 
 ```bash
 pnpm check:ai-context  # llms.txt versions match every package.json
-pnpm typecheck         # every package, including its tests
+pnpm typecheck         # every package and e2e/, including their tests
 ```
 
 If you changed a package's `exports`, `files`, build output, or module format,

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -10,8 +10,11 @@
 # dfx temporary files
 .dfx/
 
-# generated files
-declarations/
+# generated files. src/declarations/ is deliberately NOT ignored: src/index.ts
+# imports it, so `tsc` cannot resolve the project without it, and CI never runs
+# the generator before type-checking. It regenerates byte-identically from the
+# tracked src/actor/hello_actor.did, with no replica.
+src/*.generated.ts
 
 # rust
 target/

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "bash ./test.sh",
     "test": "bash ./test.sh",
-    "test:vitest": "vitest run"
+    "test:vitest": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@ic-reactor/core": "workspace:*",

--- a/e2e/src/declarations/hello_actor.d.ts
+++ b/e2e/src/declarations/hello_actor.d.ts
@@ -1,0 +1,10 @@
+import type { Principal } from '@icp-sdk/core/principal';
+import type { ActorMethod } from '@icp-sdk/core/agent';
+import type { IDL } from '@icp-sdk/core/candid';
+
+export interface _SERVICE {
+  'greet' : ActorMethod<[string], string>,
+  'greet_update' : ActorMethod<[string], string>,
+}
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/e2e/src/declarations/hello_actor.did
+++ b/e2e/src/declarations/hello_actor.did
@@ -1,0 +1,4 @@
+service : {
+    "greet" : (text) -> (text) query;
+    "greet_update" : (text) -> (text)
+}

--- a/e2e/src/declarations/hello_actor.js
+++ b/e2e/src/declarations/hello_actor.js
@@ -1,0 +1,7 @@
+export const idlFactory = ({ IDL }) => {
+  return IDL.Service({
+    'greet' : IDL.Func([IDL.Text], [IDL.Text], ['query']),
+    'greet_update' : IDL.Func([IDL.Text], [IDL.Text], []),
+  });
+};
+export const init = ({ IDL }) => { return []; };

--- a/e2e/tsconfig.typecheck.json
+++ b/e2e/tsconfig.typecheck.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "setup.ts", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist", "src/**/*.generated.ts"]
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -460,7 +460,7 @@ Script notes:
   place, `.prettierignore`, which the pre-commit hook honours too.
 - `pnpm check:ai-context` is a CI gate asserting `llms.txt` package versions
   match each `package.json` and that every `packages/*/llms.txt` exists.
-- `pnpm typecheck` runs each package's own `typecheck` script and covers tests
+- `pnpm typecheck` runs each package's own `typecheck` script plus `e2e/`'s and covers tests
   as well as `src`. The root `tsconfig.json` is references-only, so
   `pnpm exec tsc --noEmit` at the root type-checks nothing.
 - `pnpm verify:packages` packs every publishable package, installs the tarballs

--- a/llms.txt
+++ b/llms.txt
@@ -104,7 +104,7 @@ Notes:
   place, `.prettierignore`, which the pre-commit hook honours too.
 - `pnpm check:ai-context` is a CI gate: it asserts the package versions listed
   above match each `package.json` and that every `packages/*/llms.txt` exists.
-- `pnpm typecheck` runs each package's own `typecheck` script, so `src` **and**
+- `pnpm typecheck` runs each package's own `typecheck` script plus `e2e/`'s, so `src` **and**
   tests are covered. The root `tsconfig.json` is references-only, so
   `pnpm exec tsc --noEmit` at the root checks nothing.
 - `pnpm verify:packages` packs every publishable package, installs the tarballs

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",
-    "typecheck": "pnpm -r --filter \"./packages/**\" typecheck",
+    "typecheck": "pnpm -r --filter \"./packages/**\" --filter \"./e2e\" typecheck",
     "verify:packages": "node scripts/verify-package-artifacts.mjs",
     "verify:audit": "pnpm audit --audit-level=high"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "format:check": "prettier --check .",
     "prepare": "husky",
     "typecheck": "pnpm -r --filter \"./packages/**\" typecheck",
-    "verify:packages": "node scripts/verify-package-artifacts.mjs"
+    "verify:packages": "node scripts/verify-package-artifacts.mjs",
+    "verify:audit": "pnpm audit --audit-level=high"
   },
   "lint-staged": {
     "*": [
@@ -58,7 +59,7 @@
       "axios": "^1.16.0",
       "brace-expansion": "^5.0.9",
       "devalue": "^5.8.1",
-      "fast-uri": "^3.1.5",
+      "fast-uri": "^3.1.6",
       "h3": "^1.15.9",
       "picomatch": "^4.0.4",
       "postcss": "^8.5.26",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -68,7 +68,8 @@
     "start": "tsc --watch",
     "test": "vitest run",
     "clean": "rm -rf dist tsconfig.tsbuildinfo && tsc -b",
-    "size": "size-limit"
+    "size": "size-limit",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
   },
   "devDependencies": {
     "@ic-reactor/candid": "workspace:*",

--- a/packages/parser/tests/parser-schema.test.ts
+++ b/packages/parser/tests/parser-schema.test.ts
@@ -349,7 +349,11 @@ describe("Candid Schema Parser (parseDid)", () => {
       docs: ["Save succeeded."],
     })
 
-    const idField = okField?.type.fields.find((f: any) => f.name === "id")
+    if (okField?.type.kind !== "record") {
+      throw new Error("Expected the Ok variant field to carry an inline record")
+    }
+
+    const idField = okField.type.fields.find((f: any) => f.name === "id")
     expect(idField?.metadata).toEqual({
       description: "Stored profile identifier.",
       docs: ["Stored profile identifier.", "@minLength 2"],

--- a/packages/parser/tsconfig.typecheck.json
+++ b/packages/parser/tsconfig.typecheck.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "emitDeclarationOnly": false,
+    "incremental": false,
+    "types": ["node"],
+    "rootDir": ".",
+    "noUnusedLocals": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   axios: ^1.16.0
   brace-expansion: ^5.0.9
   devalue: ^5.8.1
-  fast-uri: ^3.1.5
+  fast-uri: ^3.1.6
   h3: ^1.15.9
   picomatch: ^4.0.4
   postcss: ^8.5.26
@@ -5549,8 +5549,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -11884,7 +11884,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12837,7 +12837,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/skill-packages/ic-reactor-packages/SKILL.md
+++ b/skill-packages/ic-reactor-packages/SKILL.md
@@ -80,7 +80,7 @@ Use CI-aligned commands:
 - Example type checks: `pnpm typecheck:examples`
 - Example builds (CI gate — `tsc` never loads a bundler, so a broken Vite or Next config type-checks clean): `pnpm build:examples`
 - Docs build: `pnpm docs:build`
-- Dependency audit: `corepack pnpm audit --audit-level moderate`
+- Dependency audit (CI gate on every PR): `pnpm verify:audit`
 
 Run `pnpm verify:packages` after any change to a package's `exports`, `files`,
 build output, or module format — in-repo consumers resolve through workspace

--- a/skill-packages/ic-reactor-packages/SKILL.md
+++ b/skill-packages/ic-reactor-packages/SKILL.md
@@ -72,7 +72,7 @@ Use CI-aligned commands:
 
 - Format check (CI gate, covers the whole repo): `pnpm format:check`
 - AI context check (CI gate): `pnpm check:ai-context`
-- Type check every package including tests (CI gate): `pnpm typecheck`
+- Type check every package and `e2e/`, including tests (CI gate): `pnpm typecheck`
 - Strict project-reference sanity: `pnpm exec tsc -b`
 - Package builds: `pnpm build`
 - Package tests: `pnpm test`

--- a/skill-packages/ic-reactor-packages/references/package-map.md
+++ b/skill-packages/ic-reactor-packages/references/package-map.md
@@ -69,7 +69,7 @@ When the change fixes a bug, also run
 re-runs the tests against a base revision, and a test that passes with and
 without the fix proves nothing about it.
 
-`pnpm typecheck` runs each package's own `typecheck` script, so it covers tests
+`pnpm typecheck` runs each package's own `typecheck` script plus `e2e/`'s, so it covers tests
 as well as `src`. `pnpm format:check` covers the whole repo, with
 exclusions declared in one place, `.prettierignore`.
 

--- a/skill-packages/ic-reactor-packages/references/package-map.md
+++ b/skill-packages/ic-reactor-packages/references/package-map.md
@@ -51,7 +51,7 @@ For each package touched:
 | CLI                            | `pnpm --filter @ic-reactor/cli test`, `pnpm --filter @ic-reactor/cli build`; add a focused manual run for behaviour the suite does not cover |
 | Vite plugin                    | `pnpm --filter @ic-reactor/vite-plugin test`, affected Vite example build/run                                                                |
 | Package metadata or references | `pnpm typecheck`, `pnpm exec tsc -b`, `pnpm build`, `pnpm verify:packages`                                                                   |
-| Dependency/security work       | `corepack pnpm audit --audit-level moderate`, affected package builds/tests                                                                  |
+| Dependency/security work       | `pnpm verify:audit`, affected package builds/tests                                                                                           |
 
 Before finishing broad PR work, prefer:
 


### PR DESCRIPTION
Closes #340

> **Stacked on #398.** Base is `ci/dependency-review-342`; merge #395 → #396 → #397 → #398 first.

The root gate was `pnpm -r --filter "./packages/**" typecheck`, which only reaches packages that define a `typecheck` script. `packages/parser` defined none, so its TypeScript was checked by nothing; `e2e/` was outside the filter entirely. Both now have a `tsconfig.typecheck.json` + `typecheck` script — scope goes from 7 workspace projects to 8.

## ⚠️ The e2e half needed a fix first, and it was not the one the issue describes

`e2e/src/declarations/` was gitignored and untracked, while `e2e/src/index.ts` does `export * from "./declarations/hello_actor"`. On a clean checkout — the CI state — that directory does not exist.

Wiring e2e into the gate as specified would have turned three green jobs red on every PR **and blocked every npm release**, since `release.yml` and `release-tools.yml` both run `pnpm typecheck` in preflight. Measured with the directory moved aside: 5 errors. Nothing in CI regenerates them — `pnpm build` filters `./packages/**` and never touches e2e, and the vite plugin's `buildStart` hook only fires when e2e's own vitest runs, which happens solely in `e2e.yml`.

The three files are now tracked. They are deterministic output of the tracked `src/actor/hello_actor.did`: deleting the directory and re-running regenerates all three **byte-identically with no local replica** (verified with `diff -r`). This also fixes fresh-clone DX for anyone opening `e2e/` in an editor.

**A second trap came with it.** The vite plugin also writes `e2e/src/index.generated.ts`, which was *not* gitignored and whose third line imports `../../clients` — a path that does not exist. The old `e2e/tsconfig.json` already errors on it today. It is now both gitignored and excluded from the typecheck project.

## Two notes on the configs

- `packages/parser/tsconfig.typecheck.json` extends `tsconfig.base.json` directly rather than the package's own `tsconfig.json`, because **that file is inert**: its only `include` is `["dist"]` with `outDir: "./dist"`, which TypeScript auto-excludes, so it resolves to zero input files. Pointing a script at it would have gated nothing. Measured: old config **0** input files, new config **12** under `tests/`.
- Both use `include: ["src/**/*", "tests/**/*"]`, the unsuffixed form every other package uses. The `.ts`-suffixed variant silently drops `.tsx`/`.mts`/`.cts` — the same silent-skip class this issue exists to close.

Turning the parser gate on surfaced exactly one pre-existing error, at `tests/parser-schema.test.ts:352`. Fixed with a throwing narrow guard, which is the file's own idiom ~20 lines earlier — not `as any`. The 14 parser tests still pass.

The issue's premise that CI lacks a built parser dist is wrong: `./packages/**` selects all seven packages including parser, and every job runs `pnpm build` before `pnpm typecheck`. No `ci.yml` change is needed.

## Verification

- `pnpm typecheck` exits 0 at "Scope: 8 of 32 workspace projects", with both new projects visibly running
- **both acceptance criteria:** a deliberate type error in `packages/parser/src` and in `e2e/src` each fails it with exit 2
- the new e2e config catches an error in `setup.ts` that the old config never saw
- a tracked-only `git worktree` checkout (the true CI state) contains everything the gate needs

🤖 Generated with [Claude Code](https://claude.com/claude-code)