### PR TITLE
docs: fix every broken link in the generated API reference (#404)

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "astro dev",
-    "build": "typedoc --options ./typedoc.json && node scripts/split-index.js && astro build",
+    "build": "typedoc --options ./typedoc.json && node scripts/split-index.js && node scripts/rewrite-typedoc-links.js && astro build && node scripts/fix-dist-links.js",
     "postbuild": "mkdir -p ./dist/${DOCS_VERSION:-local}/ && cp -r ./src/content/docs/* ./dist/${DOCS_VERSION:-local}/",
     "preview": "pnpm build && npx serve dist/local -p 3000",
     "lint:mdx": "remark 'src/content/docs/**/*.mdx' -q --frail",

--- a/docs/scripts/check-links.mjs
+++ b/docs/scripts/check-links.mjs
@@ -13,9 +13,9 @@
  * The base is read from astro.config.mjs rather than hardcoded, so the two
  * cannot drift.
  */
-import { mkdtemp, readFile, rm, symlink } from "node:fs/promises"
+import { mkdtemp, readFile, readdir, rm, symlink } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join, resolve } from "node:path"
+import { join, posix, resolve } from "node:path"
 import { LinkChecker } from "linkinator"
 
 const docsRoot = resolve(import.meta.dirname, "..")
@@ -58,14 +58,55 @@ try {
       // binds 127.0.0.1 -- so this must exempt the local host explicitly or it
       // skips the entire site and the gate silently checks nothing.
       "^https?://(?!(localhost|127\\.0\\.0\\.1)[:/])",
-      // Scope limit, not noise suppression. typedoc-plugin-markdown emits
-      // relative `../type-aliases/X.md` cross-links while Starlight nests the
-      // route one level deeper, so these 404 for real. They are tracked
-      // separately; this gate covers the rendered routes, which is what a page
-      // rename breaks.
-      "\\.md$",
     ],
   })
