### PR TITLE
fix(docs): crawl the whole site in the link gate, not just the home page

### DIFF
--- a/docs/scripts/check-links.mjs
+++ b/docs/scripts/check-links.mjs
@@ -34,7 +34,13 @@ try {
 
   const checker = new LinkChecker()
   const result = await checker.check({
-    path: `${base}/index.html`,
+    // The crawl root must be the DIRECTORY, not index.html. linkinator sets
+    // `rootPath` to the full starting URL and only recurses into links whose
+    // href string-prefixes it (build/src/index.js:271 and :892). With
+    // `${base}/index.html` nothing on the site starts with that string, so the
+    // crawl never leaves the home page: it reported "Checked 191 internal
+    // links" for a 180-page site while visiting exactly one page.
+    path: `${base}/`,
     serverRoot: staging,
     recurse: true,
     linksToSkip: [


### PR DESCRIPTION
Follow-up to #344 / #401, fixing a defect in the link gate that PR introduced.

**The gate was checking one page.** It passed `path: ${base}/index.html` as the crawl root. linkinator sets `rootPath` to the full starting URL (`build/src/index.js:271`, `enqueueTarget({ url, rootPath: url })`) and only recurses into links whose href string-prefixes it (`:892-893`, `result.url?.href.startsWith(options.rootPath)`). No URL on the site starts with `.../v3/index.html`, so the crawl never left the home page.

It still printed a confident, wrong number. Measured on current `main`:

| crawl root | pages crawled | links checked |
|---|---|---|
| `${base}/index.html` (shipped) | **1** | 191 |
| `${base}/` (this PR) | **257** | 268 |

The 191 were the home page's own links — checked with a request each, but never recursed into. #401's deliberate-breakage test passed only because the page it renamed (`getting-started/installation`) happens to be linked from the home page, so the failure was real but the coverage behind it was not.

## Verification

- the gate still passes on current main: `Checked 268 internal links under /v3/ - no broken links.` — this does not turn CI red
- **it now catches what it could not before:** appending a link to a non-existent page in `docs/src/content/docs/guides/authentication.mdx` — a page the old root never visited — leaves the old gate at exit 0 with "no broken links", and fails the new one with `[404] ... <- v3/guides/authentication/`

The `\.md$` skip is unchanged. With the wider crawl it now hides 122 broken links rather than the ~1 it hid before; those are the TypeDoc cross-links, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)