### PR TITLE
docs: restore the @ic-reactor/react API reference (#403)

### DIFF
--- a/docs/scripts/check-links.mjs
+++ b/docs/scripts/check-links.mjs
@@ -43,6 +43,15 @@ try {
     path: `${base}/`,
     serverRoot: staging,
     recurse: true,
+    // linkinator's default concurrency (100) overwhelms its own static server
+    // once the crawl is a few hundred links: requests come back with status 0
+    // (connection dropped, not a 404) and the gate fails intermittently on
+    // whichever page lost the race. Capping concurrency and retrying transport
+    // errors makes it deterministic -- a flaky gate gets ignored, which is the
+    // failure mode this whole gate exists to avoid.
+    concurrency: 25,
+    retryErrors: true,
+    retryErrorsCount: 3,
     linksToSkip: [
       // External links are someone else's uptime, not this repo's correctness.
       // linkinator resolves every internal link against its own server, which

--- a/docs/src/content/docs/packages/core.mdx
+++ b/docs/src/content/docs/packages/core.mdx
@@ -6,6 +6,12 @@ editUrl: false
 
 import { Aside, CardGrid, LinkCard } from "@astrojs/starlight/components"
 
+<LinkCard
+  title="Generated API reference"
+  description="Every exported class, function, type and interface in @ic-reactor/core, generated from source."
+  href="/v3/libs"
+/>
+
 `@ic-reactor/core` is the framework-agnostic foundation of IC Reactor. It gives
 you the runtime building blocks for agent management, identity wiring,
 TanStack Query integration, and typed canister interaction without depending on

--- a/docs/src/content/docs/packages/react.mdx
+++ b/docs/src/content/docs/packages/react.mdx
@@ -6,6 +6,12 @@ editUrl: false
 
 import { Aside, CardGrid, LinkCard } from "@astrojs/starlight/components"
 
+<LinkCard
+  title="Generated API reference"
+  description="Every exported hook, factory, type and interface in @ic-reactor/react, generated from source."
+  href="/v3/libs"
+/>
+
 `@ic-reactor/react` is the recommended package for React applications. It
 re-exports the runtime classes from [`@ic-reactor/core`](/v3/packages/core) and
 adds hook factories, auth hooks, direct reactor hooks, and reusable query

--- a/docs/tsconfig.typedoc.json
+++ b/docs/tsconfig.typedoc.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2020", "DOM"],
+    "types": ["node"],
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "allowImportingTsExtensions": false,
+    // No `baseUrl`: it is a hard error under this repo's TypeScript
+    // (TS5101, deprecated and removed in TS 7). Without it, `paths` resolves
+    // relative to this file, which is what we want.
+    "paths": {
+      "@ic-reactor/core": ["../packages/core/src/index.ts"]
+    }
+  },
+  "include": [
+    "typedoc-entry.ts",
+    "../packages/core/src/**/*",
+    "../packages/react/src/**/*"
+  ]
+}

--- a/docs/typedoc-entry.ts
+++ b/docs/typedoc-entry.ts
@@ -1,0 +1,16 @@
+/**
+ * Barrel entry point for the generated API reference.
+ *
+ * TypeDoc gives every entry point its own module directory, so documenting the
+ * two packages as two entry points would emit `libs/core/src/...` and
+ * `libs/react/src/...` and break the five `autogenerate` sidebar groups in
+ * astro.config.mjs, which read a flat `libs/classes`, `libs/functions`, etc.
+ * One barrel over a program containing both packages keeps that layout flat.
+ *
+ * Paired with tsconfig.typedoc.json, whose `paths` maps `@ic-reactor/core` to
+ * core's SOURCE. Without that mapping react's `export * from "@ic-reactor/core"`
+ * resolves through the workspace symlink to `core/dist/*.d.ts`, and every shared
+ * page loses its GitHub source link and points at build output instead.
+ */
+export * from "../packages/core/src/index.js"
+export * from "../packages/react/src/index.js"

--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://typedoc-plugin-markdown.org/schema.json",
-  "entryPoints": ["../packages/core/src/index.ts"],
-  "tsconfig": "../packages/core/tsconfig.json",
+  "entryPoints": ["./typedoc-entry.ts"],
+  "tsconfig": "./tsconfig.typedoc.json",
   "readme": "none",
   "out": "src/content/docs/libs",
   "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-frontmatter"],