+
+  // Case-sensitivity pass. linkinator serves the built site from the local
+  // filesystem, so on macOS every href resolves case-insensitively and a link
+  // that is a hard 404 on the Linux host comes back 200. That is not a
+  // hypothetical: `starlight-page-actions` writes each page's `.md` companion
+  // at the SOURCE-cased path while building the href from the lowercased route,
+  // and the mismatch is invisible here without this check. Compare exact
+  // strings against the real file set rather than asking the filesystem.
+  const realFiles = new Set()
+  const walk = async (dir, rel = "") => {
+    for (const e of await readdir(dir, { withFileTypes: true })) {
+      const r = rel ? `${rel}/${e.name}` : e.name
+      if (e.isDirectory()) await walk(join(dir, e.name), r)
+      else realFiles.add(r)
+    }
+  }
+  await walk(join(docsRoot, "dist"))
+
+  const caseBroken = []
+  for (const page of [...realFiles].filter((f) => f.endsWith(".html"))) {
+    const html = await readFile(join(docsRoot, "dist", page), "utf8")
+    const route = `/${base}/${page.replace(/index\.html$/, "")}`
+    for (const [, href] of html.matchAll(/href="([^"]+)"/g)) {
+      if (/^(https?:|mailto:|#|\/\/)/.test(href)) continue
+      const clean = href.split("#")[0].split("?")[0]
+      if (!clean) continue
+      const abs = clean.startsWith("/")
+        ? clean
+        : posix.normalize(posix.join(route, clean))
+      if (!abs.startsWith(`/${base}/`)) continue
+      let f = abs.slice(base.length + 2)
+      if (f === "") f = "index.html"
+      else if (f.endsWith("/")) f += "index.html"
+      else if (!/\.[a-z0-9]+$/i.test(f)) f += "/index.html"
+      if (!realFiles.has(f)) caseBroken.push(`${href}\n      <- ${route}`)
+    }
+  }
+  if (caseBroken.length > 0) {
+    console.error(
+      `\n${caseBroken.length} link(s) resolve only on a case-insensitive filesystem ` +
+        `- these are 404s on the Linux host that serves the site:\n`
+    )
+    for (const b of caseBroken.slice(0, 20)) console.error(`  ${b}`)
+    if (caseBroken.length > 20)
+      console.error(`  ... and ${caseBroken.length - 20} more`)
+    process.exit(1)
+  }
 
   const broken = result.links.filter((l) => l.state === "BROKEN")
   const checked = result.links.filter((l) => l.state !== "SKIPPED").length

--- a/docs/scripts/fix-dist-links.js
+++ b/docs/scripts/fix-dist-links.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Post-`astro build` repairs to the built site, for two things neither Astro
+ * nor the plugins get right on their own.
+ *
+ * 1. PAGE-ACTION MARKDOWN LINKS. `starlight-page-actions` writes each page's
+ *    `.md` companion at the SOURCE-cased path but builds the href from the
+ *    RENDERED ROUTE, which Starlight lowercases. TypeDoc filenames are
+ *    PascalCase, so every such link on a mixed-case page 404s:
+ *
+ *      href  /v3/libs/classes/authenticationmanager.md
+ *      file  dist/libs/classes/AuthenticationManager.md
+ *
+ *    This is invisible on macOS, whose filesystem is case-insensitive, and a
+ *    hard 404 on the Linux host. The home page has a second variant of the same
+ *    bug: its href is `${base}.md`, but the file is served at `${base}/index.md`.
+ *
+ *    We repoint the hrefs at the files that exist rather than emitting
+ *    lowercase duplicates, so the already-deployed source-cased URLs keep
+ *    working and nothing is published twice.
+ *
+ * 2. llms.txt. The plugin builds it from the site origin and drops the base
+ *    path, so every entry points one level above the real page. Setting
+ *    `baseUrl` in astro.config.mjs does not help: the plugin reduces the URL to
+ *    `urlObj.origin`.
+ */
+import {
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+  existsSync,
+} from "node:fs"
+import { join, resolve } from "node:path"
+
+const docsRoot = resolve(import.meta.dirname, "..")
+const DIST = join(docsRoot, "dist")
+
+const astroConfig = readFileSync(join(docsRoot, "astro.config.mjs"), "utf8")
+const base =
+  "/" +
+  (astroConfig.match(/^\s*base:\s*["'](.+?)["']/m)?.[1] ?? "").replace(
+    /^\/|\/$/g,
+    ""
+  )
+const site = astroConfig
+  .match(/^\s*site:\s*["'](.+?)["']/m)?.[1]
+  ?.replace(/\/$/, "")
+if (base === "/" || !site) {
+  console.error(
+    "fix-dist-links: could not read `base`/`site` from astro.config.mjs"
+  )
+  process.exit(1)
+}
+
+function* files(dir, rel = "") {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name)
+    const r = rel ? `${rel}/${name}` : name
+    if (statSync(full).isDirectory()) yield* files(full, r)
+    else yield [full, r]
+  }
+}
+
+// Two exact sets. `real` is compared by STRING, never with existsSync: macOS
+// resolves paths case-insensitively, so existsSync reports every lowercase
+// page-action href as already valid and this script silently fixes nothing --
+// while the same href is a hard 404 on the Linux host that serves the site.
+const real = new Set()
+const byLower = new Map()
+for (const [, rel] of files(DIST)) {
+  if (!rel.endsWith(".md")) continue
+  real.add(rel)
+  byLower.set(rel.toLowerCase(), rel)
+}
+
+let hrefsFixed = 0
+let pagesTouched = 0
+for (const [full, rel] of files(DIST)) {
+  if (!rel.endsWith(".html")) continue
+  const src = readFileSync(full, "utf8")
+  const out = src.replace(/href="([^"]+\.md)"/g, (whole, href) => {
+    // `${base}.md` on the home page -> the real `${base}/index.md`
+    if (href === `${base}.md`) {
+      if (!real.has("index.md")) return whole
+      hrefsFixed++
+      return `href="${base}/index.md"`
+    }
+    if (!href.startsWith(`${base}/`)) return whole
+    const wanted = href.slice(base.length + 1)
+    if (real.has(wanted)) return whole // exact match; already correct
+    const actual = byLower.get(wanted.toLowerCase())
+    if (!actual) return whole // genuinely missing; leave it for the link gate
+    hrefsFixed++
+    return `href="${base}/${actual}"`
+  })
+  if (out !== src) {
+    writeFileSync(full, out)
+    pagesTouched++
+  }
+}
+
+// llms.txt: `https://host/foo/` -> `https://host/v3/foo/`
+let llmsFixed = 0
+for (const name of ["llms.txt", "llms-full.txt"]) {
+  const p = join(DIST, name)
+  if (!existsSync(p)) continue
+  const src = readFileSync(p, "utf8")
+  const out = src.replace(
+    new RegExp(
+      `${site.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?!${base}/)/`,
+      "g"
+    ),
+    () => {
+      llmsFixed++
+      return `${site}${base}/`
+    }
+  )
+  if (out !== src) writeFileSync(p, out)
+}
+
+console.log(
+  `fix-dist-links: repointed ${hrefsFixed} .md hrefs across ${pagesTouched} pages; ` +
+    `prefixed ${llmsFixed} llms.txt URLs with ${base}`
+)

