### PR TITLE
lint: enable no-misused-promises by fixing the cast that blocked it (#405)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -85,6 +85,7 @@ export default tseslint.config(
     rules: {
       "@typescript-eslint/await-thenable": "error",
       "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": "error",
     },
   },
   {

--- a/packages/react/src/hooks/useActorInfiniteQuery.test.tsx
+++ b/packages/react/src/hooks/useActorInfiniteQuery.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest"
 import { renderHook, waitFor, act } from "@testing-library/react"
 import React from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
@@ -18,6 +18,19 @@ type TestActor = {
     { messages: string[]; nextToken: string | null }
   >
 }
+
+/**
+ * The real signature of the method being mocked.
+ *
+ * `CallMethodMock` used to stand here. `ReturnType` instantiates a
+ * generic signature at its CONSTRAINT rather than its default, so that cast
+ * resolved to `Mock<Procedure | Constructable>` — whose `Constructable` branch
+ * contributes a `void`-returning call signature (which made
+ * `no-misused-promises` flag every async implementation) and whose
+ * `(...args: any[]) => any` branch silently typed every mock body's
+ * parameters as `any`, even under `strict`.
+ */
+type CallMethodMock = Mock<Reactor<TestActor>["callMethod"]>
 
 // Mock data generators
 const generatePosts = (page: number, limit: number): string[] => {
@@ -207,11 +220,11 @@ describe("useActorInfiniteQuery", () => {
     it("should determine hasNextPage based on getNextPageParam", async () => {
       // Create a mock that returns null nextCursor to indicate no more pages
       const noMorePagesMock = createMockReactor(queryClient)
-      ;(
-        noMorePagesMock.callMethod as ReturnType<typeof vi.fn>
-      ).mockImplementation(async () => {
-        return { items: ["Last Item"], nextCursor: null }
-      })
+      ;(noMorePagesMock.callMethod as CallMethodMock).mockImplementation(
+        async () => {
+          return { items: ["Last Item"], nextCursor: null }
+        }
+      )
 
       const { result } = renderHook(
         () =>
@@ -375,16 +388,15 @@ describe("useActorInfiniteQuery", () => {
         expect(result.current.isSuccess).toBe(true)
       })
 
-      const initialCallCount = (
-        mockReactor.callMethod as ReturnType<typeof vi.fn>
-      ).mock.calls.length
+      const initialCallCount = (mockReactor.callMethod as CallMethodMock).mock
+        .calls.length
 
       await act(async () => {
         await result.current.refetch()
       })
 
       expect(
-        (mockReactor.callMethod as ReturnType<typeof vi.fn>).mock.calls.length
+        (mockReactor.callMethod as CallMethodMock).mock.calls.length
       ).toBeGreaterThan(initialCallCount)
     })
   })

--- a/packages/react/src/hooks/useActorSuspenseInfiniteQuery.test.tsx
+++ b/packages/react/src/hooks/useActorSuspenseInfiniteQuery.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest"
 import { renderHook, waitFor, act } from "@testing-library/react"
 import React, { Suspense } from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
@@ -18,6 +18,19 @@ type TestActor = {
     { messages: string[]; nextToken: string | null }
   >
 }
+
+/**
+ * The real signature of the method being mocked.
+ *
+ * `CallMethodMock` used to stand here. `ReturnType` instantiates a
+ * generic signature at its CONSTRAINT rather than its default, so that cast
+ * resolved to `Mock<Procedure | Constructable>` — whose `Constructable` branch
+ * contributes a `void`-returning call signature (which made
+ * `no-misused-promises` flag every async implementation) and whose
+ * `(...args: any[]) => any` branch silently typed every mock body's
+ * parameters as `any`, even under `strict`.
+ */
+type CallMethodMock = Mock<Reactor<TestActor>["callMethod"]>
 
 // Mock data generators
 const generatePosts = (page: number, limit: number): string[] => {
@@ -220,11 +233,11 @@ describe("useActorSuspenseInfiniteQuery", () => {
       const noMorePagesMock = createMockReactor(
         queryClient
       ) as unknown as Reactor<TestActor>
-      ;(
-        noMorePagesMock.callMethod as ReturnType<typeof vi.fn>
-      ).mockImplementation(async () => {
-        return { items: ["Last Item"], nextCursor: null }
-      })
+      ;(noMorePagesMock.callMethod as CallMethodMock).mockImplementation(
+        async () => {
+          return { items: ["Last Item"], nextCursor: null }
+        }
+      )
 
       const { result } = renderHook(
         () =>
@@ -390,16 +403,15 @@ describe("useActorSuspenseInfiniteQuery", () => {
         expect(result.current.isSuccess).toBe(true)
       })
 
-      const initialCallCount = (
-        mockReactor.callMethod as ReturnType<typeof vi.fn>
-      ).mock.calls.length
+      const initialCallCount = (mockReactor.callMethod as CallMethodMock).mock
+        .calls.length
 
       await act(async () => {
         await result.current.refetch()
       })
 
       expect(
-        (mockReactor.callMethod as ReturnType<typeof vi.fn>).mock.calls.length
+        (mockReactor.callMethod as CallMethodMock).mock.calls.length
       ).toBeGreaterThan(initialCallCount)
     })
   })

--- a/packages/react/tests/createInfiniteQuery.test.tsx
+++ b/packages/react/tests/createInfiniteQuery.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest"
 import { renderHook, waitFor, act } from "@testing-library/react"
 import React from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
@@ -28,6 +28,19 @@ type TestActor = {
     { messages: string[]; hasMore: boolean }
   >
 }
+
+/**
+ * The real signature of the method being mocked.
+ *
+ * `CallMethodMock` used to stand here. `ReturnType` instantiates a
+ * generic signature at its CONSTRAINT rather than its default, so that cast
+ * resolved to `Mock<Procedure | Constructable>` — whose `Constructable` branch
+ * contributes a `void`-returning call signature (which made
+ * `no-misused-promises` flag every async implementation) and whose
+ * `(...args: any[]) => any` branch silently typed every mock body's
+ * parameters as `any`, even under `strict`.
+ */
+type CallMethodMock = Mock<Reactor<TestActor>["callMethod"]>
 
 // Mock data generator
 const generatePosts = (
@@ -428,14 +441,13 @@ describe("createInfiniteQuery", () => {
         expect(result.current.isSuccess).toBe(true)
       })
 
-      const initialCallCount = (
-        mockReactor.callMethod as ReturnType<typeof vi.fn>
-      ).mock.calls.length
+      const initialCallCount = (mockReactor.callMethod as CallMethodMock).mock
+        .calls.length
 
       await postsQuery.invalidate()
 
       expect(
-        (mockReactor.callMethod as ReturnType<typeof vi.fn>).mock.calls.length
+        (mockReactor.callMethod as CallMethodMock).mock.calls.length
       ).toBeGreaterThan(initialCallCount)
     })
   })