@@ -33,11 +33,5 @@
     "notExported": true,
     "invalidLink": true,
     "notDocumented": false
-  },
-  "intentionallyNotExported": [
-    "AsObject",
-    "AsOptional",
-    "Last",
-    "VariantUnionOf"
-  ]
+  }
 }

--- a/packages/react/src/auth/authentication-manager.ts
+++ b/packages/react/src/auth/authentication-manager.ts
@@ -203,7 +203,7 @@ export class AuthenticationManager {
    * module has not been loaded yet.
    *
    * Callers that must stay inside a user gesture use this instead of
-   * {@link ensureClient}; awaiting anything before opening the identity
+   * `ensureClient`; awaiting anything before opening the identity
    * provider window loses the gesture.
    */
   public getPreparedClient(


### PR DESCRIPTION
Closes #403

The generated API reference documented `@ic-reactor/core` only. Every hook the library exists for — `createActorHooks`, `useActorQuery`, `useActorMutation`, `createAuthHooks`, `defineReactor`, the query/mutation factories, the whole identity-attribute surface — had no page, and **66 of those symbols were mentioned nowhere on the docs site at all**.

The react entry point had been listed in `typedoc.json` but produced zero output: the program was built from `packages/core/tsconfig.json`, whose `include` is `src/**/*` relative to `packages/core`, so react's index was never in it. #344 removed that dead entry rather than leave a permanent failure under the `treatWarningsAsErrors` it introduced, and deferred this restructure by name.

## Why a barrel, and not simply two entry points

TypeDoc gives each entry point its own module directory, so documenting both packages directly emits `libs/core/src/…` and `libs/react/src/…` — which breaks all five `autogenerate` sidebar groups in `astro.config.mjs`, since they read a flat `libs/classes`, `libs/functions`, etc. A single barrel over a program containing both packages keeps the layout flat: **216 files, no nested subtree, no page path emitted twice.**

**The `paths` mapping is what keeps core documented from source.** React does `export * from "@ic-reactor/core"`, which resolves through the workspace symlink to `core/dist/*.d.ts`. Left alone, all 88 shared pages would read `Defined in: core/dist/client.d.ts:34` — plain text, no link, pointing at build output — and the 14 core helpers that arrive as `export declare const` would be reclassified from Functions to Variables and move sidebar section. `baseUrl` is deliberately absent: it's a hard error under this repo's TypeScript (TS5101), so `paths` resolves relative to the config instead.

`packages/core/src/types/reactor.ts` is untouched, as #403 requires. An early version of the docs tsconfig disabled `noUnusedLocals`/`noUnusedParameters` and thereby made that file's `@ts-expect-error` unused (TS2578) — the fix was to stop overriding those, not to edit core.

## A gate defect this change would otherwise have introduced

The crawl grew from 268 links to 382, and at linkinator's default concurrency of 100 its own static server began dropping requests — failing with status `0` (a connection drop, not a 404) on whichever page lost the race. **2 of 3 runs went red, on different pages each time.** Capping concurrency at 25 with transport retries makes it deterministic: 5 of 5 clean. A flaky gate gets ignored, which is the failure mode this gate exists to prevent.

## Acceptance (all seven from #403)

| | |
|---|---|
| `docs:build` clean, warnings-as-errors still on | ✅ 0 errors, 0 warnings |
| 216 files, up from 102 | ✅ 216 |
| All 10 previously-absent react symbols present | ✅ 0 missing |
| `ClientManager.md` links to `packages/core/src/client.ts`, not dist | ✅ |
| `functions/isNullish.md` exists (helpers stay under Functions) | ✅ |
| Flat layout, no `libs/core`/`libs/react`, no duplicate paths | ✅ 0 / 0 |
| `typecheck` green with `reactor.ts` unmodified; link gate clean | ✅ |

Repo gates green: build, lint, format:check, check:ai-context, verify:audit, and 1,362 tests.

**Note for the next release:** the `{@link ensureClient}` → `` `ensureClient` `` change is in `packages/react/src`, so it will appear in that package's `.d.ts` diff. It's a doc comment — no behavioural effect — but it adds to the (still non-functional) delta discussed when we concluded no release was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)