--- a/docs/scripts/rewrite-typedoc-links.js
+++ b/docs/scripts/rewrite-typedoc-links.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Rewrites TypeDoc's relative `.md` cross-links into absolute Starlight routes.
+ *
+ * typedoc-plugin-markdown writes links as paths between the `.md` FILES it
+ * emitted, e.g. `libs/classes/DisplayReactor.md` links to
+ * `../type-aliases/BaseActor.md`. Astro serves that source file at the route
+ * `/v3/libs/classes/displayreactor/` — one segment deeper than the file's own
+ * directory, per-segment lowercased, with a trailing slash. Astro leaves `.md`
+ * hrefs in content-collection markdown untouched, so the href survives verbatim
+ * into the HTML and the browser resolves it against the wrong directory:
+ *
+ *     ../type-aliases/BaseActor.md  from  /v3/libs/classes/displayreactor/
+ *       -> /v3/libs/classes/type-aliases/BaseActor.md   404
+ *       -> /v3/libs/type-aliases/baseactor/             the real page
+ *
+ * Runs after `typedoc` and before `astro build`. The base is read from
+ * astro.config.mjs rather than hardcoded, matching check-links.mjs.
+ */
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs"
+import { join, posix, dirname, relative, resolve } from "node:path"
+
+const docsRoot = resolve(import.meta.dirname, "..")
+const LIBS = join(docsRoot, "src/content/docs/libs")
+
+const astroConfig = readFileSync(join(docsRoot, "astro.config.mjs"), "utf8")
+const baseMatch = astroConfig.match(/^\s*base:\s*["'](.+?)["']/m)
+if (!baseMatch) {
+  console.error(
+    "rewrite-typedoc-links: could not read `base` from astro.config.mjs"
+  )
+  process.exit(1)
+}
+const base = "/" + baseMatch[1].replace(/^\/|\/$/g, "")
+
+/** Starlight's slug rule for these pages: plain per-segment lowercase. */
+const slug = (p) =>
+  p
+    .split("/")
+    .map((s) => s.toLowerCase())
+    .join("/")
+
+/** `libs/type-aliases/BaseActor.md` -> `/v3/libs/type-aliases/baseactor/` */
+function routeFor(libsRelativePath) {
+  const noExt = libsRelativePath.replace(/\.md$/, "")
+  if (noExt === "index") return `${base}/libs/`
+  return `${base}/libs/${slug(noExt)}/`
+}
+
+function* markdownFiles(dir) {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name)
+    if (statSync(full).isDirectory()) yield* markdownFiles(full)
+    else if (name.endsWith(".md")) yield full
+  }
+}
+
+// Matches a markdown link whose target is a RELATIVE .md path. Absolute hrefs
+// (the page-action `/v3/...md` links) and external URLs are left alone.
+const RELATIVE_MD = /\]\((?!\/|https?:|#)([^)\s]+?\.md)(#[^)\s]*)?\)/g
+
+let filesChanged = 0
+let linksRewritten = 0
+
+for (const file of markdownFiles(LIBS)) {
+  const src = readFileSync(file, "utf8")
+  const fileDir = dirname(relative(LIBS, file))
+  const out = src.replace(RELATIVE_MD, (whole, target, hash = "") => {
+    // resolve the target against the containing file's directory, as a reader
+    // of the FILE tree would
+    const resolved = posix.normalize(
+      posix.join(fileDir === "." ? "" : fileDir, target)
+    )
+    if (resolved.startsWith("..")) return whole // escapes libs/; leave it alone
+    linksRewritten++
+    return `](${routeFor(resolved)}${hash})`
+  })
+  if (out !== src) {
+    writeFileSync(file, out)
+    filesChanged++
+  }
+}
+
+console.log(
+  `rewrote ${linksRewritten} TypeDoc cross-links across ${filesChanged} files -> ${base}/libs/**`
+)


### PR DESCRIPTION
Closes #404

The API reference was not navigable. Three separate defects, none of which the link gate could see.

## 1. TypeDoc wrote filesystem-relative links; Starlight serves each page a directory deeper

`typedoc-plugin-markdown` emits cross-links as paths between the `.md` files it wrote, so `libs/classes/DisplayReactor.md` linked to `../type-aliases/BaseActor.md`. Astro renders that source file at `/v3/libs/classes/displayreactor/` — one segment deeper, per-segment lowercased — and leaves `.md` hrefs untouched, so the browser asked for `/v3/libs/classes/type-aliases/BaseActor.md` and got a 404.

**Measured before the fix: 1,164 relative `.md` hrefs across the built site.** (Up from the ~245 in the issue, because #411 doubled the reference.)

`scripts/rewrite-typedoc-links.js` resolves each target against its containing directory and emits an absolute route, running between `typedoc` and `astro build`. 1,282 links rewritten across 141 files; relative `.md` hrefs now **0**.

Not `publicPath` — as the issue notes, it changes the prefix only, converting 404s into raw-markdown hits.

## 2. Page-action links were built from the route but written at the source path

`starlight-page-actions` writes each page's `.md` companion at the **source-cased** path while building the href from the **lowercased route**. TypeDoc filenames are PascalCase, so every such link on a mixed-case page 404d — **239 of them**. The home page had a second variant: href `${base}.md` against a file served at `${base}/index.md`.

`scripts/fix-dist-links.js` repoints those hrefs at the files that actually exist, rather than emitting lowercase duplicates — so already-deployed source-cased URLs keep working and nothing ships twice.

## 3. `llms.txt` dropped the base path

All 292 entries advertised `https://ic-reactor.b3pay.net/foo/` instead of `/v3/foo/`. Setting `baseUrl` doesn't help — the plugin reduces the URL to its origin. Fixed in the same post-build step.

## The gate now guards all of it — and needed more than the skip removed

The `"\.md$"` entry is gone from `linksToSkip`, taking the crawl from 382 links to **675**.

**That alone is not sufficient, and the reason is worth recording.** linkinator serves the built site from the local filesystem, so on macOS every href resolves case-insensitively and a hard 404 on the Linux host comes back 200. I hit this while writing the fix: an `existsSync` guard in `fix-dist-links.js` reported all 239 mismatched hrefs as already valid, and the script silently "fixed" one.

So `check-links.mjs` gained a case-sensitivity pass that compares exact strings against the real file set instead of asking the filesystem. Verified it fails: reintroducing a single lowercase page-action href exits 1 with `resolve only on a case-insensitive filesystem`.

## Acceptance

| | |
|---|---|
| 0 relative `.md` hrefs under `dist/libs` | ✅ 0 (from 1,164) |
| Every absolute `.md` href resolves, checked case-sensitively | ✅ 0 broken (from 239) |
| All `llms.txt` entries carry the base | ✅ 292/292 |
| Crawl root is `${base}/`, several hundred links | ✅ 675 |
| `"\.md$"` skip gone, gate exits 0 | ✅ |
| Regression guard | ✅ the fixed gate, plus the case pass |

An independent case-sensitive audit of all 294 built pages reports **0 broken internal links of any kind**. Repo gates green; no publishable package source is touched. The post-deploy check in the issue can only be confirmed once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)