@@ -727,15 +739,14 @@ describe("createInfiniteQueryFactory", () => {
     const allQueryRerun = makeList((cursor) => [
       { cursor, limit: 5, filter: "all", q: "" },
     ])
-    const callCountBeforeRerun = (
-      mockReactor.callMethod as ReturnType<typeof vi.fn>
-    ).mock.calls.length
+    const callCountBeforeRerun = (mockReactor.callMethod as CallMethodMock).mock
+      .calls.length
     const rerunData = await allQueryRerun.fetch()
 
     expect(rerunData.pages[0].posts[0]).toContain("filter=all;q=;sort=")
-    expect(
-      (mockReactor.callMethod as ReturnType<typeof vi.fn>).mock.calls.length
-    ).toBe(callCountBeforeRerun)
+    expect((mockReactor.callMethod as CallMethodMock).mock.calls.length).toBe(
+      callCountBeforeRerun
+    )
 
     expect(queryClient.getQueryData(allQuery.getQueryKey())).toBeDefined()
     expect(queryClient.getQueryData(completedQuery.getQueryKey())).toBeDefined()

--- a/packages/react/tests/createQuery.test.tsx
+++ b/packages/react/tests/createQuery.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest"
 import { renderHook, waitFor } from "@testing-library/react"
 import React, { Suspense } from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
@@ -24,6 +24,13 @@ interface TestActor {
   get_item: ActorMethod<[string], [] | [Item]>
   list_items: ActorMethod<[], string[]>
 }
+
+/**
+ * The real signature of the method being mocked. See the note in
+ * useActorInfiniteQuery.test.tsx: `CallMethodMock` resolves to
+ * `Mock<Procedure | Constructable>`, which types every mock body as `any`.
+ */
+type CallMethodMock = Mock<Reactor<TestActor>["callMethod"]>
 
 // Mock data
 const mockUser: User = { name: "Alice", age: 30n }
@@ -231,7 +238,7 @@ describe("createQuery", () => {
       await userQuery.fetch()
 
       // Reset mock to check if called again
-      ;(mockReactor.callMethod as ReturnType<typeof vi.fn>).mockClear()
+      ;(mockReactor.callMethod as CallMethodMock).mockClear()
 
       // Get from cache (should use cached value due to staleTime default behavior if implemented?
       // Actually default staleTime in createActorQuery might be 0 unless configured or defaulted in QueryClient?

--- a/packages/react/tests/createSuspenseInfiniteQuery.test.tsx
+++ b/packages/react/tests/createSuspenseInfiniteQuery.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest"
 import { renderHook, waitFor } from "@testing-library/react"
 import React, { Suspense } from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
@@ -8,6 +8,7 @@ import {
 } from "../src/createSuspenseInfiniteQuery.js"
 import { ActorMethod } from "@icp-sdk/core/agent"
 import { Reactor } from "@ic-reactor/core"
+import type { ReactorCallParams, ReactorReturnOk } from "@ic-reactor/core"
 
 // Define a test actor type with paginated methods
 type TestActor = {
@@ -28,6 +29,33 @@ type TestActor = {
     { messages: string[]; hasMore: boolean }
   >
 }
+
+/**
+ * The real signature of the method being mocked.
+ *
+ * `CallMethodMock` used to stand here. `ReturnType` instantiates a
+ * generic signature at its CONSTRAINT rather than its default, so that cast
+ * resolved to `Mock<Procedure | Constructable>` — whose `Constructable` branch
+ * contributes a `void`-returning call signature (which made
+ * `no-misused-promises` flag every async implementation) and whose
+ * `(...args: any[]) => any` branch silently typed every mock body's parameters
+ * as `any`, even under `strict`.
+ */
+type CallMethodMock = Mock<Reactor<TestActor>["callMethod"]>
+
+/**
+ * Pinned to the one method the fetch-count test exercises.
+ *
+ * `CallMethodMock` instantiates `M` at its constraint `keyof TestActor`, so
+ * `params.args` is the union of every method's argument tuple and
+ * `functionName === "getPosts"` narrows nothing from inside the callback. This
+ * alias fixes `M`, which is what makes `args[0]` a real typed tuple.
+ */
+type CallGetPosts = Mock<
+  (
+    params: Omit<ReactorCallParams<TestActor, "getPosts">, "queryKey">
+  ) => Promise<ReactorReturnOk<TestActor, "getPosts">>
+>
 
 // Mock data generator
 const generatePosts = (
@@ -325,14 +353,13 @@ describe("createSuspenseInfiniteQuery", () => {
         expect(result.current.isSuccess).toBe(true)
       })
 
-      const initialCallCount = (
-        mockReactor.callMethod as ReturnType<typeof vi.fn>
-      ).mock.calls.length
+      const initialCallCount = (mockReactor.callMethod as CallMethodMock).mock
+        .calls.length
 
       await postsQuery.invalidate()
 
       expect(
-        (mockReactor.callMethod as ReturnType<typeof vi.fn>).mock.calls.length
+        (mockReactor.callMethod as CallMethodMock).mock.calls.length
       ).toBeGreaterThan(initialCallCount)
     })
   })
@@ -643,21 +670,18 @@ describe("refetching behavior with infinite queries", () => {
     mockReactor = createMockReactor(queryClient)
 
     // Override callMethod to track fetch count and return dynamic data
-    ;(mockReactor.callMethod as ReturnType<typeof vi.fn>).mockImplementation(
-      async ({ functionName, args }) => {
+    ;(mockReactor.callMethod as CallGetPosts).mockImplementation(
+      async ({ args }) => {
         fetchCount++
-        if (functionName === "getPosts") {
-          const { cursor, limit } = args[0]
-          // Return different data on each fetch to verify refetching works
-          return {
-            posts: Array.from(
-              { length: limit },
-              (_, i) => `Post ${cursor + i + 1} (fetch #${fetchCount})`
-            ),
-            nextCursor: cursor + limit < 50 ? cursor + limit : null,
-          }
+        const { cursor, limit } = args![0]
+        // Return different data on each fetch to verify refetching works
+        return {
+          posts: Array.from(
+            { length: limit },
+            (_, i) => `Post ${cursor + i + 1} (fetch #${fetchCount})`
+          ),
+          nextCursor: cursor + limit < 50 ? cursor + limit : null,
         }
-        return null
       }
     )
   })


### PR DESCRIPTION
Closes #405

#341 left `no-misused-promises` out because it reported 3 errors in infinite-query tests. **Those 3 errors were all the same cast, and the cast was wrong for a reason that has nothing to do with promises.**

## Why the rule was firing

Every flagged callback was an `async` argument to `mockImplementation` on an expression cast to `ReturnType<typeof vi.fn>`. `vi.fn` is generic with a default of `Procedure` — but `ReturnType<F>` instantiates a generic signature's type parameters at their **constraint**, not their default. So the cast resolved to `Mock<Procedure | Constructable>`, `NormalizedProcedure` distributed over that union, and its `Constructable` branch contributed a `void`-returning call signature. That is what the rule was reporting.

Nothing was ever swallowed: `Reactor.callMethod` is `async` and every query function awaits it. The proof sits in the same file — a structurally identical `async` implementation passed to `mockImplementation` on a directly-called `vi.fn()` is *not* flagged, because that resolves `T` to the default.

## The bigger problem the cast was hiding

**It switched off type checking inside every mock body it wrapped.** The same union includes `(...args: any[]) => any`, so mock implementation parameters landed as `any` even under `strict`. Four test files were unchecked in their mock bodies — that's the real reason this is worth doing, beyond turning a rule on.

All 14 casts across 5 files are replaced with `Mock<Reactor<TestActor>["callMethod"]>`.

**One site could not use that type.** `createSuspenseInfiniteQuery.test.tsx:646` destructures `args[0]` and does arithmetic on it, but the whole-method type instantiates `M` at its constraint `keyof TestActor` — so `params.args` is the union of every method's argument tuple, and `functionName === "getPosts"` narrows nothing from inside the callback. It's pinned to the single method the test exercises, which makes `args[0]` a real typed tuple and lets the un-narrowable branch go.

No scoped `checksVoidReturn: false` override on tests: that would blind the largest body of React code in the repo to genuine `onClick={async () => ...}` misuse, in order to hide a cast that was wrong on its own merits.

## Acceptance

| | |
|---|---|
| No `ReturnType<typeof vi.fn>` remains | ✅ |
| Rule in the type-aware block, `checksVoidReturn` unrelaxed | ✅ |
| `build && lint` exit 0, tree unmodified by them | ✅ |
| `typecheck` exits 0 | ✅ |
| **Rule is live, not vacuous** — restoring any one cast reproduces the error | ✅ exit 1, clears on revert |
| **Mock bodies genuinely typed** — bad field fails typecheck | ✅ `TS2339: Property 'nope' does not exist on type '{ cursor: number; limit: number; … }'` — the real tuple, not `any` |
| React tests green | ✅ 489/489 |

Full suite passes (1,362 tests). Only test files and the lint config change — no publishable source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)