### PR TITLE
fix(candid): keep the eslint disable/enable pair out of the shipped JS

### DIFF
--- a/packages/candid/src/metadata-display-reactor.ts
+++ b/packages/candid/src/metadata-display-reactor.ts
@@ -61,20 +61,20 @@ import {
  * })
  * ```
  */
-/* eslint-disable @typescript-eslint/no-unused-vars -- the type parameter is
-   not referenced by this declaration, but TypeScript requires every
-   declaration of an augmented interface to carry identical type parameters
-   (TS2428), so it cannot be renamed to the `_`-prefixed form the rule
-   accepts. Verified: renaming yields TS2428 plus TS2304. */
 declare module "@ic-reactor/core" {
+  /* eslint-disable @typescript-eslint/no-unused-vars -- the type parameter is
+     not referenced by this declaration, but TypeScript requires every
+     declaration of an augmented interface to carry identical type parameters
+     (TS2428), so it cannot be renamed to the `_`-prefixed form the rule
+     accepts. Verified: renaming yields TS2428 plus TS2304. */
   interface TransformArgsRegistry<T> {
     metadataDisplay: TransformArgsRegistry<T>["display"]
   }
   interface TransformReturnRegistry<T, A = BaseActor> {
     metadataDisplay: MethodResult<A>
   }
+  /* eslint-enable @typescript-eslint/no-unused-vars */
 }
-/* eslint-enable @typescript-eslint/no-unused-vars */
 
 export class MetadataDisplayReactor<A = BaseActor> extends CandidDisplayReactor<
   A,

--- a/packages/candid/src/metadata-reactor.ts
+++ b/packages/candid/src/metadata-reactor.ts
@@ -29,20 +29,20 @@ import {
   ServiceMeta,
 } from "./visitor/returns/index.js"
 
-/* eslint-disable @typescript-eslint/no-unused-vars -- the type parameter is
-   not referenced by this declaration, but TypeScript requires every
-   declaration of an augmented interface to carry identical type parameters
-   (TS2428), so it cannot be renamed to the `_`-prefixed form the rule
-   accepts. Verified: renaming yields TS2428 plus TS2304. */
 declare module "@ic-reactor/core" {
+  /* eslint-disable @typescript-eslint/no-unused-vars -- the type parameter is
+     not referenced by this declaration, but TypeScript requires every
+     declaration of an augmented interface to carry identical type parameters
+     (TS2428), so it cannot be renamed to the `_`-prefixed form the rule
+     accepts. Verified: renaming yields TS2428 plus TS2304. */
   interface TransformArgsRegistry<T> {
     metadata: TransformArgsRegistry<T>["candid"]
   }
   interface TransformReturnRegistry<T, A = BaseActor> {
     metadata: MethodResult<A>
   }
+  /* eslint-enable @typescript-eslint/no-unused-vars */
 }
-/* eslint-enable @typescript-eslint/no-unused-vars */
 
 /**
  * Runtime form metadata reactor for Candid interfaces.


### PR DESCRIPTION
Follow-up to #341 / PR #400, cleaning up a blemish that PR introduced into published output.

PR #400 wrapped two `declare module "@ic-reactor/core"` augmentations in a scoped `/* eslint-disable @typescript-eslint/no-unused-vars */` … `/* eslint-enable */` pair, because TS2428 forbids renaming the augmented interfaces' type parameters to the `_`-prefixed form the rule accepts.

**The pair straddled the block rather than sitting inside it.** TypeScript erases a `declare module` body entirely, so the opening `disable` went with it and the trailing `enable` did not — leaving a dangling comment as the first statement of the published file:

```
packages/candid/dist/metadata-reactor.js:7
packages/candid/dist/metadata-display-reactor.js:4
/* eslint-enable @typescript-eslint/no-unused-vars */
```

Harmless, but it ships to consumers and reads as debris. Moving both comments inside the block means both are erased.

Found while diffing published artifacts against `v3.12.3` to answer whether the recent CI work needed a release — **it does not** — so this is fixed before it rides along with the next real release rather than after it.

## Verification

- no eslint comment survives into either dist file (`grep` on both after a rebuild)
- `pnpm lint` still exits 0, so the disable is still suppressing what it was added for — this is the check that matters, since the whole point of the pair is TS2428
- build, typecheck and format:check green; candid's 412 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)